### PR TITLE
Planner: clarify precondition log message

### DIFF
--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -112,8 +112,13 @@ func (lp *Loadpoint) GetPlan(targetTime time.Time, requiredDuration, preconditio
 		return nil
 	}
 
-	lp.log.TRACE.Printf("plan: creating plan with continuous=%v, precondition=%v, duration=%v, target=%v",
-		continuous, precondition, requiredDuration.Round(time.Second), targetTime.Round(time.Second).Local())
+	pc := precondition.String()
+	if precondition >= 7*24*time.Hour {
+		pc = "everything" // 168h, UI sentinel for max
+	}
+
+	lp.log.TRACE.Printf("plan: creating plan with continuous=%v, precondition=%s, duration=%v, target=%v",
+		continuous, pc, requiredDuration.Round(time.Second), targetTime.Round(time.Second).Local())
 
 	return lp.planner.Plan(requiredDuration, precondition, targetTime, continuous)
 }


### PR DESCRIPTION
fixes #33206

The plan trace log printed the raw `precondition=168h0m0s` sentinel, which reads like a misconfiguration. The log now uses the same wording as the UI.

- `precondition >= 168h` renders as `everything` in the plan trace message, matching the UI label

🤖 Generated with [Claude Code](https://claude.com/claude-code)