### PR TITLE
EEBus: replay use case support to devices registering after discovery

### DIFF
--- a/server/eebus/eebus.go
+++ b/server/eebus/eebus.go
@@ -95,7 +95,15 @@ type EEBus struct {
 	paired    []shipapi.ServiceIdentity // devices paired via SHIP Pairing Service
 	connected map[string]bool           // connection state per ski
 
-	clients map[string][]Device
+	clients  map[string][]Device
+	useCases []useCase
+}
+
+// useCase pairs a registered use case with its support update event, which
+// carries the remote entity a device binds its getters to.
+type useCase struct {
+	eebusapi.UseCaseInterface
+	support eebusapi.EventType
 }
 
 var (
@@ -305,16 +313,25 @@ func NewServer(other Config) (*EEBus, error) {
 	}
 
 	// register use cases
-	for _, uc := range []eebusapi.UseCaseInterface{
-		c.cem.EvseCC, c.cem.EvCC,
-		c.cem.EvCem, c.cem.OpEV,
-		c.cem.OscEV, c.cem.EvSoc,
-		c.cem.OHPCF,
-		c.cs.CsLPCInterface, c.cs.CsLPPInterface,
-		c.ma.MaMGCPInterface, c.ma.MaMPCInterface, c.ma.MaMDTInterface,
-		c.eg.EgLPCInterface, c.eg.EgLPPInterface,
-	} {
-		c.service.AddUseCase(uc)
+	c.useCases = []useCase{
+		{c.cem.EvseCC, evsecc.UseCaseSupportUpdate},
+		{c.cem.EvCC, evcc.UseCaseSupportUpdate},
+		{c.cem.EvCem, evcem.UseCaseSupportUpdate},
+		{c.cem.OpEV, opev.UseCaseSupportUpdate},
+		{c.cem.OscEV, oscev.UseCaseSupportUpdate},
+		{c.cem.EvSoc, evsoc.UseCaseSupportUpdate},
+		{c.cem.OHPCF, ohpcf.UseCaseSupportUpdate},
+		{c.cs.CsLPCInterface, csplc.UseCaseSupportUpdate},
+		{c.cs.CsLPPInterface, cslpp.UseCaseSupportUpdate},
+		{c.ma.MaMGCPInterface, mgcp.UseCaseSupportUpdate},
+		{c.ma.MaMPCInterface, mpc.UseCaseSupportUpdate},
+		{c.ma.MaMDTInterface, mdt.UseCaseSupportUpdate},
+		{c.eg.EgLPCInterface, eglpc.UseCaseSupportUpdate},
+		{c.eg.EgLPPInterface, eglpp.UseCaseSupportUpdate},
+	}
+
+	for _, uc := range c.useCases {
+		c.service.AddUseCase(uc.UseCaseInterface)
 	}
 
 	// re-establish trust for devices paired via the SHIP Pairing Service
@@ -475,9 +492,42 @@ func (c *EEBus) RegisterDevice(ski, ip string, device Device) error {
 	}
 	if connected {
 		device.Connect(true)
+		c.replayUseCases(ski, device)
 	}
 
 	return nil
+}
+
+// replayUseCases re-states the use case support of an already connected remote to
+// a device registering after discovery has finished. eebus-go emits
+// UseCaseSupportUpdate only on notification, so a second device for the same ski
+// - the config UI device test while the device is running - would otherwise never
+// learn its remote entity and report "not connected" (mux must be held).
+func (c *EEBus) replayUseCases(ski string, device Device) {
+	match := func(remote string) bool { return remote == ski }
+	if ski == "" {
+		// the paired device registers without ski, see clientsFor
+		match = func(remote string) bool {
+			return c.connected[remote] && slices.ContainsFunc(c.paired, func(i shipapi.ServiceIdentity) bool {
+				return i.SKI == remote
+			})
+		}
+	}
+
+	for _, uc := range c.useCases {
+		for _, res := range uc.RemoteEntitiesScenarios() {
+			if res.Entity == nil {
+				continue
+			}
+
+			remote := res.Entity.Device()
+			if remote == nil || !match(remote.Ski()) {
+				continue
+			}
+
+			device.UseCaseEvent(remote, res.Entity, uc.support)
+		}
+	}
 }
 
 func (c *EEBus) UnregisterDevice(ski string, device Device) {

--- a/server/eebus/replay_test.go
+++ b/server/eebus/replay_test.go
@@ -1,0 +1,88 @@
+package eebus
+
+import (
+	"testing"
+
+	eebusapi "github.com/enbility/eebus-go/api"
+	eebusmocks "github.com/enbility/eebus-go/mocks"
+	"github.com/enbility/eebus-go/usecases/cem/ohpcf"
+	shipapi "github.com/enbility/ship-go/api"
+	spineapi "github.com/enbility/spine-go/api"
+	spinemocks "github.com/enbility/spine-go/mocks"
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingDevice records the use case events it receives
+type recordingDevice struct {
+	mockDevice
+	events []eebusapi.EventType
+}
+
+func (d *recordingDevice) UseCaseEvent(_ spineapi.DeviceRemoteInterface, _ spineapi.EntityRemoteInterface, event eebusapi.EventType) {
+	d.events = append(d.events, event)
+}
+
+// remoteEntity returns an entity mock belonging to a remote device with the given ski
+func remoteEntity(t *testing.T, ski string) spineapi.EntityRemoteInterface {
+	t.Helper()
+
+	remote := spinemocks.NewDeviceRemoteInterface(t)
+	remote.EXPECT().Ski().Return(ski).Maybe()
+
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	entity.EXPECT().Device().Return(remote).Maybe()
+
+	return entity
+}
+
+// registering a second device for an already connected ski must re-state the use
+// case support, otherwise the config UI device test reports "not connected"
+func TestRegisterDeviceReplaysUseCases(t *testing.T) {
+	const ski = "aabbcc"
+
+	uc := eebusmocks.NewUseCaseInterface(t)
+	uc.EXPECT().RemoteEntitiesScenarios().Return([]eebusapi.RemoteEntityScenarios{
+		{Entity: remoteEntity(t, ski)},
+		{Entity: remoteEntity(t, "ddeeff")}, // other device, must not be replayed
+	}).Once()
+
+	service := eebusmocks.NewServiceInterface(t)
+	service.EXPECT().RegisterRemoteService(shipapi.NewServiceIdentity(ski, "", "")).Once()
+
+	c := &EEBus{
+		log:       util.NewLogger("test"),
+		service:   service,
+		clients:   make(map[string][]Device),
+		connected: map[string]bool{ski: true},
+		useCases:  []useCase{{uc, ohpcf.UseCaseSupportUpdate}},
+	}
+
+	dev := new(recordingDevice)
+	require.NoError(t, c.RegisterDevice(ski, "", dev))
+
+	assert.Equal(t, []eebusapi.EventType{ohpcf.UseCaseSupportUpdate}, dev.events)
+}
+
+// a device registering for a ski that is not connected yet gets its use case
+// state from the regular event flow, replaying stale entities would be wrong
+func TestRegisterDeviceDisconnectedNoReplay(t *testing.T) {
+	const ski = "aabbcc"
+
+	service := eebusmocks.NewServiceInterface(t)
+	service.EXPECT().RegisterRemoteService(shipapi.NewServiceIdentity(ski, "", "")).Once()
+
+	c := &EEBus{
+		log:       util.NewLogger("test"),
+		service:   service,
+		clients:   make(map[string][]Device),
+		connected: make(map[string]bool),
+		useCases:  []useCase{{eebusmocks.NewUseCaseInterface(t), ohpcf.UseCaseSupportUpdate}},
+	}
+
+	dev := new(recordingDevice)
+	require.NoError(t, c.RegisterDevice(ski, "", dev))
+
+	assert.Empty(t, dev.events)
+}


### PR DESCRIPTION
follow-up to #33386

The config UI device test of an EEBus device that is already running fails with `chargeStatus: not connected` (Vaillant aroTHERM, [discussion 25058](https://github.com/evcc-io/evcc/discussions/25058#discussioncomment-18249797)). `RegisterDevice` replays the *connection* state to a device that registers for an already connected ski, but not the *use case* state — eebus-go emits `UseCaseSupportUpdate` only on notification, and discovery ran once at startup for the live instance. The test instance therefore never learns its remote entity, `WaitUseCase` runs into its timeout and `Status()` reports not connected.

- `RegisterDevice` now re-states the use case support of an already connected remote to the newly registered device, from `RemoteEntitiesScenarios()`
- the use case list gained the matching support event per use case, so the replay is generic and covers meter and charger alike

🤖 Generated with [Claude Code](https://claude.com/claude-code)