### PR TITLE
Config UI: usage-specific energy labels for device tags

### DIFF
--- a/assets/js/components/Config/ChargerModal.vue
+++ b/assets/js/components/Config/ChargerModal.vue
@@ -5,6 +5,7 @@
 		device-type="charger"
 		:is-sponsor="isSponsor"
 		:modal-title="modalTitle"
+		tags-usage="charge"
 		:provide-template-options="provideTemplateOptions"
 		:initial-values="initialValues"
 		:is-type-deprecated="isTypeDeprecated"

--- a/assets/js/components/Config/DeviceModal/Actions.vue
+++ b/assets/js/components/Config/DeviceModal/Actions.vue
@@ -7,6 +7,7 @@
 			v-bind="testState"
 			:sponsor-token-required="sponsorTokenRequired"
 			:currency="currency"
+			:usage="usage"
 			@test="$emit('test')"
 		/>
 
@@ -87,6 +88,7 @@ export default defineComponent({
 		isNew: Boolean as PropType<boolean>,
 		sponsorTokenRequired: Boolean as PropType<boolean>,
 		currency: String as PropType<CURRENCY>,
+		usage: String as PropType<string>,
 	},
 	emits: ["save", "remove", "test", "disable"],
 	computed: {

--- a/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
+++ b/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
@@ -202,6 +202,7 @@
 					:is-new="isNew"
 					:sponsor-token-required="sponsorTokenRequired"
 					:currency="currency"
+					:usage="tagsUsage"
 					@save="handleSave"
 					@remove="handleRemove"
 					@test="testManually"
@@ -299,6 +300,8 @@ export default defineComponent({
 		showMainContent: { type: Boolean, default: true },
 		// Optional: usage parameter for loadProducts (e.g., meter type: "pv", "battery", "aux", "ext")
 		usage: String,
+		// Optional: usage for test result labels
+		tagsUsage: String,
 		currency: { type: String as PropType<CURRENCY>, default: CURRENCY.EUR },
 		// Optional: custom product name computation
 		getProductName: Function as PropType<

--- a/assets/js/components/Config/DeviceTags.vue
+++ b/assets/js/components/Config/DeviceTags.vue
@@ -8,7 +8,7 @@
 				class="d-flex gap-2 overflow-hidden text-truncate"
 			>
 				<div class="label overflow-hidden text-truncate flex-shrink-1 flex-grow-1">
-					{{ $t(`config.deviceValue.${entry.name}`) }}
+					{{ deviceValueLabel(entry.name) }}
 				</div>
 				<div class="value" :class="[valueClasses(entry), truncateClasses(entry)]">
 					{{ fmtDeviceValue(entry) }}
@@ -31,7 +31,7 @@
 						:data-testid="`device-tag-${entry.name}`"
 					>
 						<td class="text-truncate">
-							{{ $t(`config.deviceValue.${entry.name}`) }}
+							{{ deviceValueLabel(entry.name) }}
 						</td>
 						<td
 							v-for="(val, idx) in entry.value"
@@ -78,6 +78,9 @@ const PHASE_TAGS = ["phaseCurrents", "phaseVoltages", "phasePowers"];
 
 const FORECAST_TAGS = ["priceRates", "co2Rates", "solarRates", "temperatureRates"];
 
+// display order, remaining tags follow in backend order
+const FIRST_TAGS = ["power", "soc", "capacity", "energy", "returnEnergy"];
+
 export default {
 	name: "DeviceTags",
 	components: { TariffChart },
@@ -85,6 +88,7 @@ export default {
 	props: {
 		tags: Object,
 		currency: String,
+		usage: String,
 	},
 	data() {
 		return {
@@ -92,8 +96,11 @@ export default {
 		};
 	},
 	computed: {
+		effectiveUsage() {
+			return this.tags?.heating?.value ? "consumer" : this.usage;
+		},
 		regularEntries() {
-			return Object.entries(this.tags)
+			const entries = Object.entries(this.tags)
 				.filter(
 					([name]) =>
 						!HIDDEN_TAGS.includes(name) &&
@@ -103,6 +110,11 @@ export default {
 				.map(([name, { value, error, warning, muted, asleep }]) => {
 					return { name, value, error, warning, muted, asleep };
 				});
+			const first = FIRST_TAGS.flatMap((name) =>
+				entries.filter((entry) => entry.name === name)
+			);
+			const rest = entries.filter(({ name }) => !FIRST_TAGS.includes(name));
+			return [...first, ...rest];
 		},
 		phaseEntries() {
 			return Object.entries(this.tags)
@@ -176,6 +188,13 @@ export default {
 		},
 	},
 	methods: {
+		deviceValueLabel(name) {
+			const usageKey = `config.deviceValue.usage.${this.effectiveUsage}.${name}`;
+			if (this.effectiveUsage && this.$te(usageKey)) {
+				return this.$t(usageKey);
+			}
+			return this.$t(`config.deviceValue.${name}`);
+		},
 		truncateClasses(entry) {
 			// don't truncate numeric values
 			return typeof entry.value === "string"

--- a/assets/js/components/Config/MeterCard.vue
+++ b/assets/js/components/Config/MeterCard.vue
@@ -16,7 +16,7 @@
 			<component :is="iconComponent" v-else />
 		</template>
 		<template #tags>
-			<DeviceTags :tags="tags" />
+			<DeviceTags :tags="tags" :usage="meterType" />
 		</template>
 	</DeviceCard>
 </template>

--- a/assets/js/components/Config/MeterModal.vue
+++ b/assets/js/components/Config/MeterModal.vue
@@ -16,6 +16,7 @@
 		:custom-fields="customFields"
 		:preserve-on-template-change="preserveFields"
 		:usage="templateUsage"
+		:tags-usage="selectedType"
 		:on-configuration-loaded="onConfigurationLoaded"
 		@added="(name) => emitChanged('added', name)"
 		@updated="() => emitChanged('updated')"

--- a/assets/js/components/Config/TestResult.vue
+++ b/assets/js/components/Config/TestResult.vue
@@ -35,6 +35,7 @@
 			<DeviceTags
 				:tags="result as Record<string, any>"
 				:currency="currency"
+				:usage="usage"
 				class="success-values"
 			/>
 		</div>
@@ -59,6 +60,7 @@ export default defineComponent({
 		error: String as PropType<string | null>,
 		sponsorTokenRequired: Boolean,
 		currency: String as PropType<CURRENCY>,
+		usage: String as PropType<string>,
 	},
 	emits: ["test"],
 	data() {

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -53,7 +53,7 @@
 							@enable="handleDisable('loadpoint', loadpoint.id!, false)"
 						>
 							<template #tags>
-								<DeviceTags :tags="loadpointTags(loadpoint)" />
+								<DeviceTags :tags="loadpointTags(loadpoint)" usage="charge" />
 							</template>
 							<template #icon>
 								<VehicleIcon

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -210,7 +210,7 @@
       "chargeStatusC": "lädt",
       "chargeStatusE": "Keine Leistung",
       "chargeStatusF": "Fehler",
-      "chargedEnergy": "Geladen",
+      "chargedEnergy": "Geladen (Session)",
       "co2": "Netz-CO₂",
       "configured": "Konfiguriert",
       "connected": "Verbunden",
@@ -259,6 +259,31 @@
       "temp": "Temperatur",
       "topic": "Thema",
       "url": "URL",
+      "usage": {
+        "aux": {
+          "energy": "Verbraucht",
+          "returnEnergy": "Erzeugt"
+        },
+        "battery": {
+          "energy": "Entladen",
+          "returnEnergy": "Geladen"
+        },
+        "charge": {
+          "energy": "Geladen",
+          "returnEnergy": "Entladen"
+        },
+        "consumer": {
+          "energy": "Verbraucht",
+          "returnEnergy": "Erzeugt"
+        },
+        "grid": {
+          "energy": "Bezogen",
+          "returnEnergy": "Eingespeist"
+        },
+        "pv": {
+          "energy": "Erzeugt"
+        }
+      },
       "vehicleLimitSoc": "Ladelimit",
       "yes": "Ja"
     },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -210,7 +210,7 @@
       "chargeStatusC": "charging",
       "chargeStatusE": "no power",
       "chargeStatusF": "error",
-      "chargedEnergy": "Charged",
+      "chargedEnergy": "Charged (session)",
       "co2": "Grid CO₂",
       "configured": "Configured",
       "connected": "Connected",
@@ -259,6 +259,31 @@
       "temp": "Temperature",
       "topic": "Topic",
       "url": "URL",
+      "usage": {
+        "aux": {
+          "energy": "Consumed",
+          "returnEnergy": "Produced"
+        },
+        "battery": {
+          "energy": "Discharged",
+          "returnEnergy": "Charged"
+        },
+        "charge": {
+          "energy": "Charged",
+          "returnEnergy": "Discharged"
+        },
+        "consumer": {
+          "energy": "Consumed",
+          "returnEnergy": "Produced"
+        },
+        "grid": {
+          "energy": "Imported",
+          "returnEnergy": "Exported"
+        },
+        "pv": {
+          "energy": "Produced"
+        }
+      },
       "vehicleLimitSoc": "Charge limit",
       "yes": "yes"
     },

--- a/tests/config-aux.spec.ts
+++ b/tests/config-aux.spec.ts
@@ -88,7 +88,7 @@ energy:
     await restResult.getByRole("link", { name: "validate" }).click();
     await expect(restResult).toContainText("Status: successful");
     await expect(restResult).toContainText(["Power", "3.0 kW"].join(""));
-    await expect(restResult).toContainText(["Energy", "42.0 kWh"].join(""));
+    await expect(restResult).toContainText(["Consumed", "42.0 kWh"].join(""));
 
     // create
     await modal.getByRole("button", { name: "Save" }).click();
@@ -126,7 +126,7 @@ energy:
     await restResult.getByRole("link", { name: "validate" }).click();
     await expect(restResult).toContainText("Status: successful");
     await expect(restResult).toContainText(["Power", "300 W"].join(""));
-    await expect(restResult).toContainText(["Energy", "4.2 kWh"].join(""));
+    await expect(restResult).toContainText(["Consumed", "4.2 kWh"].join(""));
     await modal.getByRole("button", { name: "Save" }).click();
     await expectModalHidden(modal);
     await expect(page.getByTestId("aux")).toHaveCount(1);

--- a/tests/config-custom-meter.spec.ts
+++ b/tests/config-custom-meter.spec.ts
@@ -38,7 +38,7 @@ uri: http://${simulatorHost()}`
     await expect(testResult).toContainText("Status: unknown");
     await testResult.getByRole("link", { name: "validate" }).click();
     await expect(testResult).toContainText("Status: successful");
-    await expect(testResult).toContainText(["Energy", "0.0 kWh"].join(""));
+    await expect(testResult).toContainText(["Imported", "0.0 kWh"].join(""));
 
     // save
     await meterModal.getByRole("button", { name: "Save" }).click();
@@ -50,7 +50,7 @@ uri: http://${simulatorHost()}`
     await page.reload();
     await expect(page.getByTestId("fatal-error")).not.toBeVisible();
     await expect(page.getByTestId("grid")).toBeVisible();
-    await expect(page.getByTestId("grid")).toContainText(["Energy", "0.0 kWh"].join(""));
+    await expect(page.getByTestId("grid")).toContainText(["Imported", "0.0 kWh"].join(""));
 
     // edit
     await page.getByTestId("grid").getByRole("button", { name: "edit" }).click();

--- a/tests/config-loadpoint.spec.ts
+++ b/tests/config-loadpoint.spec.ts
@@ -735,7 +735,7 @@ temp:
     await restResult.getByRole("link", { name: "validate" }).click();
     await expect(restResult).toContainText("Status: successful");
     await expect(restResult).toContainText(["Power", "1.0 kW"].join(""));
-    await expect(restResult).toContainText(["Energy", "700 Wh"].join(""));
+    await expect(restResult).toContainText(["Consumed", "700 Wh"].join(""));
     await expect(restResult).toContainText(["Temperature", "25.0°C"].join(""));
     await expect(restResult).toContainText(["Heater limit", "50.0°C"].join(""));
 


### PR DESCRIPTION
fixes #33399

The configuration screen showed generic "Energy" / "Energy (reverse)" labels on all meter tiles. The German "Energie (rückwärts)" was too long for narrow cards and got truncated. Labels are now specific to the device's role, making the values self-explanatory and shorter at the same time.

  | Device | energy (EN/DE) | returnEnergy (EN/DE) |
  | --- | --- | --- |
  | Grid | Imported / Bezogen | Exported / Eingespeist |
  | Battery | Discharged / Entladen | Charged / Geladen |
  | Solar | Produced / Erzeugt | _unchanged_ |
  | Charge meter, charger | Charged / Geladen | Discharged / Entladen |
  | Consumer, aux, heater | Consumed / Verbraucht | Produced / Erzeugt |
  | External meter | _unchanged_ | _unchanged_ |

- Meter and charger values in device cards and test results now use role-specific labels for `energy` and `returnEnergy`:
- Session energy is relabeled "Charged (session)" / "Geladen (Session)" to distinguish it from the total charged energy.
- Heaters use the consumer wording since they consume rather than charge.
- Labels without a clear role-specific meaning keep the generic wording: reverse energy on solar, and external meters, whose role is not known.
- Values are now shown in a consistent order: power, charge, capacity, then the two energy directions together. Previously the order was alphabetical by internal name, which split the energy values apart.

<img width="733" height="364" alt="charge" src="https://github.com/user-attachments/assets/918d02ac-f224-468c-8bb5-d71eb37ac3c8" />


<img width="1127" height="1008" alt="meter" src="https://github.com/user-attachments/assets/38d4b41f-7816-4e76-9260-a4dc32215040" />
