### PR TITLE
Loadpoint: honor configured phases in minimum active phases

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1689,7 +1689,7 @@ func (lp *Loadpoint) boostPower(batteryPower float64) float64 {
 			lp.circuitAllowsPhases(maxPhases, lp.effectiveMinCurrent()) {
 			// max power actually achievable on the active phases
 			activeMaxPower := min(lp.EffectiveMaxPower(), Voltage*lp.effectiveMaxCurrent()*float64(activePhases))
-			delta += max(0, lp.EffectiveMinPower()*float64(maxPhases)-activeMaxPower)
+			delta += max(0, Voltage*lp.effectiveMinCurrent()*float64(maxPhases)-activeMaxPower)
 		}
 	}
 

--- a/core/loadpoint_phases.go
+++ b/core/loadpoint_phases.go
@@ -111,7 +111,8 @@ func (lp *Loadpoint) MinActivePhases() int {
 
 // minActivePhases returns the minimum number of active phases for the loadpoint.
 func (lp *Loadpoint) minActivePhases() int {
-	if lp.hasPhaseSwitching() || lp.phasesConfigured == 1 {
+	// configured phases are both minimum and maximum, only automatic scales down to 1p
+	if lp.hasPhaseSwitching() && lp.phasesConfigured == 0 {
 		return 1
 	}
 

--- a/core/loadpoint_phases_test.go
+++ b/core/loadpoint_phases_test.go
@@ -152,15 +152,38 @@ func TestMinActivePhases(t *testing.T) {
 				}
 			}
 
-			// restrict scalable charger by config
+			// scalable charger pinned to fixed phases has no lower minimum than its maximum
 			expectedPhases := tc.minExpected
-			if tc.capable == 0 && configured > 0 && configured < tc.minExpected {
-				expectedPhases = configured
+			if tc.capable == 0 && configured > 1 {
+				expectedPhases = lp.maxActivePhases()
 			}
 
 			require.Equal(t, expectedPhases, lp.minActivePhases(), "expected min active phases")
 			ctrl.Finish()
 		}
+	}
+}
+
+// 1p3p charger pinned to 3p must report the 3p minimum power
+func TestEffectiveMinPowerFixedPhases(t *testing.T) {
+	Voltage = 230
+
+	for configured, expected := range map[int]float64{0: 1380, 1: 1380, 3: 4140} {
+		ctrl := gomock.NewController(t)
+
+		lp := &Loadpoint{
+			phasesConfigured: configured,
+			minCurrent:       6,
+			charger: struct {
+				*api.MockCharger
+				*api.MockPhaseSwitcher
+			}{
+				api.NewMockCharger(ctrl), api.NewMockPhaseSwitcher(ctrl),
+			},
+		}
+
+		require.Equal(t, expected, lp.EffectiveMinPower(), "configured %d", configured)
+		ctrl.Finish()
 	}
 }
 


### PR DESCRIPTION
Refs https://github.com/evcc-io/evcc/pull/32881#issuecomment-5523147845 @fur1u5

Fixes a problem where optimizer showed `MinEffectivePower` for 1p when phase configuration was fixed to 3p.

`minActivePhases` short-circuited to `1` for any charger with phase switching, regardless of the phase configuration:

```go
if lp.hasPhaseSwitching() || lp.phasesConfigured == 1 {
	return 1
}
```

`maxActivePhases` does honor it (`if lp.hasPhaseSwitching() { physical = lp.phasesConfigured }`), so a 1p3p charger pinned to 3 phases reported a 1p minimum next to a 3p maximum. Reported on #32881 with a Zaptec Go: the optimizer request carried `c_min` 1380W (230V x 6A x 1p) alongside `c_max` 11040W (230V x 16A x 3p), and pv mode enabled charging at a power the charger cannot draw.

Configured phases are both minimum and maximum, only automatic scales down to 1p. The `phasesConfigured == 1` branch drops out as dead: `maxActivePhases` already returns 1 there, via `physical = lp.phasesConfigured` for 1p3p chargers and via `setPhasesConfigured` writing `lp.phases` for fixed ones.

The only combination whose values change, at 6/16A and 230V without vehicle or measured phase restrictions:

| charger | configured | minPhases | maxPhases | minPower | maxPower |
|---|---|---|---|---|---|
| 1p3p | 3 | 1 -> **3** | 3 | 1380 -> **4140** | 11040 |

Automatic and pinned 1p on a 1p3p charger, and all three settings on a fixed charger, keep their values.

`boostPower` derived the 3p minimum as `EffectiveMinPower() * maxPhases`, which only held while the minimum was hardwired to 1p. It now computes the power from the minimum current directly, unchanged for phases on automatic.

Affects every consumer of `EffectiveMinPower`, all of which want the true minimum: optimizer `CMin`, `continuousDemand`, `loadpointProfile`, `unmodelledPower`, `GetChargePowerFlexibility`, SMA SHM `MinPowerConsumption`, eebus-evse `isCharging` and `pvMaxCurrent`.

`TestMinActivePhases` asserted the old behaviour through a rule that could never fire for a 1p3p charger (`configured < tc.minExpected` with `minExpected` always 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
