### PR TITLE
Loadpoint: extract phase timer handling

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1344,6 +1344,23 @@ func (lp *Loadpoint) resetPhaseTimer() {
 	lp.publishTimer(phaseTimer, 0, timerInactive)
 }
 
+// phaseTimerElapsed starts or continues the phase switch timer for the given action
+// and returns true once delay has elapsed. Scaling is immediate while not charging.
+func (lp *Loadpoint) phaseTimerElapsed(delay time.Duration, action string) bool {
+	if !lp.charging() { // scale immediately if not charging
+		lp.phaseTimer = elapsed
+	}
+
+	if lp.phaseTimer.IsZero() {
+		lp.log.DEBUG.Printf("start phase %s timer", action)
+		lp.phaseTimer = lp.clock.Now()
+	}
+
+	lp.publishTimer(phaseTimer, delay, action)
+
+	return lp.clock.Since(lp.phaseTimer) >= delay
+}
+
 // scalePhasesRequired validates if fixed phase configuration matches enabled phases
 func (lp *Loadpoint) scalePhasesRequired() bool {
 	return lp.hasPhaseSwitching() && lp.phasesConfigured != 0 && lp.phasesConfigured != lp.GetPhases()
@@ -1409,20 +1426,33 @@ func (lp *Loadpoint) circuitAllowsPhases(phases int, minCurrent float64) bool {
 
 // fastCharging scales to 3p if available and sets maximum current
 func (lp *Loadpoint) fastCharging() error {
-	if !lp.hasPhaseSwitching() || !lp.phaseSwitchCompleted() {
+	waiting, err := lp.fastChargingPhases()
+
+	if !waiting {
 		lp.resetPhaseTimer()
-		return lp.setLimit(lp.effectiveMaxCurrent())
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return lp.setLimit(lp.effectiveMaxCurrent())
+}
+
+// fastChargingPhases scales to 3p if load management allows and reports whether
+// it is waiting for the scale up delay to elapse
+func (lp *Loadpoint) fastChargingPhases() (bool, error) {
+	if !lp.hasPhaseSwitching() || !lp.phaseSwitchCompleted() {
+		return false, nil
 	}
 
 	if lp.circuit == nil {
-		lp.resetPhaseTimer()
-
 		// ignore api.ErrNotAvailable: the phase switch could not be performed
 		// right now, continue with the current phase configuration
 		if err := lp.scalePhasesIfAvailable(3); err != nil && !errors.Is(err, api.ErrNotAvailable) {
-			return err
+			return false, err
 		}
-		return lp.setLimit(lp.effectiveMaxCurrent())
+		return false, nil
 	}
 
 	targetPhases := 3
@@ -1444,40 +1474,25 @@ func (lp *Loadpoint) fastCharging() error {
 	// scale down: immediate
 	if targetPhases == 1 && phases == 3 {
 		if err := lp.scalePhases(1); err != nil && !errors.Is(err, api.ErrNotAvailable) {
-			return err
+			return false, err
 		}
+		return false, nil
 	}
 
 	// scale up: delayed and buffered against immediately undoing a scale down.
 	// a fixed phase configuration is not subject to load management, hence no buffer.
-	var waiting bool
 	if targetPhases == 3 && phases == 1 &&
 		(lp.phasesConfigured == 3 || lp.circuitAllowsPhases(3, phaseScaleUpBuffer*lp.effectiveMinCurrent())) {
-		if !lp.charging() { // scale immediately if not charging
-			lp.phaseTimer = elapsed
+		if !lp.phaseTimerElapsed(lp.GetEnableDelay(), phaseScale3p) {
+			return true, nil
 		}
 
-		if lp.phaseTimer.IsZero() {
-			lp.log.DEBUG.Printf("start phase %s timer", phaseScale3p)
-			lp.phaseTimer = lp.clock.Now()
-		}
-
-		lp.publishTimer(phaseTimer, lp.GetEnableDelay(), phaseScale3p)
-
-		if lp.clock.Since(lp.phaseTimer) >= lp.GetEnableDelay() {
-			if err := lp.scalePhases(3); err != nil && !errors.Is(err, api.ErrNotAvailable) {
-				return err
-			}
-		} else {
-			waiting = true
+		if err := lp.scalePhases(3); err != nil && !errors.Is(err, api.ErrNotAvailable) {
+			return false, err
 		}
 	}
 
-	if !waiting {
-		lp.resetPhaseTimer()
-	}
-
-	return lp.setLimit(lp.effectiveMaxCurrent())
+	return false, nil
 }
 
 // minCharging scales to 1p if available and sets minimum current
@@ -1535,18 +1550,7 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64, ma
 
 	// scale down phases
 	if scalable {
-		if !lp.charging() { // scale immediately if not charging
-			lp.phaseTimer = elapsed
-		}
-
-		if lp.phaseTimer.IsZero() {
-			lp.log.DEBUG.Printf("start phase %s timer", phaseScale1p)
-			lp.phaseTimer = lp.clock.Now()
-		}
-
-		lp.publishTimer(phaseTimer, lp.GetDisableDelay(), phaseScale1p)
-
-		if elapsed := lp.clock.Since(lp.phaseTimer); elapsed >= lp.GetDisableDelay() {
+		if lp.phaseTimerElapsed(lp.GetDisableDelay(), phaseScale1p) {
 			if err := lp.scalePhases(1); err != nil {
 				// a charger may report it cannot switch phases right now
 				// (api.ErrNotAvailable); assume a failed switch and stay silent
@@ -1578,18 +1582,7 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64, ma
 	if targetCurrent := powerToCurrent(availablePower, maxPhases); targetCurrent >= minCurrent && scalable {
 		lp.log.DEBUG.Printf("available power %.0fW > %.0fW min %dp threshold", availablePower, float64(maxPhases)*Voltage*minCurrent, maxPhases)
 
-		if !lp.charging() { // scale immediately if not charging
-			lp.phaseTimer = elapsed
-		}
-
-		if lp.phaseTimer.IsZero() {
-			lp.log.DEBUG.Printf("start phase %s timer", phaseScale3p)
-			lp.phaseTimer = lp.clock.Now()
-		}
-
-		lp.publishTimer(phaseTimer, lp.GetEnableDelay(), phaseScale3p)
-
-		if elapsed := lp.clock.Since(lp.phaseTimer); elapsed >= lp.GetEnableDelay() {
+		if lp.phaseTimerElapsed(lp.GetEnableDelay(), phaseScale3p) {
 			if err := lp.scalePhases(3); err != nil {
 				// a charger may report it cannot switch phases right now
 				// (api.ErrNotAvailable); assume a failed switch and stay silent

--- a/core/loadpoint_phases_test.go
+++ b/core/loadpoint_phases_test.go
@@ -609,6 +609,8 @@ func TestFastChargingCircuitBasedPhaseScaling(t *testing.T) {
 		phaseTimerRunning     bool
 	}{
 		{desc: "no circuit", activePhases: 3, phasesConfigured: 0, status: api.StatusB, chargePower: 0, expectedPhases: 3, noCircuit: true, phaseTimerRunning: true},
+		// without load management scaling up cannot overload anything- no delay
+		{desc: "no circuit, charging at 1p", activePhases: 1, phasesConfigured: 0, status: api.StatusC, chargePower: 3680, expectedPhases: 3, noCircuit: true, phaseTimerRunning: true},
 
 		{desc: "fixed 1p, 1p active", activePhases: 1, phasesConfigured: 1, status: api.StatusB, chargePower: 0, availableCircuitPower: 11040, expectedPhases: 1},
 		{desc: "fixed 1p, 3p active", activePhases: 3, phasesConfigured: 1, status: api.StatusB, chargePower: 0, availableCircuitPower: 11040, expectedPhases: 1},
@@ -696,7 +698,7 @@ func TestFastChargingCircuitBasedPhaseScaling(t *testing.T) {
 			require.NoError(t, err)
 
 			// handle scale phases up delay
-			if tc.activePhases == 1 && tc.expectedPhases == 3 && tc.status == api.StatusC {
+			if !tc.noCircuit && tc.activePhases == 1 && tc.expectedPhases == 3 && tc.status == api.StatusC {
 				require.Equal(t, 1, lp.phases, "should not scale up immediately while charging")
 
 				clck.Add(lp.Enable.Delay - time.Second)


### PR DESCRIPTION
Follow-up cleanup on #28174, no behavior change.

`fastCharging` gained a scale up block that copies the timer handling `pvScalePhases` already had in two places — `elapsed` when not charging, start on `IsZero`, `publishTimer`, compare against the delay. Extracted as `phaseTimerElapsed(delay, action)` and used at all three sites. Also drops the `elapsed :=` shadowing of the package-level `elapsed` in `pvScalePhases`.

Split the phase decision out of `fastCharging` into `fastChargingPhases`, so `resetPhaseTimer()` and `setLimit(effectiveMaxCurrent())` appear once each instead of at every early return.

One test case added: `no circuit, charging at 1p`. Removing the `circuit == nil` fast path did not fail any test before — the existing no-circuit case is already on 3p, so the branch was a no-op for it. The new case covers the actual contract, that without load management scaling up happens without the enable delay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
