### PR TITLE
Atmoce: add discharge and modbus block reads

### DIFF
--- a/meter/template_test.go
+++ b/meter/template_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util/templates"
 	"github.com/evcc-io/evcc/util/test"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v4"
 )
 
 var acceptable = []string{
@@ -47,4 +49,29 @@ func TestTemplates(t *testing.T) {
 			t.Error(err)
 		}
 	})
+}
+
+func TestAtmoceBatteryModes(t *testing.T) {
+	for _, firmware := range []string{"<01.01.00.28.15", ">=01.01.00.28.15"} {
+		t.Run(firmware, func(t *testing.T) {
+			tmpl, err := templates.ByName(templates.Meter, "atmoce")
+			require.NoError(t, err)
+			data, _, err := tmpl.RenderResult(templates.Meter, templates.RenderModeInstance, map[string]any{
+				"usage": "battery", "firmware": firmware, "modbus": "tcpip", "host": "localhost", "port": 15020,
+			})
+			require.NoError(t, err)
+			var conf map[string]any
+			require.NoError(t, yaml.Unmarshal(data, &conf))
+			require.NotContains(t, conf, "batterymodes")
+			delete(conf, "type")
+
+			m, err := NewConfigurableFromConfig(t.Context(), conf)
+			require.NoError(t, err)
+			ctrl, ok := api.Cap[api.BatteryController](m)
+			require.True(t, ok)
+			require.Equal(t, []api.BatteryMode{
+				api.BatteryNormal, api.BatteryHold, api.BatteryCharge, api.BatteryHoldCharge, api.BatteryDischarge,
+			}, ctrl.BatteryModes())
+		})
+	}
 }

--- a/meter/template_test.go
+++ b/meter/template_test.go
@@ -6,8 +6,6 @@ import (
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util/templates"
 	"github.com/evcc-io/evcc/util/test"
-	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v4"
 )
 
 var acceptable = []string{
@@ -49,29 +47,4 @@ func TestTemplates(t *testing.T) {
 			t.Error(err)
 		}
 	})
-}
-
-func TestAtmoceBatteryModes(t *testing.T) {
-	for _, firmware := range []string{"<01.01.00.28.15", ">=01.01.00.28.15"} {
-		t.Run(firmware, func(t *testing.T) {
-			tmpl, err := templates.ByName(templates.Meter, "atmoce")
-			require.NoError(t, err)
-			data, _, err := tmpl.RenderResult(templates.Meter, templates.RenderModeInstance, map[string]any{
-				"usage": "battery", "firmware": firmware, "modbus": "tcpip", "host": "localhost", "port": 15020,
-			})
-			require.NoError(t, err)
-			var conf map[string]any
-			require.NoError(t, yaml.Unmarshal(data, &conf))
-			require.NotContains(t, conf, "batterymodes")
-			delete(conf, "type")
-
-			m, err := NewConfigurableFromConfig(t.Context(), conf)
-			require.NoError(t, err)
-			ctrl, ok := api.Cap[api.BatteryController](m)
-			require.True(t, ok)
-			require.Equal(t, []api.BatteryMode{
-				api.BatteryNormal, api.BatteryHold, api.BatteryCharge, api.BatteryHoldCharge, api.BatteryDischarge,
-			}, ctrl.BatteryModes())
-		})
-	}
 }

--- a/templates/definition/meter/atmoce.yaml
+++ b/templates/definition/meter/atmoce.yaml
@@ -60,6 +60,9 @@ render: |
       address: 60073 # Grid Active Power (kW * 1000)
       type: holding
       decode: int32
+    block: # 60069-60074
+      register: 60069
+      count: 6
     scale: 1
   energy:
     source: modbus
@@ -68,6 +71,9 @@ render: |
       address: 60184 # Cumulative Electricity Purchase Volume (kWh * 100)
       type: holding
       decode: uint64
+    block: # 60160-60189
+      register: 60160
+      count: 30
     scale: 0.01
   returnenergy:
     source: modbus
@@ -76,6 +82,9 @@ render: |
       address: 60178 # Cumulative Electricity Sales Volume (kWh * 100)
       type: holding
       decode: uint64
+    block: # 60160-60189
+      register: 60160
+      count: 30
     scale: 0.01
   currents:
   - source: modbus
@@ -84,9 +93,9 @@ render: |
       address: 60090 # Phase A Grid Current (A * 100)
       type: holding
       decode: int16
-    block: # 60089-60094
+    block: # 60089-60095
       register: 60089
-      count: 6
+      count: 7
     scale: 0.01
   - source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -94,9 +103,9 @@ render: |
       address: 60092 # Phase B Grid Current (A * 100)
       type: holding
       decode: int16
-    block: # 60089-60094
+    block: # 60089-60095
       register: 60089
