### PR TITLE
chore: deploy OpenAPI spec to docs public folder

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -67,7 +67,7 @@ jobs:
           publish_dir: ./openapi-deploy
           external_repository: evcc-io/docs
           publish_branch: main
-          destination_dir: static
+          destination_dir: public
           allow_empty_commit: false
           commit_message: Update OpenAPI spec
           keep_files: true


### PR DESCRIPTION
fixes #33355

The OpenAPI spec in this repo already contains `battery.returnEnergy` and the release workflow deployed it correctly. However, since the docs site migration to Astro Starlight, the rendered REST API pages are built from `public/openapi.yaml`, while the deploy job still pushes to `static/`, so the rendered documentation stayed stale.

- change the deploy target of the OpenAPI job from `static/` to `public/`
- after merge, a `workflow_dispatch` run of the workflow updates the docs without waiting for the next release
- the orphaned `static/openapi.yaml` in evcc-io/docs can be removed separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)