### PR TITLE
Config UI Loadpoint: rework min/max current inputs

### DIFF
--- a/assets/js/components/Config/FormRow.vue
+++ b/assets/js/components/Config/FormRow.vue
@@ -1,6 +1,6 @@
 <!-- oxlint-disable vue/no-v-html -->
 <template>
-	<div class="mb-4">
+	<div class="form-row">
 		<label :for="id">
 			<div class="form-label">
 				{{ label }}
@@ -62,3 +62,8 @@ export default {
 	},
 };
 </script>
+<style scoped>
+.form-row {
+	margin-bottom: 1.5rem;
+}
+</style>

--- a/assets/js/components/Config/LoadpointModal.vue
+++ b/assets/js/components/Config/LoadpointModal.vue
@@ -107,7 +107,7 @@
 
 			<div v-if="values.charger || !isNew">
 				<div class="collapsible-wrapper" :class="{ open: !isNew }">
-					<div class="collapsible-content">
+					<div class="collapsible-content ring-space">
 						<h6 class="mt-4">{{ $t("config.loadpoint.chargingTitle") }}</h6>
 
 						<FormRow
@@ -319,110 +319,78 @@
 							}}</small>
 						</h6>
 
-						<FormRow
-							v-if="!chargerIsSwitchDevice"
-							id="chargerPower"
-							:label="$t('config.loadpoint.chargerTypeLabel')"
-							:help="
-								chargerPower === '11kw'
-									? $t('config.loadpoint.chargerPower11kwHelp')
-									: chargerPower === '22kw'
-										? $t('config.loadpoint.chargerPower22kwHelp')
-										: $t('config.loadpoint.chargerPowerCustomHelp')
-							"
-						>
-							<SelectGroup
-								id="chargerPower"
-								v-model="chargerPower"
-								class="w-100"
-								:options="[
-									{
-										name: $t('config.loadpoint.chargerPower11kw'),
-										value: '11kw',
-									},
-									{
-										name: $t('config.loadpoint.chargerPower22kw'),
-										value: '22kw',
-									},
-									{
-										name: $t('config.loadpoint.chargerPowerCustom'),
-										value: 'other',
-									},
-								]"
-								transparent
-							/>
-						</FormRow>
-
-						<div
-							v-if="!chargerIsSwitchDevice && chargerPower === 'other'"
-							class="row ms-3 mb-5"
-						>
-							<FormRow
-								id="loadpointMinCurrent"
-								:label="$t('config.loadpoint.minCurrentLabel')"
-								class="col-sm-6 mb-sm-0"
-								:help="
-									values.minCurrent < 6
-										? $t('config.loadpoint.minCurrentHelp')
-										: undefined
-								"
-							>
-								<PropertyField
-									id="loadpointMinCurrent"
-									v-model="values.minCurrent"
-									type="Float"
-									unit="A"
-									size="w-25 w-min-200"
-									class="me-2"
-									required
-								/>
-							</FormRow>
-
-							<FormRow
-								id="loadpointMaxCurrent"
-								:label="$t('config.loadpoint.maxCurrentLabel')"
-								class="col-sm-6 mb-sm-0"
-								:help="
-									values.maxCurrent < values.minCurrent
-										? $t('config.loadpoint.maxCurrentHelp')
-										: undefined
-								"
-							>
-								<PropertyField
-									id="loadpointMaxCurrent"
-									v-model="values.maxCurrent"
-									type="Float"
-									unit="A"
-									size="w-25 w-min-200"
-									class="me-2"
-									required
-								/>
-							</FormRow>
-						</div>
-
-						<template v-if="!chargerIsSinglePhase">
-							<FormRow
-								v-if="chargerSupports1p3p"
-								id="loadpointParamPhases"
-								:label="$t('config.loadpoint.phasesAutomatic')"
-								:help="$t('config.loadpoint.phasesAutomaticHelp')"
-							>
-							</FormRow>
-							<FormRow
-								v-else
-								id="loadpointParamPhases"
-								:label="$t('config.loadpoint.phasesLabel')"
-								:help="$t('config.loadpoint.phasesHelp')"
-							>
-								<SelectGroup
+						<template v-if="!chargerIsSwitchDevice">
+							<template v-if="!chargerIsSinglePhase">
+								<FormRow
+									v-if="chargerSupports1p3p"
 									id="loadpointParamPhases"