-      count: 6
+      count: 7
     scale: 0.01
   - source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -104,9 +113,9 @@ render: |
       address: 60094 # Phase C Grid Current (A * 100)
       type: holding
       decode: int16
-    block: # 60089-60094
+    block: # 60089-60095
       register: 60089
-      count: 6
+      count: 7
     scale: 0.01
   voltages:
   - source: modbus
@@ -115,9 +124,9 @@ render: |
       address: 60089 # Phase A Grid Voltage (V * 10)
       type: holding
       decode: uint16
-    block: # 60089-60094
+    block: # 60089-60095
       register: 60089
-      count: 6
+      count: 7
     scale: 0.1
   - source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -125,9 +134,9 @@ render: |
       address: 60091 # Phase B Grid Voltage (V * 10)
       type: holding
       decode: uint16
-    block: # 60089-60094
+    block: # 60089-60095
       register: 60089
-      count: 6
+      count: 7
     scale: 0.1
   - source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -135,9 +144,9 @@ render: |
       address: 60093 # Phase C Grid Voltage (V * 10)
       type: holding
       decode: uint16
-    block: # 60089-60094
+    block: # 60089-60095
       register: 60089
-      count: 6
+      count: 7
     scale: 0.1
   {{- end }}
   {{- if eq .usage "pv" }}
@@ -148,6 +157,9 @@ render: |
       address: 60069 # Photovoltaic Power Output (kW * 1000)
       type: holding
       decode: uint32
+    block: # 60069-60074
+      register: 60069
+      count: 6
     scale: 1
   energy:
     source: modbus
@@ -156,6 +168,9 @@ render: |
       address: 60160 # Cumulative Photovoltaic Power Generation (kWh * 100)
       type: holding
       decode: uint64
+    block: # 60160-60189
+      register: 60160
+      count: 30
     scale: 0.01
   maxacpower: {{ .maxacpower }}
   {{- if not ( eq .firmware "<01.01.00.28.15" ) }}
@@ -236,6 +251,9 @@ render: |
       address: 60071 # Energy Storage Charging/Discharging Power (kW * 1000)
       type: holding
       decode: int32
+    block: # 60069-60074
+      register: 60069
+      count: 6
     scale: 1
   energy:
     source: modbus
@@ -244,6 +262,9 @@ render: |
       address: 60172 # Cumulative Energy Storage Discharging Capacity (kWh * 100)
       type: holding
       decode: uint64
+    block: # 60160-60189
+      register: 60160
+      count: 30
     scale: 0.01
   returnenergy:
     source: modbus
@@ -252,6 +273,9 @@ render: |
       address: 60166 # Cumulative Energy Storage Charging Capacity (kWh * 100)
       type: holding
       decode: uint64
+    block: # 60160-60189
+      register: 60160
+      count: 30
     scale: 0.01
   maxchargepower:
     source: modbus
@@ -276,6 +300,9 @@ render: |
       address: 60095 # Energy Storage SOC (%)
       type: holding
       decode: uint16
+    block: # 60089-60095
+      register: 60089
+      count: 7
     scale: 1
   batterymode:
     source: switch

--- a/templates/definition/meter/atmoce.yaml
+++ b/templates/definition/meter/atmoce.yaml
@@ -373,6 +373,37 @@ render: |
                   address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
                   type: writeholding
                   decode: uint16
+          - case: 5 # discharge -> Enable grid discharging with minimum target soc (will be stopped by evcc)
+            set:
+              source: sequence
+              set:
+                - source: const
+                  value: {{ .minsoc }}
+                  set:
+                    source: modbus
+                    {{- include "modbus" . | indent 18 }}
+                    register:
+                      address: 60312 # Energy Storage Forced Charging/Discharging Target SOC (%)
+                      type: writeholding
+                      decode: uint16
+                - source: const
+                  value: 0
+                  set:
+                    source: modbus
+                    {{- include "modbus" . | indent 18 }}
+                    register:
+                      address: 60311 # Energy Storage Forced Charging/Discharging Mode (0 = Target SOC, 1 = Charging/discharging duration)
+                      type: writeholding
+                      decode: uint16
+                - source: const
+                  value: 1
+                  set:
+                    source: modbus
+                    {{- include "modbus" . | indent 18 }}
+                    register:
+                      address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
+                      type: writeholding
+                      decode: uint16
       {{- if eq .firmware ">=01.01.00.28.15" }}
       - source: switch
         switch:

--- a/templates/definition/meter/atmoce.yaml
+++ b/templates/definition/meter/atmoce.yaml
@@ -186,7 +186,7 @@ render: |
             {{- include "modbus" . | indent 10 }}
             register:
               address: 60322 # Photovoltaic Maximum Power (kW * 1000)
-              type: writeholdings
+              type: writemultiple
               encoding: uint32
     default:
       source: go
