### PR TITLE
Charger (Shelly): support multiple relay channels

### DIFF
--- a/charger/shelly.go
+++ b/charger/shelly.go
@@ -28,11 +28,12 @@ func NewShellyFromConfig(other map[string]any) (api.Charger, error) {
 		URI          string
 		User         string
 		Password     string
-		Channel      int
+		Channel      []int
 		StandbyPower float64
 		Cache        time.Duration
 	}{
-		Cache: time.Second,
+		Channel: []int{0},
+		Cache:   time.Second,
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
@@ -44,18 +45,18 @@ func NewShellyFromConfig(other map[string]any) (api.Charger, error) {
 		return nil, err
 	}
 
-	if phases, ok := c.conn.Generation.(shelly.Phases); ok {
-		implement.Has(c, implement.PhaseVoltages(phases.Voltages))
-		implement.Has(c, implement.PhaseCurrents(phases.Currents))
-		implement.Has(c, implement.PhasePowers(phases.Powers))
+	if c.conn.HasPhases() {
+		implement.Has(c, implement.PhaseVoltages(c.conn.Voltages))
+		implement.Has(c, implement.PhaseCurrents(c.conn.Currents))
+		implement.Has(c, implement.PhasePowers(c.conn.Powers))
 	}
 
 	return c, nil
 }
 
 // NewShelly creates Shelly charger
-func NewShelly(embed embed, uri, user, password string, channel int, standbypower float64, cache time.Duration) (*Shelly, error) {
-	conn, err := shelly.NewConnection(uri, user, password, channel, cache)
+func NewShelly(embed embed, uri, user, password string, channels []int, standbypower float64, cache time.Duration) (*Shelly, error) {
+	conn, err := shelly.NewConnection(uri, user, password, channels, cache)
 	if err != nil {
 		return nil, err
 	}

--- a/meter/shelly.go
+++ b/meter/shelly.go
@@ -29,11 +29,12 @@ func NewShellyFromConfig(other map[string]any) (api.Meter, error) {
 		URI      string
 		User     string
 		Password string
-		Channel  int
+		Channel  []int
 		Usage    string
 		Cache    time.Duration
 	}{
-		Cache: time.Second,
+		Channel: []int{0},
+		Cache:   time.Second,
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
@@ -65,18 +66,18 @@ func NewShellyFromConfig(other map[string]any) (api.Meter, error) {
 		}
 	}
 
-	if phases, ok := c.conn.Generation.(shelly.Phases); ok {
-		implement.Has(c, implement.PhaseVoltages(phases.Voltages))
-		implement.Has(c, implement.PhaseCurrents(phases.Currents))
-		implement.Has(c, implement.PhasePowers(phases.Powers))
+	if c.conn.HasPhases() {
+		implement.Has(c, implement.PhaseVoltages(c.conn.Voltages))
+		implement.Has(c, implement.PhaseCurrents(c.conn.Currents))
+		implement.Has(c, implement.PhasePowers(c.conn.Powers))
 	}
 
 	return c, nil
 }
 
 // NewShelly creates Shelly meter
-func NewShelly(uri, user, password, usage string, channel int, cache time.Duration) (*Shelly, error) {
-	conn, err := shelly.NewConnection(uri, user, password, channel, cache)
+func NewShelly(uri, user, password, usage string, channels []int, cache time.Duration) (*Shelly, error) {
+	conn, err := shelly.NewConnection(uri, user, password, channels, cache)
 	if err != nil {
 		return nil, err
 	}

--- a/meter/shelly/connection.go
+++ b/meter/shelly/connection.go
@@ -33,8 +33,8 @@ type Phases interface {
 
 // Connection is the Shelly connection. It aggregates one Generation per configured channel.
 type Connection struct {
-	Generation // first channel, decides the device capabilities
-	gens       []Generation
+	Generation // first relay, decides the device capabilities
+	relays     []Generation
 	gen        int
 }
 
@@ -90,12 +90,12 @@ func NewConnection(uri, user, password string, channels []int, cache time.Durati
 		}
 	}
 
-	gens := make([]Generation, 0, len(channels))
+	relays := make([]Generation, 0, len(channels))
 	for _, channel := range channels {
 		if resp.Gen < 2 {
 			// Shelly GEN 1 API
 			// https://shelly-api-docs.shelly.cloud/gen1/#shelly-family-overview
-			gens = append(gens, newGen1(client, uri, model, channel, cache))
+			relays = append(relays, newGen1(client, uri, model, channel, cache))
 			continue
 		}
 
@@ -105,27 +105,27 @@ func NewConnection(uri, user, password string, channels []int, cache time.Durati
 		if err != nil {
 			return nil, err
 		}
-		gens = append(gens, gen)
+		relays = append(relays, gen)
 	}
 
 	// channels are compared after construction- the Pro output add-on can remap
 	// multiple configured channels onto the same relay
-	used := make(map[int]bool, len(gens))
-	for _, gen := range gens {
+	used := make(map[int]bool, len(relays))
+	for _, gen := range relays {
 		if used[gen.relay()] {
 			return nil, fmt.Errorf("duplicate channel: %d", gen.relay())
 		}
 		used[gen.relay()] = true
 	}
 
-	conn := &Connection{Generation: gens[0], gens: gens, gen: resp.Gen}
+	conn := &Connection{Generation: relays[0], relays: relays, gen: resp.Gen}
 
 	return conn, nil
 }
 
 // Enabled reports whether all configured channels are switched on
 func (c *Connection) Enabled() (bool, error) {
-	for _, gen := range c.gens {
+	for _, gen := range c.relays {
 		enabled, err := gen.Enabled()
 		if err != nil || !enabled {
 			return false, err
@@ -138,7 +138,7 @@ func (c *Connection) Enabled() (bool, error) {
 // left in the wrong state would otherwise go unnoticed by the Enabled readback.
 func (c *Connection) Enable(enable bool) error {
 	var errs []error
-	for _, gen := range c.gens {
+	for _, gen := range c.relays {
 		if err := gen.Enable(enable); err != nil {
 			errs = append(errs, err)
 		}
@@ -164,7 +164,7 @@ func (c *Connection) ReturnEnergy() (float64, error) {
 // sum accumulates a reading across all configured channels
 func (c *Connection) sum(fun func(Generation) (float64, error)) (float64, error) {
 	var total float64
-	for _, gen := range c.gens {
+	for _, gen := range c.relays {
 		val, err := fun(gen)
 		if err != nil {
 			return 0, err
@@ -178,7 +178,7 @@ func (c *Connection) sum(fun func(Generation) (float64, error)) (float64, error)
 // device readings, three channels are mapped to L1..L3 in configuration order.
 func (c *Connection) HasPhases() bool {
 	_, ok := c.Generation.(Phases)
-	return ok && (len(c.gens) == 1 || len(c.gens) == 3)
+	return ok && (len(c.relays) == 1 || len(c.relays) == 3)
 }
 
 // Currents implements the api.PhaseCurrents interface
@@ -201,12 +201,12 @@ func (c *Connection) phaseValues(fun func(Phases) (float64, float64, float64, er
 		return 0, 0, 0, api.ErrNotAvailable
 	}
 
-	if len(c.gens) == 1 {
+	if len(c.relays) == 1 {
 		return fun(c.Generation.(Phases))
 	}
 
 	var res [3]float64
-	for i, gen := range c.gens {
+	for i, gen := range c.relays {
 		l1, _, _, err := fun(gen.(Phases))
 		if err != nil {
 			return 0, 0, 0, err

--- a/meter/shelly/connection.go
+++ b/meter/shelly/connection.go
@@ -15,8 +15,6 @@ import (
 type Generation interface {
 	Enabled() (bool, error)
 	Enable(bool) error
-	// relay is the switch id the channel resolves to, which may differ from the configured one
-	relay() int
 	api.Meter
 	api.MeterEnergy
 	api.MeterReturnEnergy
@@ -105,31 +103,34 @@ func NewConnection(uri, user, password string, channels []int, cache time.Durati
 	}
 
 	relays := make([]Generation, 0, len(channels))
+	used := make(map[int]bool, len(channels))
+
 	for _, channel := range channels {
+		var gen Generation
+		relay := channel
+
 		if resp.Gen < 2 {
 			// Shelly GEN 1 API
 			// https://shelly-api-docs.shelly.cloud/gen1/#shelly-family-overview
-			relays = append(relays, newGen1(client, uri, model, channel, cache))
-			continue
+			gen = newGen1(client, uri, model, channel, cache)
+		} else {
+			// Shelly GEN 2+ API
+			// https://shelly-api-docs.shelly.cloud/gen2/
+			g, err := newGen2(client, uri, model, channel, cache)
+			if err != nil {
+				return nil, err
+			}
+
+			// the Pro output add-on remaps every channel to the same relay
+			gen, relay = g, g.switchchannel
 		}
 
-		// Shelly GEN 2+ API
-		// https://shelly-api-docs.shelly.cloud/gen2/
-		gen, err := newGen2(client, uri, model, channel, cache)
-		if err != nil {
-			return nil, err
+		if used[relay] {
+			return nil, fmt.Errorf("duplicate channel: %d", relay)
 		}
+		used[relay] = true
+
 		relays = append(relays, gen)
-	}
-
-	// channels are compared after construction- the Pro output add-on can remap
-	// multiple configured channels onto the same relay
-	used := make(map[int]bool, len(relays))
-	for _, gen := range relays {
-		if used[gen.relay()] {
-			return nil, fmt.Errorf("duplicate channel: %d", gen.relay())
-		}
-		used[gen.relay()] = true
 	}
 
 	conn := &Connection{relays: relays, gen: resp.Gen}

--- a/meter/shelly/connection.go
+++ b/meter/shelly/connection.go
@@ -29,11 +29,14 @@ type Phases interface {
 	api.PhasePowers
 }
 
-// Connection is the Shelly connection
+// Connection is the Shelly connection. It aggregates one Generation per configured channel.
 type Connection struct {
-	Generation
-	gen int
+	Generation // first channel, decides the device capabilities
+	gens       []Generation
+	gen        int
 }
+
+var _ Phases = (*Connection)(nil)
 
 // SignedPower reports whether the device returns directional (signed) power.
 func (c *Connection) SignedPower() bool {
@@ -41,9 +44,21 @@ func (c *Connection) SignedPower() bool {
 }
 
 // NewConnection creates a new Shelly device connection.
-func NewConnection(uri, user, password string, channel int, cache time.Duration) (*Connection, error) {
+func NewConnection(uri, user, password string, channels []int, cache time.Duration) (*Connection, error) {
 	if uri == "" {
 		return nil, errors.New("missing uri")
+	}
+
+	if len(channels) == 0 {
+		return nil, errors.New("missing channel")
+	}
+
+	used := make(map[int]bool, len(channels))
+	for _, channel := range channels {
+		if used[channel] {
+			return nil, fmt.Errorf("duplicate channel: %d", channel)
+		}
+		used[channel] = true
 	}
 
 	for _, suffix := range []string{"/", "/rcp", "/shelly"} {
@@ -68,26 +83,130 @@ func NewConnection(uri, user, password string, channel int, cache time.Duration)
 
 	client.Transport = request.NewTripper(log, transport.Insecure())
 
-	var gen Generation
-	if resp.Gen < 2 {
-		// Shelly GEN 1 API
-		// https://shelly-api-docs.shelly.cloud/gen1/#shelly-family-overview
-		if user != "" {
+	// authentication is wrapped once, the client is shared by all channels
+	if user != "" {
+		if resp.Gen < 2 {
+			// https://shelly-api-docs.shelly.cloud/gen1/#authentication
 			log.Redact(transport.BasicAuthHeader(user, password))
-		}
-		gen = newGen1(client, uri, model, channel, user, password, cache)
-	} else {
-		// Shelly GEN 2+ API
-		// https://shelly-api-docs.shelly.cloud/gen2/
-
-		var err error
-		gen, err = newGen2(client, uri, model, channel, user, password, cache)
-		if err != nil {
-			return nil, err
+			client.Transport = transport.BasicAuth(user, password, client.Transport)
+		} else {
+			// Shelly gen 2 rfc7616 authentication
+			// https://shelly-api-docs.shelly.cloud/gen2/General/Authentication
+			client.Transport = transport.Digest(user, password, client.Transport)
 		}
 	}
 
-	conn := &Connection{Generation: gen, gen: resp.Gen}
+	gens := make([]Generation, 0, len(channels))
+	for _, channel := range channels {
+		if resp.Gen < 2 {
+			// Shelly GEN 1 API
+			// https://shelly-api-docs.shelly.cloud/gen1/#shelly-family-overview
+			gens = append(gens, newGen1(client, uri, model, channel, cache))
+			continue
+		}
+
+		// Shelly GEN 2+ API
+		// https://shelly-api-docs.shelly.cloud/gen2/
+		gen, err := newGen2(client, uri, model, channel, cache)
+		if err != nil {
+			return nil, err
+		}
+		gens = append(gens, gen)
+	}
+
+	conn := &Connection{Generation: gens[0], gens: gens, gen: resp.Gen}
 
 	return conn, nil
+}
+
+// Enabled reports whether all configured channels are switched on
+func (c *Connection) Enabled() (bool, error) {
+	for _, gen := range c.gens {
+		enabled, err := gen.Enabled()
+		if err != nil || !enabled {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+// Enable switches all configured channels
+func (c *Connection) Enable(enable bool) error {
+	for _, gen := range c.gens {
+		if err := gen.Enable(enable); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CurrentPower implements the api.Meter interface
+func (c *Connection) CurrentPower() (float64, error) {
+	return c.sum(Generation.CurrentPower)
+}
+
+// TotalEnergy implements the api.MeterEnergy interface
+func (c *Connection) TotalEnergy() (float64, error) {
+	return c.sum(Generation.TotalEnergy)
+}
+
+// ReturnEnergy implements the api.MeterReturnEnergy interface
+func (c *Connection) ReturnEnergy() (float64, error) {
+	return c.sum(Generation.ReturnEnergy)
+}
+
+// sum accumulates a reading across all configured channels
+func (c *Connection) sum(fun func(Generation) (float64, error)) (float64, error) {
+	var total float64
+	for _, gen := range c.gens {
+		val, err := fun(gen)
+		if err != nil {
+			return 0, err
+		}
+		total += val
+	}
+	return total, nil
+}
+
+// HasPhases reports whether per-phase readings are available. A single channel uses the
+// device readings, three channels are mapped to L1..L3 in configuration order.
+func (c *Connection) HasPhases() bool {
+	_, ok := c.Generation.(Phases)
+	return ok && (len(c.gens) == 1 || len(c.gens) == 3)
+}
+
+// Currents implements the api.PhaseCurrents interface
+func (c *Connection) Currents() (float64, float64, float64, error) {
+	return c.phaseValues(Phases.Currents)
+}
+
+// Voltages implements the api.PhaseVoltages interface
+func (c *Connection) Voltages() (float64, float64, float64, error) {
+	return c.phaseValues(Phases.Voltages)
+}
+
+// Powers implements the api.PhasePowers interface
+func (c *Connection) Powers() (float64, float64, float64, error) {
+	return c.phaseValues(Phases.Powers)
+}
+
+func (c *Connection) phaseValues(fun func(Phases) (float64, float64, float64, error)) (float64, float64, float64, error) {
+	if !c.HasPhases() {
+		return 0, 0, 0, api.ErrNotAvailable
+	}
+
+	if len(c.gens) == 1 {
+		return fun(c.Generation.(Phases))
+	}
+
+	var res [3]float64
+	for i, gen := range c.gens {
+		l1, _, _, err := fun(gen.(Phases))
+		if err != nil {
+			return 0, 0, 0, err
+		}
+		res[i] = l1
+	}
+
+	return res[0], res[1], res[2], nil
 }

--- a/meter/shelly/connection.go
+++ b/meter/shelly/connection.go
@@ -31,11 +31,10 @@ type Phases interface {
 	api.PhasePowers
 }
 
-// Connection is the Shelly connection. It aggregates one Generation per configured channel.
+// Connection is the Shelly connection. It aggregates one Generation per configured relay.
 type Connection struct {
-	Generation // first relay, decides the device capabilities
-	relays     []Generation
-	gen        int
+	relays []Generation
+	gen    int
 }
 
 var _ Phases = (*Connection)(nil)
@@ -43,6 +42,21 @@ var _ Phases = (*Connection)(nil)
 // SignedPower reports whether the device returns directional (signed) power.
 func (c *Connection) SignedPower() bool {
 	return c.gen >= 3
+}
+
+// IsThreePhase reports whether the device is a three-phase energy meter
+func (c *Connection) IsThreePhase() bool {
+	return c.relays[0].IsThreePhase()
+}
+
+// IsReversed reports whether the device-side "Reverse power measurement" setting is enabled
+func (c *Connection) IsReversed() bool {
+	return c.relays[0].IsReversed()
+}
+
+// HasReturnEnergy reports whether the device measures energy in the return direction
+func (c *Connection) HasReturnEnergy() bool {
+	return c.relays[0].HasReturnEnergy()
 }
 
 // NewConnection creates a new Shelly device connection.
@@ -118,7 +132,7 @@ func NewConnection(uri, user, password string, channels []int, cache time.Durati
 		used[gen.relay()] = true
 	}
 
-	conn := &Connection{Generation: relays[0], relays: relays, gen: resp.Gen}
+	conn := &Connection{relays: relays, gen: resp.Gen}
 
 	return conn, nil
 }
@@ -174,10 +188,10 @@ func (c *Connection) sum(fun func(Generation) (float64, error)) (float64, error)
 	return total, nil
 }
 
-// HasPhases reports whether per-phase readings are available. A single channel uses the
-// device readings, three channels are mapped to L1..L3 in configuration order.
+// HasPhases reports whether per-phase readings are available. A single relay uses the
+// device readings, three relays are mapped to L1..L3 in configuration order.
 func (c *Connection) HasPhases() bool {
-	_, ok := c.Generation.(Phases)
+	_, ok := c.relays[0].(Phases)
 	return ok && (len(c.relays) == 1 || len(c.relays) == 3)
 }
 
@@ -202,7 +216,7 @@ func (c *Connection) phaseValues(fun func(Phases) (float64, float64, float64, er
 	}
 
 	if len(c.relays) == 1 {
-		return fun(c.Generation.(Phases))
+		return fun(c.relays[0].(Phases))
 	}
 
 	var res [3]float64

--- a/meter/shelly/connection.go
+++ b/meter/shelly/connection.go
@@ -15,6 +15,8 @@ import (
 type Generation interface {
 	Enabled() (bool, error)
 	Enable(bool) error
+	// relay is the switch id the channel resolves to, which may differ from the configured one
+	relay() int
 	api.Meter
 	api.MeterEnergy
 	api.MeterReturnEnergy
@@ -51,14 +53,6 @@ func NewConnection(uri, user, password string, channels []int, cache time.Durati
 
 	if len(channels) == 0 {
 		return nil, errors.New("missing channel")
-	}
-
-	used := make(map[int]bool, len(channels))
-	for _, channel := range channels {
-		if used[channel] {
-			return nil, fmt.Errorf("duplicate channel: %d", channel)
-		}
-		used[channel] = true
 	}
 
 	for _, suffix := range []string{"/", "/rcp", "/shelly"} {
@@ -114,6 +108,16 @@ func NewConnection(uri, user, password string, channels []int, cache time.Durati
 		gens = append(gens, gen)
 	}
 
+	// channels are compared after construction- the Pro output add-on can remap
+	// multiple configured channels onto the same relay
+	used := make(map[int]bool, len(gens))
+	for _, gen := range gens {
+		if used[gen.relay()] {
+			return nil, fmt.Errorf("duplicate channel: %d", gen.relay())
+		}
+		used[gen.relay()] = true
+	}
+
 	conn := &Connection{Generation: gens[0], gens: gens, gen: resp.Gen}
 
 	return conn, nil
@@ -130,14 +134,16 @@ func (c *Connection) Enabled() (bool, error) {
 	return true, nil
 }
 
-// Enable switches all configured channels
+// Enable switches all configured channels. Every channel is attempted, a channel
+// left in the wrong state would otherwise go unnoticed by the Enabled readback.
 func (c *Connection) Enable(enable bool) error {
+	var errs []error
 	for _, gen := range c.gens {
 		if err := gen.Enable(enable); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // CurrentPower implements the api.Meter interface

--- a/meter/shelly/connection.go
+++ b/meter/shelly/connection.go
@@ -122,7 +122,8 @@ func NewConnection(uri, user, password string, channels []int, cache time.Durati
 			}
 
 			// the Pro output add-on remaps every channel to the same relay
-			gen, relay = g, g.switchchannel
+			gen = g
+			relay = g.switchchannel
 		}
 
 		if used[relay] {
@@ -133,9 +134,7 @@ func NewConnection(uri, user, password string, channels []int, cache time.Durati
 		relays = append(relays, gen)
 	}
 
-	conn := &Connection{relays: relays, gen: resp.Gen}
-
-	return conn, nil
+	return &Connection{relays: relays, gen: resp.Gen}, nil
 }
 
 // Enabled reports whether all configured channels are switched on
@@ -176,7 +175,6 @@ func (c *Connection) ReturnEnergy() (float64, error) {
 	return c.sum(Generation.ReturnEnergy)
 }
 
-// sum accumulates a reading across all configured channels
 func (c *Connection) sum(fun func(Generation) (float64, error)) (float64, error) {
 	var total float64
 	for _, gen := range c.relays {

--- a/meter/shelly/connection_test.go
+++ b/meter/shelly/connection_test.go
@@ -2,6 +2,7 @@ package shelly
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -44,6 +45,71 @@ func shellyServer(t *testing.T, rpc map[string]string) *httptest.Server {
 	}))
 }
 
+// TestMultiChannelConnection covers a multi-relay device (Shelly Pro 3) switched as
+// a single three-phase device: readings are aggregated, phases follow channel order.
+func TestMultiChannelConnection(t *testing.T) {
+	var switched []bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req Gen2SetRpcPost
+		json.NewDecoder(r.Body).Decode(&req)
+
+		switch r.URL.Path {
+		case "/shelly":
+			json.NewEncoder(w).Encode(map[string]any{"gen": 2, "model": "SPSW-003XE16EU"})
+		case "/rpc/Shelly.ListMethods":
+			json.NewEncoder(w).Encode(Gen2Methods{Methods: []string{"Switch.GetStatus", "Switch.GetConfig", "Switch.Set"}})
+		case "/rpc/Switch.GetConfig":
+			w.Write([]byte(`{"id":0}`))
+		case "/rpc/Switch.Set":
+			switched = append(switched, req.On)
+			w.Write([]byte(`{"was_on":false}`))
+		case "/rpc/Switch.GetStatus":
+			// per-channel readings, scaled by channel id
+			fmt.Fprintf(w, `{"id":%d,"output":true,"apower":%d,"voltage":230,"current":%d,"aenergy":{"total":%d}}`,
+				req.Id, 100*(req.Id+1), req.Id+1, 1000*(req.Id+1))
+		default:
+			http.Error(w, `{"code":-105,"message":"no handler"}`, http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	conn, err := NewConnection(srv.URL, "", "", []int{0, 1, 2}, time.Second)
+	require.NoError(t, err)
+
+	enabled, err := conn.Enabled()
+	require.NoError(t, err)
+	assert.True(t, enabled)
+
+	power, err := conn.CurrentPower()
+	require.NoError(t, err)
+	assert.Equal(t, 600.0, power, "power is summed across channels")
+
+	total, err := conn.TotalEnergy()
+	require.NoError(t, err)
+	assert.Equal(t, 6.0, total, "energy is summed across channels")
+
+	require.True(t, conn.HasPhases())
+
+	l1, l2, l3, err := conn.Powers()
+	require.NoError(t, err)
+	assert.Equal(t, []float64{100, 200, 300}, []float64{l1, l2, l3})
+
+	l1, l2, l3, err = conn.Currents()
+	require.NoError(t, err)
+	assert.Equal(t, []float64{1, 2, 3}, []float64{l1, l2, l3})
+
+	require.NoError(t, conn.Enable(true))
+	assert.Equal(t, []bool{true, true, true}, switched, "all channels are switched")
+}
+
+// TestDuplicateChannel asserts that duplicate channels are rejected- they would
+// count the same relay twice.
+func TestDuplicateChannel(t *testing.T) {
+	_, err := NewConnection("http://foo", "", "", []int{0, 0}, time.Second)
+	require.Error(t, err)
+}
+
 // TestNakedSwitchConnection asserts that a switch without power measurement
 // (Shelly Plus 1) connects - its status has neither aenergy nor ret_aenergy.
 func TestNakedSwitchConnection(t *testing.T) {
@@ -53,7 +119,7 @@ func TestNakedSwitchConnection(t *testing.T) {
 	})
 	defer srv.Close()
 
-	conn, err := NewConnection(srv.URL, "", "", 0, time.Second)
+	conn, err := NewConnection(srv.URL, "", "", []int{0}, time.Second)
 	require.NoError(t, err, "naked switch must connect")
 
 	assert.False(t, conn.IsReversed())
@@ -90,7 +156,7 @@ func TestSwitchConnectionStatusError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	conn, err := NewConnection(srv.URL, "", "", 0, time.Second)
+	conn, err := NewConnection(srv.URL, "", "", []int{0}, time.Second)
 	require.NoError(t, err, "status error must not break connecting")
 
 	_, err = conn.CurrentPower()
@@ -105,7 +171,7 @@ func TestPlugConnection(t *testing.T) {
 	})
 	defer srv.Close()
 
-	conn, err := NewConnection(srv.URL, "", "", 0, time.Second)
+	conn, err := NewConnection(srv.URL, "", "", []int{0}, time.Second)
 	require.NoError(t, err)
 
 	assert.False(t, conn.IsReversed())
@@ -124,7 +190,7 @@ func TestReversedSwitchConnection(t *testing.T) {
 	})
 	defer srv.Close()
 
-	conn, err := NewConnection(srv.URL, "", "", 0, time.Second)
+	conn, err := NewConnection(srv.URL, "", "", []int{0}, time.Second)
 	require.NoError(t, err)
 
 	assert.True(t, conn.IsReversed())

--- a/meter/shelly/connection_test.go
+++ b/meter/shelly/connection_test.go
@@ -3,6 +3,7 @@ package shelly
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -103,11 +104,34 @@ func TestMultiChannelConnection(t *testing.T) {
 	assert.Equal(t, []bool{true, true, true}, switched, "all channels are switched")
 }
 
-// TestDuplicateChannel asserts that duplicate channels are rejected- they would
-// count the same relay twice.
+// TestDuplicateChannel asserts that channels resolving to the same relay are
+// rejected- they would count the same relay twice. The Pro output add-on remaps
+// every configured channel to switch 100, so the check must run on the resolved id.
 func TestDuplicateChannel(t *testing.T) {
-	_, err := NewConnection("http://foo", "", "", []int{0, 0}, time.Second)
-	require.Error(t, err)
+	for _, tc := range []struct {
+		name     string
+		channels []int
+		rpc      map[string]string
+	}{
+		{"configured twice", []int{0, 0}, nil},
+		{"remapped by add-on", []int{0, 1}, map[string]string{
+			"ProOutputAddon.GetPeripherals": `{"digital_out":{"switch:100":{}}}`,
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rpc := map[string]string{
+				"Switch.GetStatus": `{"id":0,"output":true}`,
+				"Switch.GetConfig": `{"id":0}`,
+			}
+			maps.Copy(rpc, tc.rpc)
+
+			srv := shellyServer(t, rpc)
+			defer srv.Close()
+
+			_, err := NewConnection(srv.URL, "", "", tc.channels, time.Second)
+			require.Error(t, err)
+		})
+	}
 }
 
 // TestNakedSwitchConnection asserts that a switch without power measurement

--- a/meter/shelly/connection_test.go
+++ b/meter/shelly/connection_test.go
@@ -3,7 +3,6 @@ package shelly
 import (
 	"encoding/json"
 	"fmt"
-	"maps"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -113,23 +112,20 @@ func TestDuplicateChannel(t *testing.T) {
 		channels []int
 		rpc      map[string]string
 	}{
-		{"configured twice", []int{0, 0}, nil},
+		{"configured twice", []int{0, 0}, map[string]string{
+			"Switch.GetStatus": `{"id":0,"output":true}`,
+		}},
 		{"remapped by add-on", []int{0, 1}, map[string]string{
+			"Switch.GetStatus":              `{"id":0,"output":true}`,
 			"ProOutputAddon.GetPeripherals": `{"digital_out":{"switch:100":{}}}`,
 		}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			rpc := map[string]string{
-				"Switch.GetStatus": `{"id":0,"output":true}`,
-				"Switch.GetConfig": `{"id":0}`,
-			}
-			maps.Copy(rpc, tc.rpc)
-
-			srv := shellyServer(t, rpc)
+			srv := shellyServer(t, tc.rpc)
 			defer srv.Close()
 
 			_, err := NewConnection(srv.URL, "", "", tc.channels, time.Second)
-			require.Error(t, err)
+			require.ErrorContains(t, err, "duplicate channel")
 		})
 	}
 }

--- a/meter/shelly/gen1.go
+++ b/meter/shelly/gen1.go
@@ -84,10 +84,6 @@ func (c *gen1) CurrentPower() (float64, error) {
 	return power, nil
 }
 
-func (c *gen1) relay() int {
-	return c.channel
-}
-
 func (c *gen1) Enabled() (bool, error) {
 	var res Gen1SwitchResponse
 	uri := fmt.Sprintf("%s/relay/%d", c.uri, c.channel)

--- a/meter/shelly/gen1.go
+++ b/meter/shelly/gen1.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
-	"github.com/evcc-io/evcc/util/transport"
 )
 
 // Gen1API endpoint reference: https://shelly-api-docs.shelly.cloud/gen1/#shelly-family-overview
@@ -46,11 +45,7 @@ type gen1 struct {
 }
 
 // newGen1 initializes the connection to the shelly gen1 api and sets up the cached gen1Status
-func newGen1(client *request.Helper, uri, model string, channel int, user, password string, cache time.Duration) *gen1 {
-	if user != "" {
-		client.Transport = transport.BasicAuth(user, password, client.Transport)
-	}
-
+func newGen1(client *request.Helper, uri, model string, channel int, cache time.Duration) *gen1 {
 	c := &gen1{
 		Helper:  client,
 		uri:     uri,

--- a/meter/shelly/gen1.go
+++ b/meter/shelly/gen1.go
@@ -84,6 +84,10 @@ func (c *gen1) CurrentPower() (float64, error) {
 	return power, nil
 }
 
+func (c *gen1) relay() int {
+	return c.channel
+}
+
 func (c *gen1) Enabled() (bool, error) {
 	var res Gen1SwitchResponse
 	uri := fmt.Sprintf("%s/relay/%d", c.uri, c.channel)

--- a/meter/shelly/gen2.go
+++ b/meter/shelly/gen2.go
@@ -233,6 +233,10 @@ func (c *gen2) CurrentPower() (float64, error) {
 	}
 }
 
+func (c *gen2) relay() int {
+	return c.switchchannel
+}
+
 // Gen2Enabled implements the Gen2 api.Charger interface
 func (c *gen2) Enabled() (bool, error) {
 	if c.hasSwitchEndpoint() {

--- a/meter/shelly/gen2.go
+++ b/meter/shelly/gen2.go
@@ -233,10 +233,6 @@ func (c *gen2) CurrentPower() (float64, error) {
 	}
 }
 
-func (c *gen2) relay() int {
-	return c.switchchannel
-}
-
 // Gen2Enabled implements the Gen2 api.Charger interface
 func (c *gen2) Enabled() (bool, error) {
 	if c.hasSwitchEndpoint() {

--- a/meter/shelly/gen2.go
+++ b/meter/shelly/gen2.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
-	"github.com/evcc-io/evcc/util/transport"
 )
 
 // Gen2API endpoint reference: https://shelly-api-docs.shelly.cloud/gen2/
@@ -119,7 +118,7 @@ func (c *gen2) apiCall[T any](id int, method string) func() (T, error) {
 }
 
 // gen2InitApi initializes the connection to the shelly gen2+ api and sets up the cached gen2SwitchStatus, gen2EM1Status and gen2EMStatus
-func newGen2(helper *request.Helper, uri, model string, channel int, user, password string, cache time.Duration) (*gen2, error) {
+func newGen2(helper *request.Helper, uri, model string, channel int, cache time.Duration) (*gen2, error) {
 	// Shelly GEN 2+ API
 	// https://shelly-api-docs.shelly.cloud/gen2/
 	c := &gen2{
@@ -127,12 +126,6 @@ func newGen2(helper *request.Helper, uri, model string, channel int, user, passw
 		uri:           fmt.Sprintf("%s/rpc", util.DefaultScheme(uri, "http")),
 		switchchannel: channel,
 		model:         model,
-	}
-
-	// Shelly gen 2 rfc7616 authentication
-	// https://shelly-api-docs.shelly.cloud/gen2/General/Authentication
-	if user != "" {
-		c.Client.Transport = transport.Digest(user, password, c.Client.Transport)
 	}
 
 	var res Gen2Methods

--- a/templates/definition/charger/shelly-3p.yaml
+++ b/templates/definition/charger/shelly-3p.yaml
@@ -1,0 +1,20 @@
+template: shelly-3p
+products:
+  - { brand: Shelly, description: { generic: Pro 3 } }
+requirements:
+  description:
+    de: Die Relais 1, 2 und 3 werden gemeinsam geschaltet.
+    en: Relays 1, 2 and 3 are switched together.
+group: switchsockets
+params:
+  - name: host
+  - name: user
+  - name: password
+  - preset: switchsocket
+render: |
+  type: shelly
+  uri: http://{{ .host }}
+  user: {{ .user }}
+  password: {{ .password }}
+  channel: [0, 1, 2]  # shelly device relay channels, switched together
+  {{ include "switchsocket" . }}

--- a/templates/definition/charger/shelly-3p.yaml
+++ b/templates/definition/charger/shelly-3p.yaml
@@ -1,6 +1,6 @@
 template: shelly-3p
 products:
-  - { brand: Shelly, description: { generic: Pro 3 } }
+  - { brand: Shelly, description: { de: Pro 3 (dreiphasig), en: Pro 3 (three phase) } }
 requirements:
   description:
     de: Die Relais 1, 2 und 3 werden gemeinsam geschaltet.

--- a/templates/definition/charger/shelly.yaml
+++ b/templates/definition/charger/shelly.yaml
@@ -3,6 +3,7 @@ products:
   - { brand: Shelly, description: { generic: 1 } }
   - { brand: Shelly, description: { generic: Plus 1 } }
   - { brand: Shelly, description: { generic: Pro 1 } }
+  - { brand: Shelly, description: { de: Pro 3 (einphasig), en: Pro 3 (single phase) } }
   - { brand: Shelly, description: { generic: Plug S } }
   - { brand: Shelly, description: { generic: Plug M } }
 capabilities: ["meter"]


### PR DESCRIPTION
fixes #33398

Shelly multi-relay devices could only be used one relay at a time, so a three-phase heating element on a Shelly Pro 3 had to be configured as three separate switch sockets. The Shelly connection now takes a channel list and aggregates the relays into one device, mirroring the existing Tasmota behaviour.

- `channel` accepts a list (`channel: [0, 1, 2]`); a plain scalar keeps working, so existing configs are unaffected
- all configured relays are switched together, power and energy readings are summed
- new `shelly-3p` switch socket template for the Shelly Pro 3
- digest/basic auth is now wrapped once on the shared HTTP client instead of per channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)