-									v-model="values.phasesConfigured"
-									class="w-100"
-									:options="phasesOptions"
-									transparent
-									equal-width
-								/>
-							</FormRow>
+									:label="$t('config.loadpoint.phasesAutomatic')"
+									:help="$t('config.loadpoint.phasesAutomaticHelp')"
+								>
+								</FormRow>
+								<FormRow
+									v-else
+									id="loadpointParamPhases"
+									:label="$t('config.loadpoint.phasesLabel')"
+									:help="$t('config.loadpoint.phasesHelp')"
+								>
+									<SelectGroup
+										id="loadpointParamPhases"
+										v-model="values.phasesConfigured"
+										class="w-100"
+										:options="phasesOptions"
+										transparent
+										equal-width
+									/>
+								</FormRow>
+							</template>
+
+							<div class="row">
+								<FormRow
+									id="loadpointMinCurrent"
+									:label="$t('config.loadpoint.minCurrentLabel')"
+									class="col-sm-6 mb-sm-0"
+									:warning="minCurrentWarning"
+								>
+									<div class="d-flex align-items-center gap-2">
+										<PropertyField
+											id="loadpointMinCurrent"
+											v-model="values.minCurrent"
+											type="Float"
+											unit="A"
+											size="w-50 w-sm-100"
+											required
+										/>
+										<span class="evcc-gray text-nowrap power-hint">
+											≈ {{ fmtPhasePower(values.minCurrent, minPhases) }}
+										</span>
+									</div>
+								</FormRow>
+
+								<FormRow
+									id="loadpointMaxCurrent"
+									:label="$t('config.loadpoint.maxCurrentLabel')"
+									class="col-sm-6 mb-0"
+									:warning="maxCurrentWarning"
+								>
+									<div class="d-flex align-items-center gap-2">
+										<PropertyField
+											id="loadpointMaxCurrent"
+											v-model="values.maxCurrent"
+											type="Float"
+											unit="A"
+											size="w-50 w-sm-100"
+											required
+										/>
+										<span class="evcc-gray text-nowrap power-hint">
+											≈ {{ fmtPhasePower(values.maxCurrent, maxPhases) }}
+										</span>
+									</div>
+								</FormRow>
+								<div class="col-12 form-text evcc-gray hyphenate">
+									{{ $t(`config.loadpoint.currentRangeHelp.${loadpointType}`) }}
+								</div>
+							</div>
 						</template>
 
 						<div v-if="showCircuit">