@@ -207,7 +207,7 @@ render: |
             {{- include "modbus" . | indent 10 }}
             register:
               address: 60322 # Photovoltaic Maximum Power (kW * 1000)
-              type: writeholdings
+              type: writemultiple
               encoding: uint32
   curtailed: # the power limit is expressed as percent of nominal AC power
     source: go
@@ -318,7 +318,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
-                  type: writeholding
+                  type: writemultiple
                   decode: uint16
             {{- if eq .firmware ">=01.01.00.28.15" }}
             - source: const
@@ -328,7 +328,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60318 # Energy Storage Maximum Charging Power (kW * 1000)
-                  type: writeholdings
+                  type: writemultiple
                   decode: uint32
             - source: const
               value: 0xFFFFFFFF # No limit
@@ -337,7 +337,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60320 # Energy Storage Maximum Discharging Power (kW * 1000)
-                  type: writeholdings
+                  type: writemultiple
                   decode: uint32
             {{- end }}
       - case: 2 # hold -> No discharging
@@ -351,7 +351,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
-                  type: writeholding
+                  type: writemultiple
                   decode: uint16
             {{- if eq .firmware ">=01.01.00.28.15" }}
             - source: const
@@ -361,7 +361,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60318 # Energy Storage Maximum Charging Power (kW * 1000)
-                  type: writeholdings
+                  type: writemultiple
                   decode: uint32
             - source: const
               value: 0 # Set discharge limit to 0W
@@ -370,7 +370,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60320 # Energy Storage Maximum Discharging Power (kW * 1000)
-                  type: writeholdings
+                  type: writemultiple
                   decode: uint32
             {{- end }}
       - case: 3 # charge -> Enable grid charging with maximum target soc (will be stopped by evcc)
@@ -384,7 +384,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60312 # Energy Storage Forced Charging/Discharging Target SOC (%)
-                  type: writeholding
+                  type: writemultiple
                   decode: uint16
             - source: const
               value: 0
@@ -393,7 +393,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60311 # Energy Storage Forced Charging/Discharging Mode (0 = Target SOC, 1 = Charging/discharging duration)
-                  type: writeholding
+                  type: writemultiple
                   decode: uint16
             - source: const
               value: 0
@@ -402,7 +402,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
-                  type: writeholding
+                  type: writemultiple
                   decode: uint16
             {{- if eq .firmware ">=01.01.00.28.15" }}
             - source: const
@@ -412,7 +412,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60318 # Energy Storage Maximum Charging Power (kW * 1000)
-                  type: writeholdings
+                  type: writemultiple
                   decode: uint32
             - source: const
               value: 0xFFFFFFFF # No limit
@@ -421,7 +421,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60320 # Energy Storage Maximum Discharging Power (kW * 1000)
-                  type: writeholdings
+                  type: writemultiple
                   decode: uint32
             {{- end }}
       - case: 4 # holdcharge -> No charging
@@ -435,7 +435,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
-                  type: writeholding
+                  type: writemultiple
                   decode: uint16
             {{- if eq .firmware ">=01.01.00.28.15" }}
             - source: const
@@ -445,7 +445,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60318 # Energy Storage Maximum Charging Power (kW * 1000)
-                  type: writeholdings
+                  type: writemultiple
                   decode: uint32
             - source: const
               value: 0xFFFFFFFF # No limit
@@ -454,7 +454,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60320 # Energy Storage Maximum Discharging Power (kW * 1000)
-                  type: writeholdings
+                  type: writemultiple
                   decode: uint32
             {{- end }}
       - case: 5 # discharge -> Enable grid discharging with minimum target soc (will be stopped by evcc)
@@ -468,7 +468,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60312 # Energy Storage Forced Charging/Discharging Target SOC (%)
-                  type: writeholding
+                  type: writemultiple
                   decode: uint16
             - source: const
               value: 0
@@ -477,7 +477,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60311 # Energy Storage Forced Charging/Discharging Mode (0 = Target SOC, 1 = Charging/discharging duration)
-                  type: writeholding
+                  type: writemultiple
                   decode: uint16
             - source: const
               value: 1
@@ -486,7 +486,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
-                  type: writeholding
+                  type: writemultiple
                   decode: uint16
             {{- if eq .firmware ">=01.01.00.28.15" }}
             - source: const
@@ -496,7 +496,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60318 # Energy Storage Maximum Charging Power (kW * 1000)
-                  type: writeholdings
+                  type: writemultiple
                   decode: uint32
             - source: const
               value: 0xFFFFFFFF # No limit
@@ -505,7 +505,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60320 # Energy Storage Maximum Discharging Power (kW * 1000)
-                  type: writeholdings
+                  type: writemultiple
                   decode: uint32
             {{- end }}
   {{- if not ( eq .firmware "<01.01.00.28.15" ) }}
