### PR TITLE
API: raise the jq query limit to 8k

### DIFF
--- a/server/http_site_handler.go
+++ b/server/http_site_handler.go
@@ -34,7 +34,7 @@ var ignoreState = []string{"releaseNotes"} // excessive size
 
 // limits for the unauthenticated jq parameter of the state endpoint
 const (
-	maxJqQueryLen    = 512         // maximum length of the jq query
+	maxJqQueryLen    = 8192        // maximum length of the jq query
 	maxJqDuration    = time.Second // maximum jq evaluation time
 	maxJqResultBytes = 1 << 20     // maximum size of the encoded jq result
 )


### PR DESCRIPTION
fixes #33387

512 bytes turned out to be too tight for real clients. The Garmin Connect IQ app filters the state server-side and aggregates the price forecast before sending it to the watch, which needs about 3.5k minified, so it broke on v0.315.0.

The length cap is the weakest of the three guards anyway: evaluation time and result size are what actually bound the work, and both stay as they are. 8k leaves room for aggregating filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