@@ -740,7 +708,6 @@ export default {
 			saving: false,
 			values: deepClone(defaultValues) as ConfigLoadpoint,
 			baseline: JSON.stringify(defaultValues),
-			chargerPower: "11kw",
 			solarMode: "default",
 			autoCreate: false,
 			autoCreateInProgress: false,
@@ -836,6 +803,22 @@ export default {
 			result[10]!.name = "10 (highest)";
 			return result;
 		},
+		minCurrentWarning() {
+			return this.values.minCurrent < 6 && !this.chargerIsHeating
+				? this.$t("config.loadpoint.minCurrentHelp")
+				: undefined;
+		},
+		maxCurrentWarning() {
+			return this.values.maxCurrent < this.values.minCurrent
+				? this.$t("config.loadpoint.maxCurrentHelp")
+				: undefined;
+		},
+		minPhases() {
+			return this.values.phasesConfigured || 1;
+		},
+		maxPhases() {
+			return this.values.phasesConfigured || 3;
+		},
 		phasesOptions() {
 			return [
 				{ value: 1, name: this.$t("config.loadpoint.phases1p") },
@@ -904,15 +887,6 @@ export default {
 				this.loadConfiguration();
 			}
 		},
-		chargerPower(value) {
-			if (value === "11kw") {
-				this.values.minCurrent = 6;
-				this.values.maxCurrent = 16;
-			} else if (value === "22kw") {
-				this.values.minCurrent = 6;
-				this.values.maxCurrent = 32;
-			}
-		},
 		solarMode(value) {
 			if (value === "default") {
 				this.values.thresholds = deepClone(defaultThresholds);
@@ -940,7 +914,6 @@ export default {
 			try {
 				const res = await api.get(`config/loadpoints/${this.id}`);
 				this.values = deepClone(res.data);
-				this.updateChargerPower();
 				this.updateSolarMode();
 				this.updatePhases();
 				this.rebaseline();
@@ -1060,16 +1033,6 @@ export default {
 				this.values.meter = "";
 			}
 		},
-		updateChargerPower() {
-			const { minCurrent, maxCurrent } = this.values;
-			if (minCurrent === 6 && maxCurrent === 16) {
-				this.chargerPower = "11kw";
-			} else if (minCurrent === 6 && maxCurrent === 32) {
-				this.chargerPower = "22kw";
-			} else {
-				this.chargerPower = "other";
-			}
-		},
 		updateSolarMode() {
 			const { thresholds } = this.values;
 			if (deepEqual(thresholds, defaultThresholds)) {
@@ -1110,5 +1073,9 @@ export default {
 }
 h6 {
 	margin-top: 4rem;
+}
+.power-hint {
+	/* fits "≈ 11.1 kW", keeps input width stable */
+	min-width: 9ch;
 }
 </style>

--- a/assets/js/components/Config/PropertyField.vue
+++ b/assets/js/components/Config/PropertyField.vue
@@ -87,7 +87,7 @@
 		:valueLabel="zonesValueLabel"
 	/>
 	<div v-else class="d-flex" :class="sizeClass">
-		<div class="position-relative flex-grow-1">
+		<div class="position-relative flex-grow-1 shrinkable">
 			<input
 				:id="id"
 				:value="value"
@@ -462,6 +462,9 @@ export default {
 </script>
 
 <style scoped>
+.shrinkable {
+	min-width: 0;
+}
 .w-min-100 {
 	min-width: min(100px, 100%);
 }

--- a/assets/js/components/Loadpoints/SettingsModal.vue
+++ b/assets/js/components/Loadpoints/SettingsModal.vue
@@ -172,8 +172,6 @@ import { defineComponent, type PropType } from "vue";
 import { PHASES, CURRENCY, SMART_COST_TYPE, type UiForecast, type UiLoadpoint } from "@/types/evcc";
 import api from "@/api";
 
-const V = 230;
-
 const range = (start: number, stop: number, step = -1) =>
 	Array.from({ length: (stop - start) / step + 1 }, (_, i) => start + i * step);
 
@@ -323,9 +321,6 @@ export default defineComponent({
 		},
 		apiPath(func: string) {
 			return "loadpoints/" + this.id + "/" + func;
-		},
-		fmtPhasePower(current?: number, phases?: PHASES) {
-			return this.fmtW(V * (current || 0) * (phases || 0));
 		},
 		formId(name: string) {
 			return `loadpoint_${this.id}_${name}`;

--- a/assets/js/mixins/formatter.ts
+++ b/assets/js/mixins/formatter.ts
@@ -136,6 +136,9 @@ export default defineComponent({
       const abs = Math.abs(watt);
       return abs >= 10_000_000 ? POWER_UNIT.MW : abs >= 1000 ? POWER_UNIT.KW : POWER_UNIT.W;
     },
+    fmtPhasePower(current?: number, phases?: number) {
+      return this.fmtW(230 * (current || 0) * (phases || 0));
+    },
     fmtW(watt = 0, format = POWER_UNIT.KW, withUnit = true, digits?: number) {
       let unit = format;
       let d = digits;

--- a/i18n/bg.json
+++ b/i18n/bg.json
@@ -277,13 +277,6 @@
         "charging": "Зарядно",
         "heating": "Нагревател"
       },
-      "chargerPower11kw": "11 кВт",
-      "chargerPower11kwHelp": "Ще бъде използван ток в диапазона от 6 до 16 А.",
-      "chargerPower22kw": "22 кВт",
-      "chargerPower22kwHelp": "Ще бъде използван ток в диапазона от 6 до 32 А.",
-      "chargerPowerCustom": "други",
-      "chargerPowerCustomHelp": "Определи специфичен токов диапазон.",
-      "chargerTypeLabel": "Вид на зарадяното",
       "chargingTitle": "Поведение",
       "circuitHelp": "Задание на управление на товара, за да бъде осигурена достатъчно мощност и ограничения на тока не са превишени.",
       "circuitInvalid": "Веригата не съществува",

--- a/i18n/bs.json
+++ b/i18n/bs.json
@@ -277,13 +277,6 @@
         "charging": "Učitaj",
         "heating": "Grijač"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Koristit će trenutni raspon od 6 do 16 A.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Koristit će trenutni raspon od 6 do 32 A.",
-      "chargerPowerCustom": "drugo",
-      "chargerPowerCustomHelp": "Definirajte prilagođeni raspon struje.",
-      "chargerTypeLabel": "Tip opterećenja",
       "chargingTitle": "Ponašanje",
       "circuitHelp": "Dodjela zadatka upravljanja opterećenjem kako bi se osiguralo da se ne prekorače ograničenja snage i struje.",
       "circuitInvalid": "Kružni tok ne postoji",

--- a/i18n/ca.json
+++ b/i18n/ca.json
@@ -441,13 +441,6 @@
         "charging": "Carregador",
         "heating": "Dispositiu de calefacció"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Utilitzarà un interval de corrent de 6 a 16 A.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Utilitzarà un interval de corrent de 6 a 32 A.",
-      "chargerPowerCustom": "altre",
-      "chargerPowerCustomHelp": "Defineix un interval de corrent personalitzat.",
-      "chargerTypeLabel": "Tipus de carregador",
       "chargingTitle": "Comportament",
       "circuitHelp": "Assignació a la gestió de càrregues per a assegurar que no se superin els límits de potència i corrent.",
       "circuitInvalid": "El circuit no existeix",

--- a/i18n/cs.json
+++ b/i18n/cs.json
@@ -441,13 +441,6 @@
         "charging": "Nabíječka",
         "heating": "Zařízení pro vytápění"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Použije se nastavení proudu od 6 do 16 A.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Použije se nastavení proudu od 6 do 32 A.",
-      "chargerPowerCustom": "Ostatní",
-      "chargerPowerCustomHelp": "Definujte vlastní rozsah proudu (A) připojeného zařízení.",
-      "chargerTypeLabel": "Typ nabíječky",
       "chargingTitle": "Chování",
       "circuitHelp": "Řízení zátěže zajišťující nepřekročení limitů proudu a výkonu.",
       "circuitInvalid": "Obvod neexistuje",

--- a/i18n/da.json
+++ b/i18n/da.json
@@ -432,13 +432,6 @@
         "charging": "Oplader",
         "heating": "Varmelegeme"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Benytter en strømstyrke mellem 6 og 16 A.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Benytter en strømstyrke mellem 6 og 32 A.",
-      "chargerPowerCustom": "andre",
-      "chargerPowerCustomHelp": "Definer strømstyrke interval.",
-      "chargerTypeLabel": "Oplader type",
       "chargingTitle": "Tilstand",
       "circuitHelp": "Belastningsstyring som sikrer, at effekt- og strømgrænser ikke overskrides.",
       "circuitInvalid": "Kredsløbet findes ikke",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -442,13 +442,6 @@
         "charging": "Wallbox",
         "heating": "Heizgerät"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Verwendet einen Strombereich von 6 bis 16 A.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Verwendet einen Strombereich von 6 bis 32 A.",
-      "chargerPowerCustom": "andere",
-      "chargerPowerCustomHelp": "Definiere einen eigenen Strombereich.",
-      "chargerTypeLabel": "Ladetyp",
       "chargingTitle": "Verhalten",
       "circuitHelp": "Lastmanagement-Zuordnung, um die Leistungs- und Stromgrenzen nicht zu überschreiten.",
       "circuitInvalid": "Stromkreis existiert nicht",
@@ -462,6 +455,10 @@
       "creating": {
         "charging": "Wallbox gespeichert. Ladepunkt wird erstellt …",
         "heating": "Heizgerät gespeichert. Heizung wird erstellt …"
+      },
+      "currentRangeHelp": {
+        "charging": "Typisch: 6-16 A bei 11 kW, 6-32 A bei 22 kW Wallboxen (3-phasig).",
+        "heating": "Abhängig von der Nennleistung des Heizgeräts (siehe Datenblatt)."
       },
       "defaultModeHelp": {
         "charging": "Lademodus beim Anschließen des Fahrzeugs.",

--- a/i18n/el.json
+++ b/i18n/el.json
@@ -277,13 +277,6 @@
         "charging": "Φορτιστής",
         "heating": "Θερμαντήρας"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Θα χρησιμοποιήσει εύρος έντασης ρεύματος από 6 έως 16 Α.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Θα χρησιμοποιήσει εύρος έντασης ρεύματος από 6 έως 32 A.",
-      "chargerPowerCustom": "άλλο",
-      "chargerPowerCustomHelp": "Ορίστε ένα προσαρμοσμένο εύρος έντασης ρεύματος.",
-      "chargerTypeLabel": "Τύπος φορτιστή",
       "chargingTitle": "Συμπεριφορά",
       "circuitHelp": "Εκχώρηση διαχείρισης φορτίου για τη διασφάλιση της μη υπέρβασης των ορίων ισχύος και ρεύματος.",
       "circuitInvalid": "Το κύκλωμα δεν υπάρχει",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -442,13 +442,6 @@
         "charging": "Charger",
         "heating": "Heating device"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Will use a current range of 6 to 16 A.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Will use a current range of 6 to 32 A.",
-      "chargerPowerCustom": "other",
-      "chargerPowerCustomHelp": "Define a custom current range.",
-      "chargerTypeLabel": "Charger type",
       "chargingTitle": "Behaviour",
       "circuitHelp": "Load management assignment to ensure power and current limits are not exceeded.",
       "circuitInvalid": "Circuit does not exist",
@@ -462,6 +455,10 @@
       "creating": {
         "charging": "Charger saved. Creating charging point …",
         "heating": "Heating device saved. Creating heater …"
+      },
+      "currentRangeHelp": {
+        "charging": "Typical: 6-16 A for 11 kW, 6-32 A for 22 kW chargers (3-phase).",
+        "heating": "Depends on the rated power of the heating device (see data sheet)."
       },
       "defaultModeHelp": {
         "charging": "Charging mode when connecting the vehicle.",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -322,13 +322,6 @@
         "charging": "Cargador",
         "heating": "Calentador"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Utilizará un rango de corriente de 6 a 16 A.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Utilizará un rango de corriente de 6 a 32 A.",
-      "chargerPowerCustom": "otro",
-      "chargerPowerCustomHelp": "Defina un rango de corriente personalizado.",
-      "chargerTypeLabel": "Tipo de cargador",
       "chargingTitle": "Comportamiento",
       "circuitHelp": "Asignación de gestión de carga para garantizar que no se superen los límites de potencia y corriente.",
       "circuitInvalid": "El circuito no existe",

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -432,13 +432,6 @@
         "charging": "Laturi",
         "heating": "Lämmityslaite"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Käyttää 6-16 A:n virta-aluetta.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Käyttää 6-32 A:n virta-aluetta.",
-      "chargerPowerCustom": "muu",
-      "chargerPowerCustomHelp": "Mukauta käytettävä virta-alue.",
-      "chargerTypeLabel": "Laturin tyyppi",
       "chargingTitle": "Toiminta",
       "circuitHelp": "Kuormanhallinnan määritys varmistaa, että teho ja virtarajoitteita ei ylitetä.",
       "circuitInvalid": "Piiriä ei ole olemassa",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -427,13 +427,6 @@
         "charging": "Chargeur",
         "heating": "Dispositif de chauffage"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Utilisera des courants de 6 à 16 A.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Utilisera des courants de 6 à 32 A.",
-      "chargerPowerCustom": "autre",
-      "chargerPowerCustomHelp": "Définir un intervalle de courant personnalisé.",
-      "chargerTypeLabel": "Type de chargeur",
       "chargingTitle": "Comportement",
       "circuitHelp": "Assignation de la gestion de charge afin d’assurer que les limites de puissance et de courant ne sont pas dépassées.",
       "circuitInvalid": "Le circuit n'existe pas",

--- a/i18n/hr.json
+++ b/i18n/hr.json
@@ -277,13 +277,6 @@
         "charging": "Punjač",
         "heating": "Grijač"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Koristit će raspon struje od 6 do 16 A.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Koristit će raspon struje od 6 do 32 A.",
-      "chargerPowerCustom": "drugo",
-      "chargerPowerCustomHelp": "Definiraj prilagođeni raspon struje.",
-      "chargerTypeLabel": "Tip punjača",
       "chargingTitle": "Način rada",
       "circuitHelp": "Dodjela upravljanja opterećenjem kako bi se osiguralo da se ne prekorače ograničenja snage i struje.",
       "circuitInvalid": "Kružni tok ne postoji",

--- a/i18n/hu.json
+++ b/i18n/hu.json
@@ -287,13 +287,6 @@
         "charging": "Töltő",
         "heating": "Fűtőberendezés"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "6 és 16 A közötti áramtartomány lesz használatban.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "6 és 32 A közötti áramtartomány lesz használatban.",
-      "chargerPowerCustom": "egyéb",
-      "chargerPowerCustomHelp": "Definiáljon egy egyedi áramtartományt.",
-      "chargerTypeLabel": "Töltő típusa",
       "chargingTitle": "Viselkedés",
       "circuitHelp": "Terheléskezelési hozzárendelés a teljesítmény- és áramkorlátok túllépésének biztosítására.",
       "circuitInvalid": "Az áramkör nem létezik",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -425,13 +425,6 @@
         "charging": "Caricabatterie",
         "heating": "Riscaldatore"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Utilizzerà un intervallo di corrente tra 6 e 16 A.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Utilizzerà un intervallo di corrente tra 6 e 32 A.",
-      "chargerPowerCustom": "altro",
-      "chargerPowerCustomHelp": "Definire un intervallo di corrente personalizzato.",
-      "chargerTypeLabel": "Tipo di caricabatterie",
       "chargingTitle": "Comportamento",
       "circuitHelp": "Assegnazione della gestione del carico per garantire che i limiti di potenza e corrente non vengano superati.",
       "circuitInvalid": "Il circuito non esiste",

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -317,13 +317,6 @@
         "charging": "充電器",
         "heating": "ヒーター"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "6 〜 16 A の電流値を使用します。",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "6 〜 32 A の電流値を使用します。",
-      "chargerPowerCustom": "その他",
-      "chargerPowerCustomHelp": "カスタムの電流値を設定します。",
-      "chargerTypeLabel": "充電器タイプ",
       "chargingTitle": "挙動",
       "circuitHelp": "電力および電流の上限値を超えないようにするための、負荷管理の割り当てです。",
       "circuitInvalid": "指定された回路が存在しません",

--- a/i18n/lb.json
+++ b/i18n/lb.json
@@ -427,13 +427,6 @@
         "charging": "Wallbox",
         "heating": "Heizungsgerät"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Verwennt Stroum vu 6 bis 16 A.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Verwennt Stroum vu 6 bis 32 A.",
-      "chargerPowerCustom": "aneren",
-      "chargerPowerCustomHelp": "Een eegenen Stroumberäich definéieren.",
-      "chargerTypeLabel": "Luedleeschtung",
       "chargingTitle": "Verhalen",
       "circuitHelp": "Laaschtmanagement-Zouweisung, fir sécher ze goen, dass d'Leeschtung a Stroumlimitten net iwwerschratt ginn.",
       "circuitInvalid": "De Circuit existéiert net",

--- a/i18n/lt.json
+++ b/i18n/lt.json
@@ -441,13 +441,6 @@
         "charging": "Įkroviklis",
         "heating": "Šildytuvas"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Naudos įkrovimo srovę nuo 6 iki 16 A.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Naudos įkrovimo srovę nuo 6 iki 32 A.",
-      "chargerPowerCustom": "kiti",
-      "chargerPowerCustomHelp": "Nurodykite įkrovimo srovės ribas.",
-      "chargerTypeLabel": "Įkroviklio tipas",
       "chargingTitle": "Elgesys",
       "circuitHelp": "Apkrovos valdymo priskyrimas, siekiant užtikrinti, kad nebūtų viršytos galios ir srovės ribos.",
       "circuitInvalid": "Tokios grandinės nėra",

--- a/i18n/lv.json
+++ b/i18n/lv.json
@@ -441,13 +441,6 @@
         "charging": "Lādētājs",
         "heating": "Sildīšanas ierīce"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Izmantos strāvas diapazonu no 6 līdz 16 A.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Izmantos strāvas diapazonu no 6 līdz 32 A.",
-      "chargerPowerCustom": "cits",
-      "chargerPowerCustomHelp": "Definējiet pielāgotu strāvas diapazonu.",
-      "chargerTypeLabel": "Lādētāja tips",
       "chargingTitle": "Uzvedība",
       "circuitHelp": "Slodzes pārvaldības piešķīrums, lai nodrošinātu jaudas un strāvas robežu nepārsniegšanu.",
       "circuitInvalid": "Ķēde nepastāv",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -435,13 +435,6 @@
         "charging": "Oplader",
         "heating": "Verwarmingstoestel"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Zal een stroom van 6 tot 16 A gebruiken.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Zal een stroom van 6 tot 32 A gebruiken.",
-      "chargerPowerCustom": "andere",
-      "chargerPowerCustomHelp": "Definieer een aangepast stroombereik.",
-      "chargerTypeLabel": "Type laadpunt",
       "chargingTitle": "Gedrag",
       "circuitHelp": "Wijst een circuit toe binnen het elektriciteitsnetwerk om overschrijding van vermogens- en stroomlimieten te voorkomen.",
       "circuitInvalid": "Het circuit bestaat niet",

--- a/i18n/no.json
+++ b/i18n/no.json
@@ -326,13 +326,6 @@
         "charging": "Lader",
         "heating": "Varmeelement"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Vil bruke et strømområde på 6 til 16 A.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Vil bruke et strømområde på 6 til 32 A.",
-      "chargerPowerCustom": "annen",
-      "chargerPowerCustomHelp": "Definer et tilpasset strømområde.",
-      "chargerTypeLabel": "Ladertype",
       "chargingTitle": "Oppførsel",
       "circuitHelp": "Laststyringsoppgave for å sikre at effekt- og strømgrenser ikke overskrides.",
       "circuitInvalid": "Kretsen eksisterer ikke",

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -402,13 +402,6 @@
         "charging": "Ładowarka",
         "heating": "Podgrzewacz"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Użyty zakres prądu będzie wynosił od 6 do 16 A.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Użyty zakres prądu będzie wynosił od 6 do 32 A.",
-      "chargerPowerCustom": "inny",
-      "chargerPowerCustomHelp": "Zdefiniuj niestandardowy zakres prądu.",
-      "chargerTypeLabel": "Typ ładowarki",
       "chargingTitle": "Postępowanie",
       "circuitHelp": "Przypisanie zarządzania obciążeniem w celu zapewnienia, że nie zostaną przekroczone limity mocy i prądu.",
       "circuitInvalid": "Obwód nie istnieje",

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -427,13 +427,6 @@
         "charging": "Carregador",
         "heating": "Dispositivo de aquecimento"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Utilização de uma gama de correntes de 6 a 16 A.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Utilização de uma gama de correntes de 6 a 32 A.",
-      "chargerPowerCustom": "outro",
-      "chargerPowerCustomHelp": "Definir um intervalo de Correntes personalizado.",
-      "chargerTypeLabel": "Tipo de Carregador",
       "chargingTitle": "Comportamento",
       "circuitHelp": "Atribuição de gestão de carga para garantir que os limites de potência e corrente não são excedidos.",
       "circuitInvalid": "O circuito não existe",

--- a/i18n/ro.json
+++ b/i18n/ro.json
@@ -307,13 +307,6 @@
         "charging": "Încărcător",
         "heating": "Încălzitor"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Va utiliza un interval de curent de la 6 la 16 A.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Va utiliza un interval de curent de la 6 la 32 A.",
-      "chargerPowerCustom": "altul",
-      "chargerPowerCustomHelp": "Definiți un interval curent personalizat.",
-      "chargerTypeLabel": "Tipul încărcătorului",
       "chargingTitle": "Comportament",
       "circuitHelp": "Atribuirea gestionării sarcinii pentru a se asigura că limitele de putere și curent nu sunt depășite.",
       "circuitInvalid": "Circuitul nu există",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -432,13 +432,6 @@
         "charging": "Зарядное устройство",
         "heating": "Нагревательное устройство"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Будет использовать ток в диапазоне от 6 до 16 А.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Будет использовать ток в диапазоне от 6 до 32 А.",
-      "chargerPowerCustom": "другой",
-      "chargerPowerCustomHelp": "Определите пользовательский диапазон тока.",
-      "chargerTypeLabel": "Тип зарядного устройства",
       "chargingTitle": "Поведение",
       "circuitHelp": "Задание управления нагрузкой для обеспечения соблюдения ограничений по мощности и току.",
       "circuitInvalid": "Цепь не существует",

--- a/i18n/sk.json
+++ b/i18n/sk.json
@@ -432,13 +432,6 @@
         "charging": "Nabíjačka",
         "heating": "Ohrievač"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Bude používať rozsah prúdu od 6 do 16 A.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Bude používať rozsah prúdu od 6 do 32 A.",
-      "chargerPowerCustom": "iné",
-      "chargerPowerCustomHelp": "Definujte vlastný rozsah prúdu.",
-      "chargerTypeLabel": "Typ nabíjačky",
       "chargingTitle": "Správanie",
       "circuitHelp": "Priradenie riadenia záťaže, aby sa zabezpečilo, že nebudú prekročené limity výkonu a prúdu.",
       "circuitInvalid": "Obvod neexistuje",

--- a/i18n/sl.json
+++ b/i18n/sl.json
@@ -293,13 +293,6 @@
         "charging": "Polnilnica",
         "heating": "Grelec"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Uporabilo se bo tokovno območje od 6 do 16 A.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Uporabilo se bo tokovno območje od 6 do 32 A.",
-      "chargerPowerCustom": "drugo",
-      "chargerPowerCustomHelp": "Določite drug obseg toka.",
-      "chargerTypeLabel": "Vrsta polnilnice",
       "chargingTitle": "Vedenje",
       "circuitHelp": "Dodelitev upravljanja obremenitve, da se zagotovi, da omejitve moči in toka niso presežene.",
       "circuitInvalid": "Vezje ne obstaja",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -440,13 +440,6 @@
         "charging": "Laddare",
         "heating": "Värmekälla"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Använder mellan 6 och 16 A.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Använder mellan 6 till 32 A.",
-      "chargerPowerCustom": "annan",
-      "chargerPowerCustomHelp": "Ange strömintervall.",
-      "chargerTypeLabel": "Typ av laddare",
       "chargingTitle": "Tillstånd",
       "circuitHelp": "Belastningsstyrning som säkrar att effekt och strömgränser ej överskrids.",
       "circuitInvalid": "Kretsen saknas",

--- a/i18n/ta.json
+++ b/i18n/ta.json
@@ -354,13 +354,6 @@
         "charging": "மின்னூட்டி",
         "heating": "ஈட்டர்"
       },
-      "chargerPower11kw": "11 கிலோவாட்",
-      "chargerPower11kwHelp": "தற்போதைய 6 முதல் 16 வரை தற்போதைய வரம்பைப் பயன்படுத்தும்.",
-      "chargerPower22kw": "22 கிலோவாட்",
-      "chargerPower22kwHelp": "தற்போதைய 6 முதல் 32 ஏ வரை பயன்படுத்தும்.",
-      "chargerPowerCustom": "மற்றொன்று",
-      "chargerPowerCustomHelp": "தனிப்பயன் தற்போதைய வரம்பை வரையறுக்கவும்.",
-      "chargerTypeLabel": "சார்சர் வகை",
       "chargingTitle": "நடத்தை",
       "circuitHelp": "ஆற்றல் மற்றும் தற்போதைய வரம்புகள் மீறப்படுவதில்லை என்பதை உறுதிப்படுத்த சுமை மேலாண்மை பணி.",
       "circuitInvalid": "சர்க்யூட் இல்லை",

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -366,13 +366,6 @@
         "charging": "“Doldurma cihazı”",
         "heating": "Isıtıcı"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "6 ila 16 A akım aralığını kullanır.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "6 ila 32 A akım aralığını kullanır.",
-      "chargerPowerCustom": "diğer",
-      "chargerPowerCustomHelp": "Kendine özgü bir akım aralığı tanımla.",
-      "chargerTypeLabel": "“Doldurma gücü”",
       "chargingTitle": "Davranış",
       "circuitHelp": "Güç ve akım limitlerinin aşılmaması için yük yönetim ataması.",
       "circuitInvalid": "Devre mevcut değil",

--- a/i18n/uk.json
+++ b/i18n/uk.json
@@ -279,13 +279,6 @@
         "charging": "Зарядний пристрій",
         "heating": "Обігрівач"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "Використовуватиметься діапазон струму від 6 до 16 А.",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "Буде використовувати діапазон струму від 6 до 32 А.",
-      "chargerPowerCustom": "інші",
-      "chargerPowerCustomHelp": "Визначте настроюваний діапазон струму.",
-      "chargerTypeLabel": "Тип зарядного пристрою",
       "chargingTitle": "Поведінка",
       "circuitHelp": "Призначення керування навантаженням для забезпечення неперевищення обмежень потужності та струму.",
       "circuitInvalid": "Схема не існує",

--- a/i18n/zh-Hans.json
+++ b/i18n/zh-Hans.json
@@ -223,13 +223,6 @@
       "chargerLabel": {
         "charging": "充电桩"
       },
-      "chargerPower11kw": "11 kW",
-      "chargerPower11kwHelp": "将使用 6 至 16 A 的电流范围。",
-      "chargerPower22kw": "22 kW",
-      "chargerPower22kwHelp": "将使用 6 至 32 A 的电流范围。",
-      "chargerPowerCustom": "其他",
-      "chargerPowerCustomHelp": "定义自定义电流范围。",
-      "chargerTypeLabel": "充电桩类型",
       "chargingTitle": "充电",
       "circuitHelp": "负载管理分配，以确保不超过功率和电流限制。",
       "circuitLabel": "电路",

--- a/tests/config-loadpoint.spec.ts
+++ b/tests/config-loadpoint.spec.ts
@@ -29,6 +29,8 @@ test.describe("charging loadpoint", async () => {
     await page.goto("/#/config");
 
     const lpModal = page.getByTestId("loadpoint-modal");
+    const minCurrent = lpModal.getByLabel("Minimum current");
+    const maxCurrent = lpModal.getByLabel("Maximum current");
     const chargerModal = page.getByTestId("charger-modal");
 
     await expect(page.getByTestId("loadpoint")).toHaveCount(0);
@@ -57,9 +59,17 @@ test.describe("charging loadpoint", async () => {
     await expect(lpModal.getByTestId("loadpointSolarMode-default")).toHaveClass(/active/);
     await expect(lpModal.getByTestId("loadpointSolarMode-custom")).not.toHaveClass(/active/);
     // min/max current
-    await expect(lpModal.getByTestId("chargerPower-11kw")).toHaveClass(/active/);
-    await expect(lpModal.getByTestId("chargerPower-22kw")).not.toHaveClass(/active/);
-    await expect(lpModal.getByTestId("chargerPower-other")).not.toHaveClass(/active/);
+    await expect(minCurrent).toHaveValue("6");
+    await expect(maxCurrent).toHaveValue("16");
+    await expect(lpModal).toContainText("≈ 4.1 kW");
+    await expect(lpModal).toContainText("≈ 11.0 kW");
+    await expect(lpModal).toContainText("Typical: 6-16 A for 11 kW");
+    await minCurrent.fill("4");
+    await minCurrent.blur();
+    await expect(lpModal).toContainText("Only go below 6 A");
+    await minCurrent.fill("6");
+    await minCurrent.blur();
+    await expect(lpModal).not.toContainText("Only go below 6 A");
     // phases
     await expect(lpModal.getByTestId("loadpointParamPhases-1")).not.toHaveClass(/active/);
     await expect(lpModal.getByTestId("loadpointParamPhases-3")).toHaveClass(/active/);
@@ -107,7 +117,9 @@ test.describe("charging loadpoint", async () => {
     // update loadpoint power
     await page.getByTestId("loadpoint").getByRole("button", { name: "edit" }).click();
     await expectModalVisible(lpModal);
-    await lpModal.getByTestId("chargerPower-22kw").click();
+    await maxCurrent.fill("32");
+    await maxCurrent.blur();
+    await expect(lpModal).toContainText("≈ 22.1 kW");
 
     // update charger mode
     await expect(lpModal.getByText("Demo charger")).toBeVisible();
@@ -128,7 +140,7 @@ test.describe("charging loadpoint", async () => {
 
     await page.getByTestId("loadpoint").getByRole("button", { name: "edit" }).click();
     await expectModalVisible(lpModal);
-    await expect(lpModal.getByTestId("chargerPower-22kw")).toHaveClass(/active/);
+    await expect(maxCurrent).toHaveValue("32");
     await expect(lpModal.getByLabel("Title")).toHaveValue("Solar Carport 2");
     await lpModal.getByRole("button", { name: "Close" }).click();
 
@@ -611,7 +623,7 @@ power:
     await expect(modeSelect.getByRole("option", { name: "Min+Solar" })).toHaveCount(0);
 
     await expect(lpModal.getByText("Electrics")).toHaveCount(0);
-    await expect(lpModal.getByText("Charger type", { exact: true })).toHaveCount(0);
+    await expect(lpModal.getByLabel("Maximum current")).toHaveCount(0);
 
     // create
     await lpModal.getByRole("button", { name: "Save" }).click();
@@ -644,6 +656,12 @@ test.describe("heating loadpoint", async () => {
     await lpEntry.getByRole("button", { name: "edit" }).click();
     await expectModalVisible(lpModal);
     await expect(lpModal.getByRole("heading", { name: "Edit Heater" })).toBeVisible();
+
+    // heating specific current hints
+    await expect(lpModal).toContainText("Depends on the rated power of the heating device");
+    await lpModal.getByLabel("Minimum current").fill("4");
+    await lpModal.getByLabel("Minimum current").blur();
+    await expect(lpModal).not.toContainText("Only go below 6 A");
     await lpModal.getByRole("button", { name: "Save" }).click();
     await expectModalHidden(lpModal);
 


### PR DESCRIPTION
fixes #33212, part of #19753

The 11 kW / 22 kW / other preset in the loadpoint configuration assumed a 3-phase charger. On 1-phase installations the labels were wrong, for heating devices they made no sense, and switching presets silently overwrote custom currents. The preset is gone, min and max current are now entered directly.

- Min and max current always visible, no preset step
- Each field shows the resulting power for the selected phases, e.g. 16 A → ≈ 11.0 kW at 3 phases
- Phases are selected above the currents so the estimate matches
- Short guidance below: typical 11 kW / 22 kW ranges for chargers, rated-power hint for heating devices
- "Below 6 A" warning no longer shown for heating devices
- Focus ring in the loadpoint modal no longer clipped at the edges

**Screenshots**

heating

<img width="685" height="348" alt="Bildschirmfoto 2026-09-02 um 14 27 47" src="https://github.com/user-attachments/assets/107b3bfd-3405-4019-9073-4af2dc69d562" />

---

charging

<img width="615" height="348" alt="Bildschirmfoto 2026-09-02 um 14 22 05" src="https://github.com/user-attachments/assets/69695bec-e673-44b8-8b07-4f53a1904148" />