@@ -522,7 +522,7 @@ render: |
           {{- include "modbus" . | indent 8 }}
           register:
             address: 60326 # Grid Maximum Import Power (kW * 1000)
-            type: writeholdings
+            type: writemultiple
             encoding: uint32
     else:
       source: convert
@@ -535,7 +535,7 @@ render: |
           {{- include "modbus" . | indent 8 }}
           register:
             address: 60326 # Grid Maximum Import Power (kW * 1000)
-            type: writeholdings
+            type: writemultiple
             encoding: uint32
   dimmed:
     source: go

--- a/templates/definition/meter/atmoce.yaml
+++ b/templates/definition/meter/atmoce.yaml
@@ -186,7 +186,7 @@ render: |
             {{- include "modbus" . | indent 10 }}
             register:
               address: 60322 # Photovoltaic Maximum Power (kW * 1000)
-              type: writemultiple
+              type: writeholdings
               encoding: uint32
     default:
       source: go
@@ -207,7 +207,7 @@ render: |
             {{- include "modbus" . | indent 10 }}
             register:
               address: 60322 # Photovoltaic Maximum Power (kW * 1000)
-              type: writemultiple
+              type: writeholdings
               encoding: uint32
   curtailed: # the power limit is expressed as percent of nominal AC power
     source: go
@@ -318,7 +318,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
-                  type: writemultiple
+                  type: writeholding
                   decode: uint16
             {{- if eq .firmware ">=01.01.00.28.15" }}
             - source: const
@@ -328,7 +328,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60318 # Energy Storage Maximum Charging Power (kW * 1000)
-                  type: writemultiple
+                  type: writeholdings
                   decode: uint32
             - source: const
               value: 0xFFFFFFFF # No limit
@@ -337,7 +337,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60320 # Energy Storage Maximum Discharging Power (kW * 1000)
-                  type: writemultiple
+                  type: writeholdings
                   decode: uint32
             {{- end }}
       - case: 2 # hold -> No discharging
@@ -351,7 +351,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
-                  type: writemultiple
+                  type: writeholding
                   decode: uint16
             {{- if eq .firmware ">=01.01.00.28.15" }}
             - source: const
@@ -361,7 +361,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60318 # Energy Storage Maximum Charging Power (kW * 1000)
-                  type: writemultiple
+                  type: writeholdings
                   decode: uint32
             - source: const
               value: 0 # Set discharge limit to 0W
@@ -370,7 +370,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60320 # Energy Storage Maximum Discharging Power (kW * 1000)
-                  type: writemultiple
+                  type: writeholdings
                   decode: uint32
             {{- end }}
       - case: 3 # charge -> Enable grid charging with maximum target soc (will be stopped by evcc)
@@ -384,7 +384,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60312 # Energy Storage Forced Charging/Discharging Target SOC (%)
-                  type: writemultiple
+                  type: writeholding
                   decode: uint16
             - source: const
               value: 0
@@ -393,7 +393,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60311 # Energy Storage Forced Charging/Discharging Mode (0 = Target SOC, 1 = Charging/discharging duration)
-                  type: writemultiple
+                  type: writeholding
                   decode: uint16
             - source: const
               value: 0
@@ -402,7 +402,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
-                  type: writemultiple
+                  type: writeholding
                   decode: uint16
             {{- if eq .firmware ">=01.01.00.28.15" }}
             - source: const
@@ -412,7 +412,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60318 # Energy Storage Maximum Charging Power (kW * 1000)
-                  type: writemultiple
+                  type: writeholdings
                   decode: uint32
             - source: const
               value: 0xFFFFFFFF # No limit
@@ -421,7 +421,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60320 # Energy Storage Maximum Discharging Power (kW * 1000)
-                  type: writemultiple
+                  type: writeholdings
                   decode: uint32
             {{- end }}
       - case: 4 # holdcharge -> No charging
@@ -435,7 +435,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
-                  type: writemultiple
+                  type: writeholding
                   decode: uint16
             {{- if eq .firmware ">=01.01.00.28.15" }}
             - source: const
@@ -445,7 +445,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60318 # Energy Storage Maximum Charging Power (kW * 1000)
-                  type: writemultiple
+                  type: writeholdings
                   decode: uint32
             - source: const
               value: 0xFFFFFFFF # No limit
@@ -454,7 +454,7 @@ render: |
                 {{- include "modbus" . | indent 14 }}
                 register:
                   address: 60320 # Energy Storage Maximum Discharging Power (kW * 1000)
-                  type: writemultiple
+                  type: writeholdings
                   decode: uint32
             {{- end }}
   {{- if not ( eq .firmware "<01.01.00.28.15" ) }}
