### PR TITLE
Subaru vehicle: handle range unit conversion

### DIFF
--- a/vehicle/subaru/provider.go
+++ b/vehicle/subaru/provider.go
@@ -26,5 +26,8 @@ func (v *Provider) Soc() (float64, error) {
 
 func (v *Provider) Range() (int64, error) {
 	res, err := v.status()
-	return int64(res.Payload.EvRangeWithAc.Value), err
+	if err != nil {
+		return 0, err
+	}
+	return res.Payload.EvRangeWithAc.ValueInKilometers()
 }

--- a/vehicle/subaru/types.go
+++ b/vehicle/subaru/types.go
@@ -2,6 +2,7 @@ package subaru
 
 import (
 	"fmt"
+	"math"
 	"strings"
 )
 
@@ -22,9 +23,24 @@ type Status struct {
 	} `json:"payload"`
 }
 
+const kmPerMile = 1.609344
+
 type EvRange struct {
 	Unit  string  `json:"unit"`
 	Value float64 `json:"value"`
+}
+
+func (e EvRange) ValueInKilometers() (int64, error) {
+	u := strings.ToLower(strings.TrimSpace(e.Unit))
+
+	switch u {
+	case "km":
+		return int64(math.Round(e.Value)), nil
+	case "mi":
+		return int64(math.Round(e.Value * kmPerMile)), nil
+	default:
+		return 0, fmt.Errorf("unsupported unit type: %s", e.Unit)
+	}
 }
 
 type Auth struct {


### PR DESCRIPTION
### Problem
The Subaru API returns `evRangeWithAc` as `{ "unit": "...", "value": ... }`. The provider ignored the unit and returned the raw value, so vehicles reporting miles showed a range that was too low by a factor of 1.6. The value was also truncated instead of rounded, and `Range()` accessed the response before checking the error.

### Changes
- Add `EvRange.ValueInKilometers()` which converts based on `unit`:
  - `km`: returned as is
  - `mi`: multiplied by 1.609344
  - anything else: returns an error
- Unit matching is case-insensitive and trims whitespace.
- Round the result instead of truncating.
- `Range()` returns early on a status error instead of reading a zero-value response.

### Behavior change
An empty or unknown `unit` now yields an error instead of a raw value. This is intentional: a number with an unknown unit is misleading.

### Testing
- `go build` and `go vet` on `./vehicle/...` pass.
- Manually verified conversion: 100.4 km -> 100, 100.5 km -> 101, 100 mi -> 161, empty/unknown unit -> error.
