### PR TITLE
Charging plan: disable optimization when late charging covers everything

### DIFF
--- a/assets/js/components/ChargingPlans/PlanStrategy.vue
+++ b/assets/js/components/ChargingPlans/PlanStrategy.vue
@@ -27,7 +27,7 @@
 							</label>
 							<div class="col-7 col-lg-12">
 								<select
-									v-if="disabled"
+									v-if="optimizationDisabled"
 									:id="formId('continuous')"
 									class="form-select"
 									disabled
@@ -149,8 +149,15 @@ export default defineComponent({
 		cheapestKey(): string {
 			return this.isCo2 ? "cleanest" : "cheapest";
 		},
+		preconditionAll(): boolean {
+			return this.localPrecondition >= EVERYTHING;
+		},
+		optimizationDisabled(): boolean {
+			// everything is charged late, nothing left to optimize
+			return this.disabled || this.preconditionAll;
+		},
 		summary(): string {
-			if (this.disabled) {
+			if (this.disabled || this.precondition >= EVERYTHING) {
 				return this.$t("main.chargingPlan.precondition.summaryAll");
 			}
 			const parts = [
@@ -158,9 +165,7 @@ export default defineComponent({
 					`main.chargingPlan.optimization.${this.continuous ? "continuous" : this.cheapestKey}`
 				),
 			];
-			if (this.precondition >= EVERYTHING) {
-				parts.push(this.$t("main.chargingPlan.precondition.summaryAll"));
-			} else if (this.precondition) {
+			if (this.precondition) {
 				parts.push(
 					this.$t("main.chargingPlan.precondition.summary", {
 						precondition: this.fmtDurationLong(this.precondition),
@@ -172,6 +177,9 @@ export default defineComponent({
 		optimizationDescription(): string {
 			if (this.disabled) {
 				return this.$t("main.chargingPlan.optimization.disabledDescription");
+			}
+			if (this.preconditionAll) {
+				return this.$t("main.chargingPlan.precondition.disabledDescription");
 			}
 			const variant = this.localContinuous
 				? this.isCo2

--- a/tests/plan.spec.ts
+++ b/tests/plan.spec.ts
@@ -730,6 +730,24 @@ test.describe("plan strategy", async () => {
     await expect(modal.getByTestId("plan-strategy")).toContainText("cleanest uninterrupted series");
   });
 
+  test("late charging everything: optimization disabled", async ({ page }) => {
+    await page.goto("/");
+    const lp1 = await page.getByTestId("loadpoint").first();
+    await lp1.getByTestId("charging-plan").getByRole("button", { name: "none" }).click();
+    const modal = page.getByTestId("charging-plan-modal");
+    const strategy = modal.getByTestId("plan-strategy");
+    await strategy.getByRole("button", { name: "cheapest" }).click();
+
+    await modal.getByLabel("Late Charging").selectOption("everything");
+    await expect(modal.getByLabel("Optimization")).toBeDisabled();
+    await expect(modal.getByLabel("Optimization")).toHaveText("none");
+    await expect(strategy).toContainText("All charging happens right before departure.");
+
+    await modal.getByLabel("Late Charging").selectOption("no");
+    await expect(modal.getByLabel("Optimization")).toBeEnabled();
+    await expect(strategy).toContainText("cheapest slots");
+  });
+
   test("visible and functional on mobile", async ({ page }) => {
     await page.goto("/");
 


### PR DESCRIPTION
fixes #33420

With late charging set to "everything" the whole plan is charged right before departure, so the optimization strategy has no effect. The UI now reflects that instead of offering a dead setting.

- Optimization select disabled and shows "none" when late charging is "everything", reusing the existing no-tariff state
- Description explains that all charging happens right before departure
- Collapsed summary shows only "right before departure" in that case

[disable continuous.webm](https://github.com/user-attachments/assets/11a2e15a-2314-4d54-aeeb-e50b8cf700ec)