@@ -471,7 +471,7 @@ render: |
           {{- include "modbus" . | indent 8 }}
           register:
             address: 60326 # Grid Maximum Import Power (kW * 1000)
-            type: writemultiple
+            type: writeholdings
             encoding: uint32
     else:
       source: convert
@@ -484,7 +484,7 @@ render: |
           {{- include "modbus" . | indent 8 }}
           register:
             address: 60326 # Grid Maximum Import Power (kW * 1000)
-            type: writemultiple
+            type: writeholdings
             encoding: uint32
   dimmed:
     source: go

--- a/templates/definition/meter/atmoce.yaml
+++ b/templates/definition/meter/atmoce.yaml
@@ -304,15 +304,14 @@ render: |
       register: 60089
       count: 7
     scale: 1
-  batterymodes: ["normal", "hold", "charge", "holdcharge", "discharge"]
   batterymode:
-    source: sequence
-    set:
-      - source: switch
-        switch:
-          - case: 1 # normal
-            set:
-              source: const
+    source: switch
+    switch:
+      - case: 1 # normal
+        set:
+          source: sequence
+          set:
+            - source: const
               value: 2
               set:
                 source: modbus
@@ -321,140 +320,7 @@ render: |
                   address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
                   type: writeholding
                   decode: uint16
-          - case: 2 # hold -> No discharging
-            set:
-              source: const
-              value: {{ if eq .firmware "<01.01.00.28.15" }}99{{ else }}2{{ end }}
-              set:
-                source: modbus
-                {{- include "modbus" . | indent 14 }}
-                register:
-                  address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
-                  type: writeholding
-                  decode: uint16
-          - case: 3 # charge -> Enable grid charging with maximum target soc (will be stopped by evcc)
-            set:
-              source: sequence
-              set:
-                - source: const
-                  value: {{ .maxsoc }}
-                  set:
-                    source: modbus
-                    {{- include "modbus" . | indent 18 }}
-                    register:
-                      address: 60312 # Energy Storage Forced Charging/Discharging Target SOC (%)
-                      type: writeholding
-                      decode: uint16
-                - source: const
-                  value: 0
-                  set:
-                    source: modbus
-                    {{- include "modbus" . | indent 18 }}
-                    register:
-                      address: 60311 # Energy Storage Forced Charging/Discharging Mode (0 = Target SOC, 1 = Charging/discharging duration)
-                      type: writeholding
-                      decode: uint16
-                - source: const
-                  value: 0
-                  set:
-                    source: modbus
-                    {{- include "modbus" . | indent 18 }}
-                    register:
-                      address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
-                      type: writeholding
-                      decode: uint16
-          - case: 4 # holdcharge -> No charging
-            set:
-              source: const
-              value: {{ if eq .firmware "<01.01.00.28.15" }}99{{ else }}2{{ end }}
-              set:
-                source: modbus
-                {{- include "modbus" . | indent 14 }}
-                register:
-                  address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
-                  type: writeholding
-                  decode: uint16
-          - case: 5 # discharge -> Enable grid discharging with minimum target soc (will be stopped by evcc)
-            set:
-              source: sequence
-              set:
-                - source: const
-                  value: {{ .minsoc }}
-                  set:
-                    source: modbus
-                    {{- include "modbus" . | indent 18 }}
-                    register:
-                      address: 60312 # Energy Storage Forced Charging/Discharging Target SOC (%)
-                      type: writeholding
-                      decode: uint16
-                - source: const
-                  value: 0
-                  set:
-                    source: modbus
-                    {{- include "modbus" . | indent 18 }}
-                    register:
-                      address: 60311 # Energy Storage Forced Charging/Discharging Mode (0 = Target SOC, 1 = Charging/discharging duration)
-                      type: writeholding
-                      decode: uint16
-                - source: const
-                  value: 1
-                  set:
-                    source: modbus
-                    {{- include "modbus" . | indent 18 }}
-                    register:
-                      address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
-                      type: writeholding
-                      decode: uint16
-      {{- if eq .firmware ">=01.01.00.28.15" }}
-      - source: switch
-        switch:
-          - case: 2 # hold -> No discharging
-            set:
-              source: sequence
-              set:
-                - source: const
-                  value: 0xFFFFFFFF # No limit
-                  set:
-                    source: modbus
-                    {{- include "modbus" . | indent 18 }}
-                    register:
-                      address: 60318 # Energy Storage Maximum Charging Power (kW * 1000)
-                      type: writeholdings
-                      decode: uint32
-                - source: const
-                  value: 0 # Set discharge limit to 0W
-                  set:
-                    source: modbus
-                    {{- include "modbus" . | indent 18 }}
-                    register:
-                      address: 60320 # Energy Storage Maximum Discharging Power (kW * 1000)
-                      type: writeholdings
-                      decode: uint32
-          - case: 4 # holdcharge -> No charging
-            set:
-              source: sequence
-              set:
-                - source: const
-                  value: 0 # Set charge limit to 0W
-                  set:
-                    source: modbus
-                    {{- include "modbus" . | indent 18 }}
-                    register:
-                      address: 60318 # Energy Storage Maximum Charging Power (kW * 1000)
-                      type: writeholdings
-                      decode: uint32
-                - source: const
-                  value: 0xFFFFFFFF # No limit
-                  set:
-                    source: modbus
-                    {{- include "modbus" . | indent 18 }}
-                    register:
-                      address: 60320 # Energy Storage Maximum Discharging Power (kW * 1000)
-                      type: writeholdings
-                      decode: uint32
-        default:
-          source: sequence
-          set:
+            {{- if eq .firmware ">=01.01.00.28.15" }}
             - source: const
               value: 0xFFFFFFFF # No limit
               set:
@@ -473,7 +339,175 @@ render: |
                   address: 60320 # Energy Storage Maximum Discharging Power (kW * 1000)
                   type: writeholdings
                   decode: uint32
-      {{- end }}
+            {{- end }}
+      - case: 2 # hold -> No discharging
+        set:
+          source: sequence
+          set:
+            - source: const
+              value: {{ if eq .firmware "<01.01.00.28.15" }}99{{ else }}2{{ end }}
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 14 }}
+                register:
+                  address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
+                  type: writeholding
+                  decode: uint16
+            {{- if eq .firmware ">=01.01.00.28.15" }}
+            - source: const
+              value: 0xFFFFFFFF # No limit
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 14 }}
+                register:
+                  address: 60318 # Energy Storage Maximum Charging Power (kW * 1000)
+                  type: writeholdings
+                  decode: uint32
+            - source: const
+              value: 0 # Set discharge limit to 0W
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 14 }}
+                register:
+                  address: 60320 # Energy Storage Maximum Discharging Power (kW * 1000)
+                  type: writeholdings
+                  decode: uint32
+            {{- end }}
+      - case: 3 # charge -> Enable grid charging with maximum target soc (will be stopped by evcc)
+        set:
+          source: sequence
+          set:
+            - source: const
+              value: {{ .maxsoc }}
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 14 }}
+                register:
+                  address: 60312 # Energy Storage Forced Charging/Discharging Target SOC (%)
+                  type: writeholding
+                  decode: uint16
+            - source: const
+              value: 0
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 14 }}
+                register:
+                  address: 60311 # Energy Storage Forced Charging/Discharging Mode (0 = Target SOC, 1 = Charging/discharging duration)
+                  type: writeholding
+                  decode: uint16
+            - source: const
+              value: 0
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 14 }}
+                register:
+                  address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
+                  type: writeholding
+                  decode: uint16
+            {{- if eq .firmware ">=01.01.00.28.15" }}
+            - source: const
+              value: 0xFFFFFFFF # No limit
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 14 }}
+                register:
+                  address: 60318 # Energy Storage Maximum Charging Power (kW * 1000)
+                  type: writeholdings
+                  decode: uint32
+            - source: const
+              value: 0xFFFFFFFF # No limit
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 14 }}
+                register:
+                  address: 60320 # Energy Storage Maximum Discharging Power (kW * 1000)
+                  type: writeholdings
+                  decode: uint32
+            {{- end }}
+      - case: 4 # holdcharge -> No charging
+        set:
+          source: sequence
+          set:
+            - source: const
+              value: {{ if eq .firmware "<01.01.00.28.15" }}99{{ else }}2{{ end }}
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 14 }}
+                register:
+                  address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
+                  type: writeholding
+                  decode: uint16
+            {{- if eq .firmware ">=01.01.00.28.15" }}
+            - source: const
+              value: 0 # Set charge limit to 0W
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 14 }}
+                register:
+                  address: 60318 # Energy Storage Maximum Charging Power (kW * 1000)
+                  type: writeholdings
+                  decode: uint32
+            - source: const
+              value: 0xFFFFFFFF # No limit
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 14 }}
+                register:
+                  address: 60320 # Energy Storage Maximum Discharging Power (kW * 1000)
+                  type: writeholdings
+                  decode: uint32
+            {{- end }}
+      - case: 5 # discharge -> Enable grid discharging with minimum target soc (will be stopped by evcc)
+        set:
+          source: sequence
+          set:
+            - source: const
+              value: {{ .minsoc }}
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 14 }}
+                register:
+                  address: 60312 # Energy Storage Forced Charging/Discharging Target SOC (%)
+                  type: writeholding
+                  decode: uint16
+            - source: const
+              value: 0
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 14 }}
+                register:
+                  address: 60311 # Energy Storage Forced Charging/Discharging Mode (0 = Target SOC, 1 = Charging/discharging duration)
+                  type: writeholding
+                  decode: uint16
+            - source: const
+              value: 1
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 14 }}
+                register:
+                  address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
+                  type: writeholding
+                  decode: uint16
+            {{- if eq .firmware ">=01.01.00.28.15" }}
+            - source: const
+              value: 0xFFFFFFFF # No limit
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 14 }}
+                register:
+                  address: 60318 # Energy Storage Maximum Charging Power (kW * 1000)
+                  type: writeholdings
+                  decode: uint32
+            - source: const
+              value: 0xFFFFFFFF # No limit
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 14 }}
+                register:
+                  address: 60320 # Energy Storage Maximum Discharging Power (kW * 1000)
+                  type: writeholdings
+                  decode: uint32
+            {{- end }}
   {{- if not ( eq .firmware "<01.01.00.28.15" ) }}
   dim:
     source: ifelse

