### PR TITLE
Loadpoint: treat alwaysCharge as dynamic config

### DIFF
--- a/core/loadpoint/config.go
+++ b/core/loadpoint/config.go
@@ -19,6 +19,7 @@ type DynamicConfig struct {
 	// dynamic config
 	Title                    string    `json:"title"`
 	DefaultMode              string    `json:"defaultMode"`
+	AlwaysCharge             string    `json:"alwaysCharge"`
 	Priority                 int       `json:"priority"`
 	PhasesConfigured         int       `json:"phasesConfigured"`
 	MinCurrent               float64   `json:"minCurrent"`
@@ -85,6 +86,13 @@ func (payload DynamicConfig) Apply(lp API) error {
 	mode, err := api.ChargeModeString(payload.DefaultMode)
 	if err == nil {
 		lp.SetDefaultMode(mode)
+	}
+
+	// always charge is optional; ignore "not supported" for devices without current control
+	if payload.AlwaysCharge != "" {
+		if ac, acErr := api.AlwaysChargeString(payload.AlwaysCharge); acErr == nil {
+			_ = lp.SetAlwaysCharge(ac)
+		}
 	}
 
 	if err == nil {

--- a/core/loadpoint/config.go
+++ b/core/loadpoint/config.go
@@ -90,7 +90,7 @@ func (payload DynamicConfig) Apply(lp API) error {
 
 	// always charge is optional; ignore "not supported" for devices without current control
 	if payload.AlwaysCharge != "" {
-		if ac, acErr := api.AlwaysChargeString(payload.AlwaysCharge); acErr == nil {
+		if ac, err := api.AlwaysChargeString(payload.AlwaysCharge); err == nil {
 			_ = lp.SetAlwaysCharge(ac)
 		}
 	}

--- a/core/loadpoint/config_test.go
+++ b/core/loadpoint/config_test.go
@@ -23,3 +23,20 @@ func TestSplitConfigUI(t *testing.T) {
 	assert.Equal(t, 45.0, dynamic.UI.MaxTemp)
 	assert.NotContains(t, other, "ui")
 }
+
+// TestSplitConfigAlwaysCharge guards that alwaysCharge is treated as dynamic
+// config. It is persisted per loadpoint (and, for database-configured loadpoints,
+// written back into the config blob by the pv/minpv self-heal migration), so it
+// must not reach the strict static decode in NewLoadpointFromConfig.
+func TestSplitConfigAlwaysCharge(t *testing.T) {
+	payload := map[string]any{
+		"charger":      "wallbox",
+		"alwaysCharge": "on",
+	}
+
+	dynamic, other, err := SplitConfig(payload)
+	require.NoError(t, err)
+
+	assert.Equal(t, "on", dynamic.AlwaysCharge)
+	assert.NotContains(t, other, "alwaysCharge")
+}

--- a/server/http_config_loadpoint_handler.go
+++ b/server/http_config_loadpoint_handler.go
@@ -31,6 +31,7 @@ func getLoadpointDynamicConfig(lp loadpoint.API) loadpoint.DynamicConfig {
 	return loadpoint.DynamicConfig{
 		Title:                    lp.GetTitle(),
 		DefaultMode:              string(lp.GetDefaultMode()),
+		AlwaysCharge:             string(lp.GetAlwaysCharge()),
 		Priority:                 lp.GetPriority(),
 		PhasesConfigured:         lp.GetPhasesConfigured(),
 		MinCurrent:               lp.GetMinCurrent(),


### PR DESCRIPTION
Fixes #33443

#32490 added `alwaysCharge` as a persisted per-loadpoint setting but did not add it to `DynamicConfig`.

For a **database-configured** loadpoint, `lp.settings` is the `ConfigSettings` adapter, so its writes land in the loadpoint's own config blob. The `pv`/`minpv` → `alwaysCharge` self-heal migration therefore writes an `alwaysCharge` key into that config. On the next boot `SplitConfig` routes the unknown key into the *static* map (via `mapstructure:",remain"`), which `NewLoadpointFromConfig` decodes with `ErrorUnused: true` → 

```
FATAL loadpoint [db:17] decoding failed due to the following error(s): 'core.Loadpoint' has invalid keys: alwaysCharge
```

and evcc no longer boots. YAML-configured loadpoints are unaffected — their settings use a separate, prefixed store.

## Change

- add `AlwaysCharge` to `DynamicConfig` so `SplitConfig` keeps it out of the static decode
- apply it in `DynamicConfig.Apply`, mirroring `DefaultMode`; the "not supported" error for devices without current control is ignored
- regression test in `config_test.go`

Not in any release yet (#32490 landed on master after 0.315.0), so this only affects nightly / self-built users and can be fixed before it ships.
