### PR TITLE
Refresh loadpoint status when site meters are unavailable

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -2131,6 +2131,60 @@ func (lp *Loadpoint) phaseSwitchCompleted() bool {
 	return time.Since(lp.phasesSwitched) > phaseSwitchDuration
 }
 
+// refreshStatus reads and publishes charger status, identifies the connected
+// vehicle and publishes soc/range. It contains no charging control logic and is
+// therefore safe to run when site meters are unavailable.
+func (lp *Loadpoint) refreshStatus() (bool, error) {
+	welcomeCharge, err := lp.updateChargerStatus()
+	if err != nil {
+		return false, err
+	}
+
+	lp.publish(keys.VehicleWelcomeActive, welcomeCharge)
+	lp.publish(keys.Connected, lp.connected())
+	lp.publish(keys.Charging, lp.charging())
+
+	lp.resetHeatingSession()
+
+	if sr, ok := api.Cap[api.StatusReasoner](lp.charger); ok && lp.GetStatus() == api.StatusB {
+		if r, err := sr.StatusReason(); err == nil {
+			lp.publish(keys.ChargerStatusReason, r)
+		} else {
+			lp.log.ERROR.Printf("charger status reason: %v", err)
+		}
+	}
+
+	// identify connected vehicle
+	if lp.connected() && !lp.chargerHasFeature(api.IntegratedDevice) {
+		// read identity and run associated action
+		lp.identifyVehicle()
+
+		// find vehicle by status for a couple of minutes after connecting
+		if lp.vehicleUnidentified() {
+			lp.identifyVehicleByStatus()
+		}
+	}
+
+	// release deferred connect notification once detection has settled
+	lp.maybePushVehicleConnect()
+
+	// publish soc after updating charger status to make sure
+	// initial update of connected state matches charger status
+	lp.publishSocAndRange()
+
+	return welcomeCharge, nil
+}
+
+// UpdateStatus refreshes charger and vehicle state without executing charging
+// control logic. It is used when site meters are unavailable, so that vehicle
+// connection state, soc and range do not go stale while the site cannot be
+// controlled safely.
+func (lp *Loadpoint) UpdateStatus() {
+	if _, err := lp.refreshStatus(); err != nil {
+		lp.log.ERROR.Println(err)
+	}
+}
+
 // Update is the main control function. It reevaluates meters and charger state
 func (lp *Loadpoint) Update(sitePower, batteryPower float64, consumption, feedin api.Rates, batteryBuffered, batteryStart bool, greenShare float64, effPrice, effCo2 *float64, dim *bool) {
 	// hold battery boost when SOC drops below the limit: stop draining the battery, but
@@ -2199,43 +2253,11 @@ func (lp *Loadpoint) Update(sitePower, batteryPower float64, consumption, feedin
 	}
 
 	// read and publish status
-	welcomeCharge, err := lp.updateChargerStatus()
+	welcomeCharge, err := lp.refreshStatus()
 	if err != nil {
 		lp.log.ERROR.Println(err)
 		return
 	}
-
-	lp.publish(keys.VehicleWelcomeActive, welcomeCharge)
-	lp.publish(keys.Connected, lp.connected())
-	lp.publish(keys.Charging, lp.charging())
-
-	lp.resetHeatingSession()
-
-	if sr, ok := api.Cap[api.StatusReasoner](lp.charger); ok && lp.GetStatus() == api.StatusB {
-		if r, err := sr.StatusReason(); err == nil {
-			lp.publish(keys.ChargerStatusReason, r)
-		} else {
-			lp.log.ERROR.Printf("charger status reason: %v", err)
-		}
-	}
-
-	// identify connected vehicle
-	if lp.connected() && !lp.chargerHasFeature(api.IntegratedDevice) {
-		// read identity and run associated action
-		lp.identifyVehicle()
-
-		// find vehicle by status for a couple of minutes after connecting
-		if lp.vehicleUnidentified() {
-			lp.identifyVehicleByStatus()
-		}
-	}
-
-	// release deferred connect notification once detection has settled
-	lp.maybePushVehicleConnect()
-
-	// publish soc after updating charger status to make sure
-	// initial update of connected state matches charger status
-	lp.publishSocAndRange()
 
 	// sync settings with charger
 	if err := lp.syncCharger(); err != nil {

--- a/core/loadpoint_updatestatus_test.go
+++ b/core/loadpoint_updatestatus_test.go
@@ -1,0 +1,84 @@
+package core
+
+import (
+	"testing"
+
+	evbus "github.com/asaskevich/EventBus"
+	"github.com/benbjohnson/clock"
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+// TestUpdateStatusRefreshesConnectedWithoutControl verifies that UpdateStatus
+// picks up a charger status change - and hence the connected/charging state
+// shown in the UI - without executing any charging control logic.
+//
+// This is the path taken when site meters are unavailable: a failing meter must
+// not freeze vehicle connection state (see #33395).
+func TestUpdateStatusRefreshesConnectedWithoutControl(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	charger := api.NewMockCharger(ctrl)
+
+	lp := &Loadpoint{
+		log:         util.NewLogger("foo"),
+		bus:         evbus.New(),
+		clock:       clock.NewMock(),
+		charger:     charger,
+		chargeMeter: &Null{},
+		chargeRater: &Null{},
+		chargeTimer: &Null{},
+		wakeUpTimer: NewTimer(),
+		minCurrent:  minA,
+		maxCurrent:  maxA,
+		phases:      1,
+		status:      api.StatusA, // disconnected
+	}
+
+	attachListeners(t, lp)
+
+	// vehicle plugs in between cycles
+	charger.EXPECT().Status().Return(api.StatusB, nil)
+
+	// Deliberately no Enable()/MaxCurrent() expectations: UpdateStatus must not
+	// drive the charger. gomock fails the test if it does.
+	lp.UpdateStatus()
+
+	assert.Equal(t, api.StatusB, lp.GetStatus(), "status should be refreshed")
+	assert.True(t, lp.connected(), "vehicle should be reported as connected")
+
+	ctrl.Finish()
+}
+
+// TestUpdateStatusPropagatesChargerError verifies UpdateStatus tolerates a
+// charger read failure without panicking and leaves status unchanged.
+func TestUpdateStatusPropagatesChargerError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	charger := api.NewMockCharger(ctrl)
+
+	lp := &Loadpoint{
+		log:         util.NewLogger("foo"),
+		bus:         evbus.New(),
+		clock:       clock.NewMock(),
+		charger:     charger,
+		chargeMeter: &Null{},
+		chargeRater: &Null{},
+		chargeTimer: &Null{},
+		wakeUpTimer: NewTimer(),
+		minCurrent:  minA,
+		maxCurrent:  maxA,
+		phases:      1,
+		status:      api.StatusB,
+	}
+
+	attachListeners(t, lp)
+
+	charger.EXPECT().Status().Return(api.StatusNone, api.ErrTimeout)
+
+	lp.UpdateStatus()
+
+	assert.Equal(t, api.StatusB, lp.GetStatus(), "status should be unchanged on error")
+
+	ctrl.Finish()
+}

--- a/core/site.go
+++ b/core/site.go
@@ -47,6 +47,7 @@ const standbyPower = 10 // consider less than 10W as charger in standby
 type updater interface {
 	loadpoint.API
 	Update(sitePower, batteryPower float64, consumption, feedin api.Rates, batteryBuffered, batteryStart bool, greenShare float64, effectivePrice, effectiveCo2 *float64, dim *bool)
+	UpdateStatus()
 }
 
 var _ site.API = (*Site)(nil)
@@ -1262,6 +1263,13 @@ func (site *Site) update(lp updater) {
 
 	if state, err := site.updateMeters(); err != nil {
 		site.log.ERROR.Println(err)
+
+		// Meters are unavailable, so charging cannot be controlled safely.
+		// Still refresh charger and vehicle state so connection status, soc and
+		// range don't freeze while a single (possibly unrelated) meter fails.
+		if lp != nil {
+			lp.UpdateStatus()
+		}
 	} else {
 		go site.optimizerUpdateAsync(tariff.SlotDuration)
 


### PR DESCRIPTION
Fixes #33395

## Problem

`site.update()` only calls `updatePower()` — and therefore `lp.Update()` — when `updateMeters()` succeeds:

```go
if state, err := site.updateMeters(); err != nil {
    site.log.ERROR.Println(err)
} else {
    go site.optimizerUpdateAsync(tariff.SlotDuration)
    site.updatePower(lp, state, totalChargePower, consumption, feedin)
}
```

`updateMeters()` runs all meters in an `errgroup` and aborts the whole batch if any single one errors; in practice `updateGridMeter` is the one that returns a real error (`fmt.Errorf("grid power: %v", err)`).

So while a grid meter is failing or stale, `lp.Update()` never runs, and none of `updateChargerStatus()`, `identifyVehicle()`, `publishSocAndRange()` or the `keys.Connected` / `keys.Charging` publishes execute. Vehicle connection state, SoC, range and odometer freeze at their last successful value — usually the startup value.

Observed on 0.315.0 with a `tibber-pulse` grid meter whose websocket repeatedly connected and disconnected without ever delivering a live measurement. The dashboard showed the car as disconnected with SoC 0 for as long as it persisted, **while the car was plugged in and actively charging** — `chargePower` / `chargeCurrents` stayed correct the whole time, since those come from `site.updateLoadpoints()` → `lp.UpdateChargePowerAndCurrents()`, which is not gated on `updateMeters()`.

Confirmed with `-l trace`: markers internal to `lp.Update()` appeared twice at startup and then never again across 6 consecutive site cycles, each logging `[site] ERROR ... grid power: outdated`, while the vehicle's own MQTT data kept arriving correctly throughout.

## Approach

Charging **control** genuinely must not run on stale site data, so that gating is deliberately left unchanged. **Status reporting** has no dependency on site power, so it shouldn't be gated on it.

- Extract the status-reporting portion of `Update()` into `refreshStatus()` (pure move, no behaviour change).
- Add `UpdateStatus()`, which runs only that portion.
- Call it from the meter-error branch of `site.update()`.

Control flow through `Update()` is otherwise untouched — the same code runs in the same order on the success path.

## Testing

- `go build ./core/... ./server/... ./charger/... ./meter/... ./vehicle/... ./plugin/...` — clean
- `go vet ./core/...` — clean
- `go test ./core/...` — all pass
- Added `core/loadpoint_updatestatus_test.go` with two regression tests:
  - `UpdateStatus()` picks up an A→B charger transition and reports the vehicle as connected, with **no** `Enable()`/`MaxCurrent()` expectations set, so gomock fails the test if control logic touches the charger.
  - `UpdateStatus()` handles a charger read error without panicking and leaves status unchanged.

## Notes

- `updater` gains a method; no existing mock needed regenerating (full suite passes), but flagging it in case CI generates additional mocks.
- `processTasks()` is intentionally *not* called from `UpdateStatus()`, to keep the failure path light. Happy to change if you'd prefer it included.
- An alternative would be to have `updateMeters()` degrade per-meter (retain last known value with a staleness marker) rather than aborting the batch. That's a larger change with real safety implications for control decisions, so I went with the narrower fix — happy to rework if you'd prefer that direction.