--- a/templates/definition/meter/atmoce.yaml
+++ b/templates/definition/meter/atmoce.yaml
@@ -304,6 +304,7 @@ render: |
       register: 60089
       count: 7
     scale: 1
+  batterymodes: ["normal", "hold", "charge", "holdcharge", "discharge"]
   batterymode:
     source: sequence
     set:

--- a/templates/definition/meter/atmoce.yaml
+++ b/templates/definition/meter/atmoce.yaml
@@ -305,13 +305,13 @@ render: |
       count: 7
     scale: 1
   batterymode:
-    source: switch
-    switch:
-      - case: 1 # normal
-        set:
-          source: sequence
-          set:
-            - source: const
+    source: sequence
+    set:
+      - source: switch
+        switch:
+          - case: 1 # normal
+            set:
+              source: const
               value: 2
               set:
                 source: modbus
@@ -320,31 +320,9 @@ render: |
                   address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
                   type: writeholding
                   decode: uint16
-            {{- if eq .firmware ">=01.01.00.28.15" }}
-            - source: const
-              value: 0xFFFFFFFF # No limit
-              set:
-                source: modbus
-                {{- include "modbus" . | indent 14 }}
-                register:
-                  address: 60318 # Energy Storage Maximum Charging Power (kW * 1000)
-                  type: writeholdings
-                  decode: uint32
-            - source: const
-              value: 0xFFFFFFFF # No limit
-              set:
-                source: modbus
-                {{- include "modbus" . | indent 14 }}
-                register:
-                  address: 60320 # Energy Storage Maximum Discharging Power (kW * 1000)
-                  type: writeholdings
-                  decode: uint32
-            {{- end }}
-      - case: 2 # hold -> No discharging
-        set:
-          source: sequence
-          set:
-            - source: const
+          - case: 2 # hold -> No discharging
+            set:
+              source: const
               value: {{ if eq .firmware "<01.01.00.28.15" }}99{{ else }}2{{ end }}
               set:
                 source: modbus
@@ -353,82 +331,40 @@ render: |
                   address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
                   type: writeholding
                   decode: uint16
-            {{- if eq .firmware ">=01.01.00.28.15" }}
-            - source: const
-              value: 0xFFFFFFFF # No limit
+          - case: 3 # charge -> Enable grid charging with maximum target soc (will be stopped by evcc)
+            set:
+              source: sequence
               set:
