### PR TITLE
EEBus: replay use case support to devices registering after discovery

### DIFF
--- a/server/eebus/eebus.go
+++ b/server/eebus/eebus.go
@@ -95,7 +95,15 @@ type EEBus struct {
 	paired    []shipapi.ServiceIdentity // devices paired via SHIP Pairing Service
 	connected map[string]bool           // connection state per ski
 
-	clients map[string][]Device
+	clients  map[string][]Device
+	useCases []useCase
+}
+
+// useCase pairs a registered use case with its support update event, which
+// carries the remote entity a device binds its getters to.
+type useCase struct {
+	eebusapi.UseCaseInterface
+	support eebusapi.EventType
 }
 
 var (
@@ -305,16 +313,25 @@ func NewServer(other Config) (*EEBus, error) {
 	}
 
 	// register use cases
-	for _, uc := range []eebusapi.UseCaseInterface{
-		c.cem.EvseCC, c.cem.EvCC,
-		c.cem.EvCem, c.cem.OpEV,
-		c.cem.OscEV, c.cem.EvSoc,
-		c.cem.OHPCF,
-		c.cs.CsLPCInterface, c.cs.CsLPPInterface,
-		c.ma.MaMGCPInterface, c.ma.MaMPCInterface, c.ma.MaMDTInterface,
-		c.eg.EgLPCInterface, c.eg.EgLPPInterface,
-	} {
-		c.service.AddUseCase(uc)
+	c.useCases = []useCase{
+		{c.cem.EvseCC, evsecc.UseCaseSupportUpdate},
+		{c.cem.EvCC, evcc.UseCaseSupportUpdate},
+		{c.cem.EvCem, evcem.UseCaseSupportUpdate},
+		{c.cem.OpEV, opev.UseCaseSupportUpdate},
+		{c.cem.OscEV, oscev.UseCaseSupportUpdate},
+		{c.cem.EvSoc, evsoc.UseCaseSupportUpdate},
+		{c.cem.OHPCF, ohpcf.UseCaseSupportUpdate},
+		{c.cs.CsLPCInterface, csplc.UseCaseSupportUpdate},
+		{c.cs.CsLPPInterface, cslpp.UseCaseSupportUpdate},
+		{c.ma.MaMGCPInterface, mgcp.UseCaseSupportUpdate},
+		{c.ma.MaMPCInterface, mpc.UseCaseSupportUpdate},
+		{c.ma.MaMDTInterface, mdt.UseCaseSupportUpdate},
+		{c.eg.EgLPCInterface, eglpc.UseCaseSupportUpdate},
+		{c.eg.EgLPPInterface, eglpp.UseCaseSupportUpdate},
+	}
+
+	for _, uc := range c.useCases {
+		c.service.AddUseCase(uc.UseCaseInterface)
 	}
 
 	// re-establish trust for devices paired via the SHIP Pairing Service
@@ -437,7 +454,7 @@ func (c *EEBus) upsertPairing(identity shipapi.ServiceIdentity) {
 // without ski when ski is a SHIP-paired device (mux must be held)
 func (c *EEBus) clientsFor(ski string) []Device {
 	res := c.clients[ski]
-	if ski != "" && slices.ContainsFunc(c.paired, func(i shipapi.ServiceIdentity) bool { return i.SKI == ski }) {
+	if c.pairedIndex(shipapi.NewServiceIdentity(ski, "", "")) >= 0 {
 		res = append(slices.Clone(res), c.clients[""]...)
 	}
 	return res
@@ -475,9 +492,36 @@ func (c *EEBus) RegisterDevice(ski, ip string, device Device) error {
 	}
 	if connected {
 		device.Connect(true)
+		c.replayUseCases(ski, device)
 	}
 
 	return nil
+}
+
+// replayUseCases re-states the use case support of an already connected remote to
+// a device registering after discovery has finished. eebus-go emits
+// UseCaseSupportUpdate only on notification, so a second device for the same ski
+// - the config UI device test while the device is running - would otherwise never
+// learn its remote entity and report "not connected" (mux must be held).
+func (c *EEBus) replayUseCases(ski string, device Device) {
+	match := func(remote string) bool { return remote == ski }
+	if ski == "" {
+		// the paired device registers without ski, see clientsFor
+		match = func(remote string) bool {
+			return c.connected[remote] && c.pairedIndex(shipapi.NewServiceIdentity(remote, "", "")) >= 0
+		}
+	}
+
+	for _, uc := range c.useCases {
+		for _, res := range uc.RemoteEntitiesScenarios() {
+			remote := res.Entity.Device()
+			if remote == nil || !match(remote.Ski()) {
+				continue
+			}
+
+			device.UseCaseEvent(remote, res.Entity, uc.support)
+		}
+	}
 }
 
 func (c *EEBus) UnregisterDevice(ski string, device Device) {

--- a/server/eebus/eebus.go
+++ b/server/eebus/eebus.go
@@ -382,7 +382,7 @@ func (c *EEBus) Pairings() []PairingInfo {
 	}
 
 	for ski := range c.clients {
-		if ski == "" || c.pairedIndex(shipapi.NewServiceIdentity(ski, "", "")) >= 0 {
+		if ski == "" || c.isPaired(ski) {
 			continue
 		}
 		res = append(res, PairingInfo{
@@ -437,6 +437,11 @@ func (c *EEBus) pairedIndex(identity shipapi.ServiceIdentity) int {
 	})
 }
 
+// isPaired reports whether ski was paired via the SHIP Pairing Service (mux must be held)
+func (c *EEBus) isPaired(ski string) bool {
+	return c.pairedIndex(shipapi.NewServiceIdentity(ski, "", "")) >= 0
+}
+
 // upsertPairing adds or updates a pairing and persists it (mux must be held)
 func (c *EEBus) upsertPairing(identity shipapi.ServiceIdentity) {
 	if idx := c.pairedIndex(identity); idx >= 0 {
@@ -454,7 +459,7 @@ func (c *EEBus) upsertPairing(identity shipapi.ServiceIdentity) {
 // without ski when ski is a SHIP-paired device (mux must be held)
 func (c *EEBus) clientsFor(ski string) []Device {
 	res := c.clients[ski]
-	if c.pairedIndex(shipapi.NewServiceIdentity(ski, "", "")) >= 0 {
+	if c.isPaired(ski) {
 		res = append(slices.Clone(res), c.clients[""]...)
 	}
 	return res
@@ -508,7 +513,7 @@ func (c *EEBus) replayUseCases(ski string, device Device) {
 	if ski == "" {
 		// the paired device registers without ski, see clientsFor
 		match = func(remote string) bool {
-			return c.connected[remote] && c.pairedIndex(shipapi.NewServiceIdentity(remote, "", "")) >= 0
+			return c.connected[remote] && c.isPaired(remote)
 		}
 	}
 

--- a/server/eebus/eebus.go
+++ b/server/eebus/eebus.go
@@ -99,6 +99,10 @@ type EEBus struct {
 	useCases []useCase
 }
 
+// pairedSki is the clients key of the device paired via the SHIP Pairing Service,
+// whose ski is not known at configuration time but learned during pairing
+const pairedSki = ""
+
 // useCase pairs a registered use case with its support update event, which
 // carries the remote entity a device binds its getters to.
 type useCase struct {
@@ -382,7 +386,7 @@ func (c *EEBus) Pairings() []PairingInfo {
 	}
 
 	for ski := range c.clients {
-		if ski == "" || c.isPaired(ski) {
+		if ski == pairedSki || c.isPaired(ski) {
 			continue
 		}
 		res = append(res, PairingInfo{
@@ -439,7 +443,9 @@ func (c *EEBus) pairedIndex(identity shipapi.ServiceIdentity) int {
 
 // isPaired reports whether ski was paired via the SHIP Pairing Service (mux must be held)
 func (c *EEBus) isPaired(ski string) bool {
-	return c.pairedIndex(shipapi.NewServiceIdentity(ski, "", "")) >= 0
+	return ski != pairedSki && slices.ContainsFunc(c.paired, func(i shipapi.ServiceIdentity) bool {
+		return i.SKI == ski
+	})
 }
 
 // upsertPairing adds or updates a pairing and persists it (mux must be held)
@@ -458,11 +464,10 @@ func (c *EEBus) upsertPairing(identity shipapi.ServiceIdentity) {
 // clientsFor returns the devices registered for ski, including devices registered
 // without ski when ski is a SHIP-paired device (mux must be held)
 func (c *EEBus) clientsFor(ski string) []Device {
-	res := c.clients[ski]
 	if c.isPaired(ski) {
-		res = append(slices.Clone(res), c.clients[""]...)
+		return slices.Concat(c.clients[ski], c.clients[pairedSki])
 	}
-	return res
+	return c.clients[ski]
 }
 
 // RegisterDevice subscribes a device to the remote service with given ski.
@@ -476,7 +481,7 @@ func (c *EEBus) RegisterDevice(ski, ip string, device Device) error {
 	}
 
 	// trust for the paired device is established by pairing, not by configuration
-	if ski != "" {
+	if ski != pairedSki {
 		identity := shipapi.NewServiceIdentity(ski, "", "")
 		if len(ip) > 0 {
 			identity.IPv4 = ip
@@ -490,7 +495,7 @@ func (c *EEBus) RegisterDevice(ski, ip string, device Device) error {
 
 	// the remote service may already be connected
 	connected := c.connected[ski]
-	if ski == "" {
+	if ski == pairedSki {
 		connected = slices.ContainsFunc(c.paired, func(i shipapi.ServiceIdentity) bool {
 			return i.SKI != "" && c.connected[i.SKI]
 		})
@@ -510,7 +515,7 @@ func (c *EEBus) RegisterDevice(ski, ip string, device Device) error {
 // learn its remote entity and report "not connected" (mux must be held).
 func (c *EEBus) replayUseCases(ski string, device Device) {
 	match := func(remote string) bool { return remote == ski }
-	if ski == "" {
+	if ski == pairedSki {
 		// the paired device registers without ski, see clientsFor
 		match = func(remote string) bool {
 			return c.connected[remote] && c.isPaired(remote)
@@ -545,8 +550,8 @@ func (c *EEBus) UnregisterDevice(ski string, device Device) {
 			// which calls back into evcc's connect(ski, false) — and that needs to
 			// acquire c.mux. Holding c.mux across this cross-layer call would
 			// deadlock the same goroutine on its own non-reentrant mutex. See #28942.
-			// The paired device (empty ski) stays trusted until unpaired.
-			if ski != "" {
+			// The paired device stays trusted until unpaired.
+			if ski != pairedSki {
 				defer c.service.UnregisterRemoteService(shipapi.NewServiceIdentity(ski, "", ""))
 			}
 		}

--- a/server/eebus/eebus.go
+++ b/server/eebus/eebus.go
@@ -684,7 +684,8 @@ func (c *EEBus) ServiceAutoTrusted(service eebusapi.ServiceInterface, identity s
 	// registered without ski; wake them now that the device is paired
 	var clients []Device
 	if c.connected[identity.SKI] {
-		clients = c.clientsFor(identity.SKI)
+		// clone, the result may alias c.clients but is used after unlocking
+		clients = slices.Clone(c.clientsFor(identity.SKI))
 	}
 	c.mux.Unlock()
 

--- a/server/eebus/replay_test.go
+++ b/server/eebus/replay_test.go
@@ -1,0 +1,115 @@
+package eebus
+
+import (
+	"testing"
+
+	eebusapi "github.com/enbility/eebus-go/api"
+	eebusmocks "github.com/enbility/eebus-go/mocks"
+	"github.com/enbility/eebus-go/usecases/cem/ohpcf"
+	shipapi "github.com/enbility/ship-go/api"
+	spineapi "github.com/enbility/spine-go/api"
+	spinemocks "github.com/enbility/spine-go/mocks"
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingDevice records the use case events it receives
+type recordingDevice struct {
+	mockDevice
+	events []eebusapi.EventType
+}
+
+func (d *recordingDevice) UseCaseEvent(_ spineapi.DeviceRemoteInterface, _ spineapi.EntityRemoteInterface, event eebusapi.EventType) {
+	d.events = append(d.events, event)
+}
+
+// remoteEntity returns an entity mock belonging to a remote device with the given ski
+func remoteEntity(t *testing.T, ski string) spineapi.EntityRemoteInterface {
+	t.Helper()
+
+	remote := spinemocks.NewDeviceRemoteInterface(t)
+	remote.EXPECT().Ski().Return(ski).Maybe()
+
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	entity.EXPECT().Device().Return(remote).Maybe()
+
+	return entity
+}
+
+// registering a second device for an already connected ski must re-state the use
+// case support, otherwise the config UI device test reports "not connected"
+func TestRegisterDeviceReplaysUseCases(t *testing.T) {
+	const ski = "aabbcc"
+
+	uc := eebusmocks.NewUseCaseInterface(t)
+	uc.EXPECT().RemoteEntitiesScenarios().Return([]eebusapi.RemoteEntityScenarios{
+		{Entity: remoteEntity(t, ski)},
+		{Entity: remoteEntity(t, "ddeeff")}, // other device, must not be replayed
+	}).Once()
+
+	service := eebusmocks.NewServiceInterface(t)
+	service.EXPECT().RegisterRemoteService(shipapi.NewServiceIdentity(ski, "", "")).Once()
+
+	c := &EEBus{
+		log:       util.NewLogger("test"),
+		service:   service,
+		clients:   make(map[string][]Device),
+		connected: map[string]bool{ski: true},
+		useCases:  []useCase{{uc, ohpcf.UseCaseSupportUpdate}},
+	}
+
+	dev := new(recordingDevice)
+	require.NoError(t, c.RegisterDevice(ski, "", dev))
+
+	assert.Equal(t, []eebusapi.EventType{ohpcf.UseCaseSupportUpdate}, dev.events)
+}
+
+// the device paired via the SHIP Pairing Service registers without ski, so the
+// replay must resolve the remote through the pairing list
+func TestRegisterDevicePairedReplaysUseCases(t *testing.T) {
+	const ski = "aabbcc"
+
+	uc := eebusmocks.NewUseCaseInterface(t)
+	uc.EXPECT().RemoteEntitiesScenarios().Return([]eebusapi.RemoteEntityScenarios{
+		{Entity: remoteEntity(t, ski)},
+		{Entity: remoteEntity(t, "ddeeff")}, // connected, but not paired
+	}).Once()
+
+	c := &EEBus{
+		log:       util.NewLogger("test"),
+		ski:       "hostski", // the empty registration ski must not match the host
+		service:   eebusmocks.NewServiceInterface(t),
+		clients:   make(map[string][]Device),
+		connected: map[string]bool{ski: true, "ddeeff": true},
+		paired:    []shipapi.ServiceIdentity{shipapi.NewServiceIdentity(ski, "", "")},
+		useCases:  []useCase{{uc, ohpcf.UseCaseSupportUpdate}},
+	}
+
+	dev := new(recordingDevice)
+	require.NoError(t, c.RegisterDevice("", "", dev))
+
+	assert.Equal(t, []eebusapi.EventType{ohpcf.UseCaseSupportUpdate}, dev.events)
+}
+
+// a device registering for a ski that is not connected yet gets its use case
+// state from the regular event flow, replaying stale entities would be wrong
+func TestRegisterDeviceDisconnectedNoReplay(t *testing.T) {
+	const ski = "aabbcc"
+
+	service := eebusmocks.NewServiceInterface(t)
+	service.EXPECT().RegisterRemoteService(shipapi.NewServiceIdentity(ski, "", "")).Once()
+
+	c := &EEBus{
+		log:       util.NewLogger("test"),
+		service:   service,
+		clients:   make(map[string][]Device),
+		connected: make(map[string]bool),
+		useCases:  []useCase{{eebusmocks.NewUseCaseInterface(t), ohpcf.UseCaseSupportUpdate}},
+	}
+
+	dev := new(recordingDevice)
+	require.NoError(t, c.RegisterDevice(ski, "", dev))
+
+	assert.Empty(t, dev.events)
+}


### PR DESCRIPTION
follow-up to #33386, replaces #33423

The config UI device test of an EEBus device that is already running fails with `chargeStatus: not connected` (Vaillant aroTHERM, [discussion 25058](https://github.com/evcc-io/evcc/discussions/25058#discussioncomment-18249797)). `RegisterDevice` replays the *connection* state to a device that registers for an already connected ski, but not the *use case* state — eebus-go emits `UseCaseSupportUpdate` only on notification, and discovery ran once at startup for the live instance. The test instance therefore never learns its remote entity, `WaitUseCase` runs into its timeout and `Status()` reports not connected.

Same fix as #33423, which was merged before the cleanup pass on that branch landed and has since been reverted on master.

- `RegisterDevice` now re-states the use case support of an already connected remote to the newly registered device, from `RemoteEntitiesScenarios()`
- the use case list gained the matching support event per use case, so the replay is generic and covers meter and charger alike
- `clientsFor` and the replay reuse the existing `pairedIndex` helper instead of repeating the pairing lookup inline
- added coverage for the paired (empty ski) replay path, which resolves the remote through the pairing list

🤖 Generated with [Claude Code](https://claude.com/claude-code)