### PR TITLE
Huawei EMMA: fix grid import/export energy registers

### DIFF
--- a/templates/definition/meter/huawei-emma.yaml
+++ b/templates/definition/meter/huawei-emma.yaml
@@ -26,7 +26,16 @@ render: |
     id: 0
     uri: {{ joinHostPort .host .port }}
     register:
-      address: 31679 # Total negative active energy of built-in electric energy sensor
+      address: 31687 # Total positive active energy of built-in electric energy sensor (grid import)
+      type: holding
+      decode: int64
+    scale: 0.01
+  returnenergy:
+    source: modbus
+    id: 0
+    uri: {{ joinHostPort .host .port }}
+    register:
+      address: 31679 # Total negative active energy of built-in electric energy sensor (grid export)
       type: holding
       decode: int64
     scale: 0.01


### PR DESCRIPTION
Fix #33349

Register 31679 (total negative active energy) is the EMMA export counter but was mapped to grid `energy` (import). With no `returnenergy` register, return energy was integrated from power, so import and export tracked the same physical flow and real grid import was never recorded.

Reporter's data confirms it: evcc hourly `grid.energy` matched FusionSolar Netzeinspeisung exactly (5.61 vs 5.60 kWh at 13:00), while 0.89 kWh Netzbezug at 10:00 was missing.

- `energy`: 31687, total positive active energy (import)
- `returnenergy`: 31679, total negative active energy (export)

Register semantics per Huawei EMMA Modbus map (also used by huawei-solar-lib).

Not verified on hardware. Existing persisted meter totals rebaseline on first read, no migration needed. Historic rows stay wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