-                source: modbus
-                {{- include "modbus" . | indent 14 }}
-                register:
-                  address: 60318 # Energy Storage Maximum Charging Power (kW * 1000)
-                  type: writeholdings
-                  decode: uint32
-            - source: const
-              value: 0 # Set discharge limit to 0W
-              set:
-                source: modbus
-                {{- include "modbus" . | indent 14 }}
-                register:
-                  address: 60320 # Energy Storage Maximum Discharging Power (kW * 1000)
-                  type: writeholdings
-                  decode: uint32
-            {{- end }}
-      - case: 3 # charge -> Enable grid charging with maximum target soc (will be stopped by evcc)
-        set:
-          source: sequence
-          set:
-            - source: const
-              value: {{ .maxsoc }}
-              set:
-                source: modbus
-                {{- include "modbus" . | indent 14 }}
-                register:
-                  address: 60312 # Energy Storage Forced Charging/Discharging Target SOC (%)
-                  type: writeholding
-                  decode: uint16
-            - source: const
-              value: 0
-              set:
-                source: modbus
-                {{- include "modbus" . | indent 14 }}
-                register:
-                  address: 60311 # Energy Storage Forced Charging/Discharging Mode (0 = Target SOC, 1 = Charging/discharging duration)
-                  type: writeholding
-                  decode: uint16
-            - source: const
-              value: 0
-              set:
-                source: modbus
-                {{- include "modbus" . | indent 14 }}
-                register:
-                  address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
-                  type: writeholding
-                  decode: uint16
-            {{- if eq .firmware ">=01.01.00.28.15" }}
-            - source: const
-              value: 0xFFFFFFFF # No limit
-              set:
-                source: modbus
-                {{- include "modbus" . | indent 14 }}
-                register:
-                  address: 60318 # Energy Storage Maximum Charging Power (kW * 1000)
-                  type: writeholdings
-                  decode: uint32
-            - source: const
-              value: 0xFFFFFFFF # No limit
-              set:
-                source: modbus
-                {{- include "modbus" . | indent 14 }}
-                register:
-                  address: 60320 # Energy Storage Maximum Discharging Power (kW * 1000)
-                  type: writeholdings
-                  decode: uint32
-            {{- end }}
-      - case: 4 # holdcharge -> No charging
-        set:
-          source: sequence
-          set:
-            - source: const
+                - source: const
+                  value: {{ .maxsoc }}
+                  set:
+                    source: modbus
+                    {{- include "modbus" . | indent 18 }}
+                    register:
+                      address: 60312 # Energy Storage Forced Charging/Discharging Target SOC (%)
+                      type: writeholding
+                      decode: uint16
+                - source: const
+                  value: 0
+                  set:
+                    source: modbus
+                    {{- include "modbus" . | indent 18 }}
+                    register:
+                      address: 60311 # Energy Storage Forced Charging/Discharging Mode (0 = Target SOC, 1 = Charging/discharging duration)
+                      type: writeholding
+                      decode: uint16
+                - source: const
+                  value: 0
+                  set:
+                    source: modbus
+                    {{- include "modbus" . | indent 18 }}
+                    register:
+                      address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
+                      type: writeholding
+                      decode: uint16
+          - case: 4 # holdcharge -> No charging
+            set:
+              source: const
               value: {{ if eq .firmware "<01.01.00.28.15" }}99{{ else }}2{{ end }}
               set:
                 source: modbus
@@ -437,9 +373,58 @@ render: |
                   address: 60310 # Energy Storage Forced Charging/Discharging (0 = Forced charging, 1 = Forced discharging, 2 = Exit forced charging/discharging, 99 = Pause)
                   type: writeholding
                   decode: uint16
-            {{- if eq .firmware ">=01.01.00.28.15" }}
+      {{- if eq .firmware ">=01.01.00.28.15" }}
+      - source: switch
+        switch:
+          - case: 2 # hold -> No discharging
+            set:
+              source: sequence
+              set:
+                - source: const
+                  value: 0xFFFFFFFF # No limit
+                  set:
+                    source: modbus
+                    {{- include "modbus" . | indent 18 }}
+                    register:
+                      address: 60318 # Energy Storage Maximum Charging Power (kW * 1000)
+                      type: writeholdings
+                      decode: uint32
+                - source: const
+                  value: 0 # Set discharge limit to 0W
+                  set:
+                    source: modbus
+                    {{- include "modbus" . | indent 18 }}
+                    register:
+                      address: 60320 # Energy Storage Maximum Discharging Power (kW * 1000)
+                      type: writeholdings
+                      decode: uint32
+          - case: 4 # holdcharge -> No charging
+            set:
+              source: sequence
+              set:
+                - source: const
+                  value: 0 # Set charge limit to 0W
+                  set:
+                    source: modbus
+                    {{- include "modbus" . | indent 18 }}
+                    register:
+                      address: 60318 # Energy Storage Maximum Charging Power (kW * 1000)
+                      type: writeholdings
+                      decode: uint32
+                - source: const
+                  value: 0xFFFFFFFF # No limit
+                  set:
+                    source: modbus
+                    {{- include "modbus" . | indent 18 }}
+                    register:
+                      address: 60320 # Energy Storage Maximum Discharging Power (kW * 1000)
+                      type: writeholdings
+                      decode: uint32
+        default:
+          source: sequence
+          set:
             - source: const
-              value: 0 # Set charge limit to 0W
+              value: 0xFFFFFFFF # No limit
               set:
                 source: modbus
                 {{- include "modbus" . | indent 14 }}
@@ -456,7 +441,7 @@ render: |
                   address: 60320 # Energy Storage Maximum Discharging Power (kW * 1000)
                   type: writeholdings
                   decode: uint32
-            {{- end }}
+      {{- end }}
   {{- if not ( eq .firmware "<01.01.00.28.15" ) }}
   dim:
     source: ifelse


### PR DESCRIPTION
Follow-up to #31995, replaces #32447.

Adds forced battery discharge and shared Modbus block reads to the Atmoce template.

- Keep the outer battery-mode switch so supported modes are detected automatically, without a separate `batterymodes` list.
- Add discharge as case 5, preserving ordered register writes and firmware-specific power limits within each mode.
- Share reads for power, energy, and grid measurements/SoC.

🤖 Generated with [OpenCode](https://opencode.ai)
