### PR TITLE
UI: improve chart line readability

### DIFF
--- a/assets/js/colors.ts
+++ b/assets/js/colors.ts
@@ -26,6 +26,7 @@ const colors: {
   co2: string | null;
   temperature: string | null;
   export: string | null;
+  forecast: string | null;
   background: string | null;
   box: string | null;
   light: string | null;
@@ -44,6 +45,7 @@ const colors: {
   co2: null,
   temperature: null,
   export: null,
+  forecast: null,
   background: null,
   box: null,
   light: null,
@@ -153,6 +155,7 @@ export function updateCssColors() {
   colors.co2 = style.getPropertyValue("--evcc-co2");
   colors.temperature = style.getPropertyValue("--evcc-temperature");
   colors.export = style.getPropertyValue("--evcc-export-contrast");
+  colors.forecast = style.getPropertyValue("--evcc-dark-yellow");
   colors.background = style.getPropertyValue("--evcc-background");
   colors.box = style.getPropertyValue("--evcc-box");
   colors.pricePerKWh = style.getPropertyValue("--bs-gray-medium");

--- a/assets/js/components/Battery/BatteryHistoryChart.vue
+++ b/assets/js/components/Battery/BatteryHistoryChart.vue
@@ -11,6 +11,7 @@ import {
 	tooltipStyle,
 	tooltipTable,
 	type TooltipRow,
+	lineDefaults,
 } from "../Forecast/echarts";
 import colors, { dimColor, setAlpha, batteryColor } from "@/colors";
 import formatter, { POWER_UNIT } from "@/mixins/formatter";
@@ -102,7 +103,7 @@ export default defineComponent({
 						z: 3,
 						data: this.socHistory(b),
 						showSymbol: false,
-						lineStyle: { color: c, width: 3 },
+						lineStyle: { color: c, ...lineDefaults },
 						itemStyle: { color: c },
 						...(this.single ? { areaStyle: { color: dimColor(c) } } : {}),
 						emphasis: { disabled: true },
@@ -113,7 +114,7 @@ export default defineComponent({
 						z: 3,
 						data: this.socForecast(b),
 						showSymbol: false,
-						lineStyle: { color: c, width: 2, type: "dotted" },
+						lineStyle: { color: c, type: "dotted", ...lineDefaults },
 						itemStyle: { color: c },
 						...(this.single ? { areaStyle: { color: hatchPattern(c) } } : {}),
 						emphasis: { disabled: true },
@@ -131,7 +132,7 @@ export default defineComponent({
 						data: this.energyData(b, "hist"),
 						showSymbol: false,
 						smooth: 0.4,
-						lineStyle: { color: c, width: 3 },
+						lineStyle: { color: c, ...lineDefaults },
 						itemStyle: { color: c },
 						areaStyle: { color: setAlpha(c, "60") },
 						emphasis: { disabled: true },
@@ -144,7 +145,7 @@ export default defineComponent({
 						data: this.energyData(b, "fc"),
 						showSymbol: false,
 						smooth: 0.4,
-						lineStyle: { color: c, width: 2, type: "dotted" },
+						lineStyle: { color: c, type: "dotted", ...lineDefaults },
 						itemStyle: { color: c },
 						areaStyle: { color: hatchPattern(c) },
 						emphasis: { disabled: true },

--- a/assets/js/components/Forecast/PriceChart.vue
+++ b/assets/js/components/Forecast/PriceChart.vue
@@ -19,6 +19,7 @@ import {
 	filterForecastSlots,
 	minSlotIndex,
 	maxSlotIndex,
+	lineDefaults,
 } from "./echarts";
 import colors, { lighterColor } from "@/colors";
 import formatter from "@/mixins/formatter";
@@ -158,7 +159,7 @@ export default defineComponent({
 				data: slots.map((s) => ({
 					value: [clampStart(s.start, this.startDate), s.value],
 				})),
-				lineStyle: { color, width: 2 },
+				lineStyle: { color, ...lineDefaults },
 				areaStyle: {
 					color: new echarts.graphic.LinearGradient(
 						0,

--- a/assets/js/components/Forecast/SolarChart.vue
+++ b/assets/js/components/Forecast/SolarChart.vue
@@ -14,6 +14,7 @@ import {
 	forecastGrid,
 	forecastXAxes,
 	forecastYAxis,
+	lineDefaults,
 } from "./echarts";
 import colors, { lighterColor } from "@/colors";
 import formatter, { POWER_UNIT } from "@/mixins/formatter";
@@ -116,12 +117,12 @@ export default defineComponent({
 						symbol: "circle",
 						symbolSize: 6,
 						showSymbol: false,
-						lineStyle: { color: selfColor, width: 3 },
+						lineStyle: { color: selfColor, ...lineDefaults },
 						areaStyle: { color: lighterColor(selfColor) },
 						emphasis: {
 							disabled: false,
 							scale: false,
-							lineStyle: { color: selfColor, width: 3 },
+							lineStyle: { color: selfColor, ...lineDefaults },
 							areaStyle: { color: lighterColor(selfColor) },
 							itemStyle: { color: selfColor, borderColor: selfColor, borderWidth: 2 },
 						},

--- a/assets/js/components/Forecast/ValueChart.vue
+++ b/assets/js/components/Forecast/ValueChart.vue
@@ -18,6 +18,7 @@ import {
 	filterForecastSlots,
 	minSlotIndex,
 	maxSlotIndex,
+	lineDefaults,
 } from "./echarts";
 import colors from "@/colors";
 import formatter from "@/mixins/formatter";
@@ -117,7 +118,7 @@ export default defineComponent({
 						symbol: "circle",
 						symbolSize: 6,
 						showSymbol: false,
-						lineStyle: { color, width: 3 },
+						lineStyle: { color, ...lineDefaults },
 						emphasis: {
 							disabled: false,
 							scale: false,

--- a/assets/js/components/Forecast/echarts.ts
+++ b/assets/js/components/Forecast/echarts.ts
@@ -79,6 +79,23 @@ export function markPointLabel(
   };
 }
 
+export const lineDefaults = { width: 2, cap: "round", join: "round" } as const;
+
+// wider box-colored twin drawn beneath a line so it stays readable over bars
+export function lineCasing(line: Record<string, unknown>, z: number): Record<string, unknown> {
+  return {
+    ...line,
+    id: line["id"] ? `${line["id"]}-casing` : undefined,
+    name: `${line["name"]}-casing`,
+    z,
+    silent: true,
+    symbol: "none",
+    emphasis: { disabled: true },
+    lineStyle: { ...lineDefaults, color: colors.box || "", width: lineDefaults.width + 2 },
+    itemStyle: { color: colors.box || "" },
+  };
+}
+
 export function tooltipStyle(
   color: string,
   getChart?: () => { convertToPixel: echarts.ECharts["convertToPixel"] } | null

--- a/assets/js/components/History/GroupChart.vue
+++ b/assets/js/components/History/GroupChart.vue
@@ -11,10 +11,12 @@ import {
 	FONT_FAMILY,
 	forecastGrid,
 	forecastYAxis,
+	lineCasing,
 	tooltipStyle,
 	tooltipTable,
 	xAxisLabelStyle,
 	type TooltipRow,
+	lineDefaults,
 } from "../Forecast/echarts";
 import colors, { resolveColors, deviceColorMap, darken, batteryColor, setAlpha } from "@/colors";
 import store from "@/store";
@@ -243,7 +245,7 @@ export default defineComponent({
 			const result: Record<string, unknown>[] = [];
 
 			// Always render overlay slot (line series) so series structure is stable;
-			// data is all-null when toggled off. Prepend so it renders BEHIND bars.
+			// data is all-null when toggled off.
 			const overlayValues: (number | null)[] = Array.from(
 				{ length: cats.length },
 				() => null
@@ -258,17 +260,19 @@ export default defineComponent({
 				}
 			}
 			const overlayCol = this.overlayColor || this.color;
-			result.push({
+			const overlay = {
 				id: "overlay",
 				name: this.overlayLabel || "overlay",
 				type: "line",
 				data: overlayValues,
 				smooth: true,
 				symbol: "none",
-				lineStyle: { color: overlayCol, width: 2, type: "dotted" },
+				connectNulls: true,
+				lineStyle: { color: overlayCol, ...lineDefaults },
 				itemStyle: { color: overlayCol },
-				z: 1,
-			});
+				z: 4,
+			};
+			result.push(lineCasing(overlay, 3), overlay);
 
 			// Always render import + export series per entity, even if one direction
 			// is empty (null-filled). Stable series ids/structure across renders so

--- a/assets/js/components/Optimize/ChargeChart.vue
+++ b/assets/js/components/Optimize/ChargeChart.vue
@@ -11,9 +11,11 @@ import {
 	axisNameStyle,
 	FONT_FAMILY,
 	forecastYAxis,
+	lineCasing,
 	tooltipStyle,
 	tooltipTable,
 	type TooltipRow,
+	lineDefaults,
 } from "../Forecast/echarts";
 import type { EvoptData } from "./TimeSeriesDataTable.vue";
 import type { BatteryDetail, DeviceColors } from "@/types/evcc";
@@ -23,7 +25,15 @@ import colors from "@/colors";
 import { energyAxisScale, type EnergyAxisScale } from "@/utils/energyAxis";
 import LegendList from "../Sessions/LegendList.vue";
 import type { Legend } from "../Sessions/types";
-import { slotTimes, slotXAxis, formatSlotRange, whToKW, loadpointTitle } from "./chart";
+import {
+	slotTimes,
+	slotXAxis,
+	dayBoundaryAxis,
+	dayBoundarySeries,
+	formatSlotRange,
+	whToKW,
+	loadpointTitle,
+} from "./chart";
 
 const GRID_LABEL = "Grid Power";
 const SOLAR_LABEL = "Solar Forecast";
@@ -88,29 +98,34 @@ export default defineComponent({
 			return energyAxisScale(peak * 1000);
 		},
 		chartSeries(): Record<string, unknown>[] {
+			const grid = {
+				name: GRID_LABEL,
+				type: "line",
+				z: 4,
+				data: this.gridPower,
+				showSymbol: false,
+				smooth: 0.2,
+				lineStyle: { color: colors.grid || "", ...lineDefaults },
+				itemStyle: { color: colors.grid || "" },
+				emphasis: { disabled: true },
+			};
+			const solar = {
+				name: SOLAR_LABEL,
+				type: "line",
+				z: 4,
+				data: this.evopt.req.time_series.ft.map(this.toKW),
+				showSymbol: false,
+				smooth: 0.2,
+				lineStyle: { color: colors.forecast || "", ...lineDefaults },
+				itemStyle: { color: colors.forecast || "" },
+				emphasis: { disabled: true },
+			};
 			const series: Record<string, unknown>[] = [
-				{
-					name: GRID_LABEL,
-					type: "line",
-					z: 4,
-					data: this.gridPower,
-					showSymbol: false,
-					smooth: 0.2,
-					lineStyle: { color: colors.grid || "", width: 2 },
-					itemStyle: { color: colors.grid || "" },
-					emphasis: { disabled: true },
-				},
-				{
-					name: SOLAR_LABEL,
-					type: "line",
-					z: 4,
-					data: this.evopt.req.time_series.ft.map(this.toKW),
-					showSymbol: false,
-					smooth: 0.2,
-					lineStyle: { color: colors.self || "", width: 3 },
-					itemStyle: { color: colors.self || "" },
-					emphasis: { disabled: true },
-				},
+				dayBoundarySeries(this.times),
+				lineCasing(grid, 3),
+				grid,
+				lineCasing(solar, 3),
+				solar,
 				{
 					name: this.consumptionLabel,
 					type: "bar",
@@ -156,10 +171,12 @@ export default defineComponent({
 					...tooltipStyle(colors.text || ""),
 					formatter: this.tooltipFormatter,
 				},
-				xAxis: slotXAxis(this.times, this.weekdayShort),
+				xAxis: [slotXAxis(this.times, this.weekdayShort), dayBoundaryAxis(this.times)],
 				yAxis: forecastYAxis({
 					min: undefined,
 					position: "right",
+					// the day boundary value axis contains 0, keep the axis on the right
+					axisLine: { show: false, onZero: false },
 					splitNumber: 5,
 					name: this.axisScale.unit,
 					...axisNameStyle(),
@@ -175,7 +192,7 @@ export default defineComponent({
 		legends(): Legend[] {
 			const legends: Legend[] = [
 				{ label: GRID_LABEL, color: colors.grid || "", value: "", type: "line" },
-				{ label: SOLAR_LABEL, color: colors.self || "", value: "", type: "line" },
+				{ label: SOLAR_LABEL, color: colors.forecast || "", value: "", type: "line" },
 				{
 					label: this.consumptionLabel,
 					color: this.consumptionColor,
@@ -217,6 +234,7 @@ export default defineComponent({
 			const head = formatSlotRange(this.times, dt, arr[0]!.dataIndex);
 			const rows: TooltipRow[] = arr
 				.filter((p) => p.value != null && !Number.isNaN(p.value))
+				.filter((p) => !p.seriesName?.endsWith("-casing"))
 				.map((p) => {
 					const value = p.value as number;
 					if (p.seriesName === GRID_LABEL) {

--- a/assets/js/components/Optimize/SocChart.vue
+++ b/assets/js/components/Optimize/SocChart.vue
@@ -15,6 +15,7 @@ import {
 	forecastYAxis,
 	tooltipStyle,
 	tooltipTable,
+	lineDefaults,
 } from "../Forecast/echarts";
 import colors, { dimColor } from "@/colors";
 import formatter from "@/mixins/formatter";
@@ -119,7 +120,7 @@ export default defineComponent({
 						z: 3,
 						data: this.socSeries,
 						showSymbol: false,
-						lineStyle: { color: this.entry.color, width: 2 },
+						lineStyle: { color: this.entry.color, ...lineDefaults },
 						itemStyle: { color: this.entry.color },
 						areaStyle: { color: dimColor(this.entry.color) },
 						emphasis: { disabled: true },

--- a/assets/js/components/Optimize/TimeSeriesDataTable.vue
+++ b/assets/js/components/Optimize/TimeSeriesDataTable.vue
@@ -172,7 +172,7 @@ export default defineComponent({
 			return [
 				{
 					rows: [
-						this.powerRow("Solar Forecast", ts.ft, colors.self || ""),
+						this.powerRow("Solar Forecast", ts.ft, colors.forecast || ""),
 						this.powerRow("Household Demand", ts.gt, colors.muted || ""),
 						{
 							label: "Time Step",

--- a/assets/js/components/Optimize/chart.test.ts
+++ b/assets/js/components/Optimize/chart.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vite-plus/test";
-import { isMidnight, slotXAxis } from "./chart";
+import { dayBoundarySeries, isMidnight, slotXAxis } from "./chart";
 
 // 15min slots starting at the given local hour
 function times(startHour: number, count: number): number[] {
@@ -25,11 +25,10 @@ describe("slotXAxis", () => {
     expect(label(16)).toBe("0\nThu");
   });
 
-  test("draws a split line at day boundaries only", () => {
+  test("marks day boundaries just inside the bar edge", () => {
     expect(isMidnight(slots[16])).toBe(true);
-    expect(axis.splitLine.interval(16)).toBe(true);
-    expect(axis.splitLine.interval(15)).toBe(false);
+    expect(dayBoundarySeries(slots).markLine.data).toEqual([{ xAxis: 15.85 }]);
     // no line at the axis start, even if the first slot is midnight
-    expect(slotXAxis(times(0, 4), weekdayShort).splitLine.interval(0)).toBe(false);
+    expect(dayBoundarySeries(times(0, 4)).markLine.data).toEqual([]);
   });
 });

--- a/assets/js/components/Optimize/chart.ts
+++ b/assets/js/components/Optimize/chart.ts
@@ -27,7 +27,7 @@ export function isMidnight(time?: number): boolean {
 }
 
 // category x axis over slot times, labels at full hours every 4h (6h on mobile),
-// day boundaries as split line with the weekday shown at 00:00
+// weekday shown at 00:00
 export function slotXAxis(times: number[], weekdayShort: (d: Date) => string) {
   const step = window.innerWidth < 576 ? 6 : 4;
   return {
@@ -35,12 +35,7 @@ export function slotXAxis(times: number[], weekdayShort: (d: Date) => string) {
     data: times.map(String),
     axisLine: { show: false },
     axisTick: { show: false },
-    splitLine: {
-      show: true,
-      // split lines sit at the left edge of their slot
-      interval: (index: number) => index > 0 && isMidnight(times[index]),
-      lineStyle: { color: colors.muted || "", type: "solid" },
-    },
+    splitLine: { show: false },
     axisLabel: {
       ...xAxisLabelStyle(),
       interval: 0,
@@ -65,4 +60,38 @@ export function formatSlotRange(times: number[], dt: number[], index: number): s
 // slot energy (Wh) to average power (kW)
 export function whToKW(wh: number, dtSeconds: number): number {
   return wh / (dtSeconds / 3600) / 1000;
+}
+
+// hidden value axis aligned with the category bands (slot i spans i-0.5..i+0.5)
+export function dayBoundaryAxis(times: number[]) {
+  return {
+    type: "value",
+    min: -0.5,
+    max: times.length - 0.5,
+    show: false,
+    axisPointer: { show: false },
+  };
+}
+
+// day boundary lines. A category split line would sit in the gap between bars
+// and show as a sliver; this draws them just inside the bar's left edge, behind the bars.
+export function dayBoundarySeries(times: number[]) {
+  const data = times
+    .map((t, i) => ({ t, i }))
+    .filter(({ t, i }) => i > 0 && isMidnight(t))
+    .map(({ i }) => ({ xAxis: i - 0.15 }));
+  return {
+    type: "line",
+    xAxisIndex: 1,
+    data: [] as number[],
+    silent: true,
+    markLine: {
+      silent: true,
+      z: 1,
+      symbol: "none",
+      label: { show: false },
+      lineStyle: { color: colors.muted || "", type: "solid" },
+      data,
+    },
+  };
 }

--- a/assets/js/components/Sessions/AvgCostGroupedChart.vue
+++ b/assets/js/components/Sessions/AvgCostGroupedChart.vue
@@ -11,7 +11,13 @@
 
 <script lang="ts">
 import { defineComponent, type PropType } from "vue";
-import { FONT_FAMILY, topBottomCenterPosition, tooltipStyle, tooltipTable } from "./echarts";
+import {
+	FONT_FAMILY,
+	lineDefaults,
+	topBottomCenterPosition,
+	tooltipStyle,
+	tooltipTable,
+} from "./echarts";
 import echartsChart from "@/mixins/echartsChart";
 import formatter from "@/mixins/formatter";
 import colors, { dimColor } from "@/colors";
@@ -118,7 +124,7 @@ export default defineComponent({
 							itemStyle: {
 								color: dimColor(entryColors[i]),
 								borderColor: entryColors[i],
-								borderWidth: 3,
+								borderWidth: lineDefaults.width,
 								// round outer corners only, sharp apex at the center
 								borderRadius: [0, 0, 8, 8],
 							},

--- a/assets/js/components/Sessions/CostHistoryChart.vue
+++ b/assets/js/components/Sessions/CostHistoryChart.vue
@@ -17,6 +17,8 @@ import {
 	tooltipTable,
 	xAxisLabelStyle,
 	type TooltipRow,
+	lineCasing,
+	lineDefaults,
 } from "./echarts";
 import historyChart from "./historyChart";
 import LegendList from "./LegendList.vue";
@@ -190,19 +192,21 @@ export default defineComponent({
 				data: stackData[i],
 			}));
 			if (line) {
-				series.push({
+				const avg = {
 					name: line.label,
 					type: "line",
 					yAxisIndex: 1,
+					z: 4,
 					data: line.data,
 					smooth: 0.25,
 					symbol: "circle",
 					symbolSize: 12,
 					showSymbol: false,
 					connectNulls: true,
-					lineStyle: { color: line.color, width: 2 },
+					lineStyle: { color: line.color, ...lineDefaults },
 					itemStyle: { color: line.color },
-				});
+				};
+				series.push(lineCasing(avg, 3), avg);
 			}
 			return {
 				animation: false,

--- a/assets/js/components/Sessions/SolarGroupedChart.vue
+++ b/assets/js/components/Sessions/SolarGroupedChart.vue
@@ -11,7 +11,13 @@
 
 <script lang="ts">
 import { defineComponent, type PropType } from "vue";
-import { FONT_FAMILY, topBottomCenterPosition, tooltipStyle, tooltipTable } from "./echarts";
+import {
+	FONT_FAMILY,
+	lineDefaults,
+	topBottomCenterPosition,
+	tooltipStyle,
+	tooltipTable,
+} from "./echarts";
 import echartsChart from "@/mixins/echartsChart";
 import formatter from "@/mixins/formatter";
 import colors, { dimColor } from "@/colors";
@@ -110,7 +116,7 @@ export default defineComponent({
 							itemStyle: {
 								color: dimColor(entryColors[i]),
 								borderColor: entryColors[i],
-								borderWidth: 3,
+								borderWidth: lineDefaults.width,
 								// round outer corners only, sharp apex at the center
 								borderRadius: [0, 0, 8, 8],
 							},

--- a/assets/js/components/Sessions/SolarYearChart.vue
+++ b/assets/js/components/Sessions/SolarYearChart.vue
@@ -17,6 +17,7 @@ import {
 	tooltipStyle,
 	tooltipTable,
 	type TooltipRow,
+	lineDefaults,
 } from "./echarts";
 import echartsChart from "@/mixins/echartsChart";
 import formatter from "@/mixins/formatter";
@@ -199,7 +200,7 @@ export default defineComponent({
 						data: datasets.map((dataset) => ({
 							name: dataset.label,
 							value: dataset.data,
-							lineStyle: { color: dataset.borderColor, width: 4 },
+							lineStyle: { color: dataset.borderColor, ...lineDefaults },
 							itemStyle: { color: dataset.borderColor },
 							areaStyle:
 								singleYear && dataset.borderColor


### PR DESCRIPTION
refs #33405

Visual polish for the line charts. Tooltip placement follows separately.

- Lines get a background-colored outline. They stay readable over bars in optimizer, history and sessions charts
- Optimizer solar forecast is amber, like in the history chart. Distinguishes it from the green battery bars
- History forecast is solid, drawn in front of the bars. Gaps are bridged
- Optimizer day markers no longer show as slivers between bars
- Consistent 2px lines with rounded ends across all line charts
  - Forecast: solar and CO₂ (3px > 2px)
  - Battery history: measured (3px > 2px)
  - Optimizer: solar forecast (3px > 2px)
  - Sessions: solar share by year (4px > 2px), polar charts outline (3px > 2px)

<img width="1387" height="455" alt="Bildschirmfoto 2026-09-02 um 09 47 52" src="https://github.com/user-attachments/assets/d8fe5c9b-87a5-4ef4-961b-7eaab510e79e" />

<img width="1382" height="461" alt="Bildschirmfoto 2026-09-02 um 09 47 57" src="https://github.com/user-attachments/assets/8ab86531-5f88-4847-bb68-98f2cf46e077" />

<img width="1007" height="1394" alt="Bildschirmfoto 2026-09-02 um 09 49 32" src="https://github.com/user-attachments/assets/0d41ac08-1077-437d-9c0d-8b38f6d65a5c" />

<img width="957" height="452" alt="Bildschirmfoto 2026-09-02 um 09 51 32" src="https://github.com/user-attachments/assets/b7866816-88f2-4942-b2d1-47fa95bfb8df" />

<img width="976" height="462" alt="Bildschirmfoto 2026-09-02 um 09 51 42" src="https://github.com/user-attachments/assets/dba7c6a5-f1bd-4be7-862e-d1f021e56297" />

<img width="497" height="532" alt="Bildschirmfoto 2026-09-02 um 09 51 52" src="https://github.com/user-attachments/assets/60050b85-a196-4e71-8bff-248d3359e568" />

<img width="1011" height="356" alt="Bildschirmfoto 2026-09-02 um 09 52 58" src="https://github.com/user-attachments/assets/cd0106ea-b7d2-4359-a33f-fadc7a33b40b" />

<img width="1007" height="347" alt="Bildschirmfoto 2026-09-02 um 09 53 06" src="https://github.com/user-attachments/assets/ecab80ef-9d63-4289-a407-52a21f7496fc" />
