### PR TITLE
chore: fix master build after mode redesign merge

### DIFF
--- a/core/loadpoint_settings_test.go
+++ b/core/loadpoint_settings_test.go
@@ -43,7 +43,7 @@ func TestSettingsRoundtrip(t *testing.T) {
 	lp.charger = charger
 	lp.Prepare(new(Site), uiChan, pushChan, lpChan)
 
-	lp.SetMode(api.ModePV)
+	lp.SetMode(api.ModeSmart)
 	lp.SetPriority(3)
 	require.NoError(t, lp.SetMinCurrent(8))
 	require.NoError(t, lp.SetMaxCurrent(12))
@@ -63,7 +63,7 @@ func TestSettingsRoundtrip(t *testing.T) {
 	restored.charger = charger
 	restored.Prepare(new(Site), uiChan, pushChan, lpChan)
 
-	assert.Equal(t, api.ModePV, restored.GetMode())
+	assert.Equal(t, api.ModeSmart, restored.GetMode())
 	assert.Equal(t, 3, restored.GetPriority())
 	assert.Equal(t, 8.0, restored.GetMinCurrent())
 	assert.Equal(t, 12.0, restored.GetMaxCurrent())

--- a/core/vehicle/adapter_test.go
+++ b/core/vehicle/adapter_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/core/keys"
-	"github.com/evcc-io/evcc/server/db/settings"
+	"github.com/evcc-io/evcc/db/settings"
 	"github.com/evcc-io/evcc/util"
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
follows #32490, pairs with #33382

Master CI red after #32490 merged on a branch predating two master changes.

- Fix stale import path `server/db/settings` in vehicle adapter test
- Roundtrip test expects `smart` since `pv` is normalized on set

🤖 Generated with [Claude Code](https://claude.com/claude-code)