### PR TITLE
Loadpoint: fix meterless current load management deadlock

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -169,6 +169,7 @@ type Loadpoint struct {
 	status         api.ChargeStatus // Charger status
 	chargePower    float64          // Charging power
 	chargeCurrents []float64        // Phase currents
+	chargeCurrent  float64          // Max phase current, sampled for load management
 	connectedTime  time.Time        // Time when vehicle was connected
 	connectPending bool             // connect notification deferred until vehicle detection settles
 	pvTimer        time.Time        // PV enabled/disable timer
@@ -927,7 +928,7 @@ func (lp *Loadpoint) syncCharger() error {
 		// use measured phase currents as fallback if charger does not provide max current or does not currently relay from vehicle (TWC3)
 		if !isCg || errors.Is(err, api.ErrNotAvailable) {
 			// validate if current too high by more than 1A (https://github.com/evcc-io/evcc/issues/14731)
-			if current := lp.GetMaxPhaseCurrent(); current > lp.offeredCurrent+1.0 {
+			if current := lp.measuredMaxPhaseCurrent(); current > lp.offeredCurrent+1.0 {
 				if shouldBeConsistent && !lp.chargerHasFeature(api.Heating) {
 					lp.log.WARN.Printf("charger logic error: current mismatch (got %.3gA measured, expected %.3gA) - make sure your interval is at least 30s", current, lp.offeredCurrent)
 				}
@@ -975,16 +976,25 @@ func (lp *Loadpoint) roundedCurrent(current float64) float64 {
 	return current
 }
 
-// actualMaxChargeCurrent returns the maximum of all phase currents.
-// If currents not measured falls back to offered current.
-func (lp *Loadpoint) actualMaxChargeCurrent() float64 {
+// maxChargeCurrent returns the current the loadpoint draws: the highest measured
+// phase current, or- without a charge meter- the offered current while charging
+func (lp *Loadpoint) maxChargeCurrent() float64 {
 	if lp.chargeCurrents != nil {
-		return max(lp.chargeCurrents[0], lp.chargeCurrents[1], lp.chargeCurrents[2])
+		return lp.measuredMaxPhaseCurrent()
 	}
 	if lp.charging() {
 		return lp.offeredCurrent
 	}
 	return 0
+}
+
+// measuredMaxPhaseCurrent returns the highest measured phase current, 0 without
+// a phase-current capable charge meter
+func (lp *Loadpoint) measuredMaxPhaseCurrent() float64 {
+	if lp.chargeCurrents == nil {
+		return 0
+	}
+	return max(lp.chargeCurrents[0], lp.chargeCurrents[1], lp.chargeCurrents[2])
 }
 
 // setLimit applies charger current limits and enables/disables accordingly
@@ -993,7 +1003,7 @@ func (lp *Loadpoint) setLimit(current float64) error {
 
 	// apply circuit limits
 	if lp.circuit != nil {
-		currentLimit := lp.circuit.ValidateCurrent(lp.actualMaxChargeCurrent(), current)
+		currentLimit := lp.circuit.ValidateCurrent(lp.GetMaxPhaseCurrent(), current)
 
 		activePhases := lp.ActivePhases()
 		powerLimit := lp.circuit.ValidatePower(lp.chargePower, currentToPower(current, activePhases))
@@ -1232,15 +1242,10 @@ func (lp *Loadpoint) updateChargerStatus() (bool, error) {
 	}
 
 	var welcomeCharge bool
-	var updateCircuit bool
 
 	for _, status := range statusChanges {
 		prevStatus := lp.GetStatus()
 		lp.setStatus(status)
-
-		if prevStatus != status && (prevStatus == api.StatusC || status == api.StatusC) {
-			updateCircuit = true
-		}
 
 		for _, ev := range statusEvents(prevStatus, status) {
 			lp.bus.Publish(ev)
@@ -1263,21 +1268,6 @@ func (lp *Loadpoint) updateChargerStatus() (bool, error) {
 					welcomeCharge = false
 				}
 			}
-		}
-	}
-
-	// Unmetered circuits dynamically allocate current based on StatusC. Re-evaluate load upon transition.
-	if updateCircuit && lp.chargeCurrents == nil && lp.circuit != nil && lp.site != nil && lp.site.GetCircuit() != nil {
-		lps := make([]api.CircuitLoad, 0)
-		for _, lpAPI := range lp.site.Loadpoints() {
-			if lpAPI != nil {
-				if cl, ok := lpAPI.(api.CircuitLoad); ok {
-					lps = append(lps, cl)
-				}
-			}
-		}
-		if err := lp.site.GetCircuit().Update(lps); err != nil {
-			lp.log.ERROR.Println("circuit update:", err)
 		}
 	}
 
@@ -1628,7 +1618,7 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64, ma
 
 	// load management may cap the 1p current far below the theoretical maximum
 	if lp.circuit != nil {
-		maxCurrent = lp.circuit.ValidateCurrent(lp.actualMaxChargeCurrent(), maxCurrent)
+		maxCurrent = lp.circuit.ValidateCurrent(lp.GetMaxPhaseCurrent(), maxCurrent)
 	}
 
 	maxPhases := lp.MaxActivePhases()
@@ -1960,6 +1950,13 @@ func (lp *Loadpoint) UpdateChargePowerAndCurrents() float64 {
 			lp.log.ERROR.Printf("charge currents: %v", err)
 		}
 	}
+
+	// sampled here so that the circuit and setLimit cannot disagree within a cycle
+	current := lp.maxChargeCurrent()
+
+	lp.Lock()
+	lp.chargeCurrent = current
+	lp.Unlock()
 
 	return power
 }

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1232,10 +1232,15 @@ func (lp *Loadpoint) updateChargerStatus() (bool, error) {
 	}
 
 	var welcomeCharge bool
+	var updateCircuit bool
 
 	for _, status := range statusChanges {
 		prevStatus := lp.GetStatus()
 		lp.setStatus(status)
+
+		if prevStatus != status && (prevStatus == api.StatusC || status == api.StatusC) {
+			updateCircuit = true
+		}
 
 		for _, ev := range statusEvents(prevStatus, status) {
 			lp.bus.Publish(ev)
@@ -1258,6 +1263,21 @@ func (lp *Loadpoint) updateChargerStatus() (bool, error) {
 					welcomeCharge = false
 				}
 			}
+		}
+	}
+
+	// Unmetered circuits dynamically allocate current based on StatusC. Re-evaluate load upon transition.
+	if updateCircuit && lp.chargeCurrents == nil && lp.circuit != nil && lp.site != nil && lp.site.GetCircuit() != nil {
+		lps := make([]api.CircuitLoad, 0)
+		for _, lpAPI := range lp.site.Loadpoints() {
+			if lpAPI != nil {
+				if cl, ok := lpAPI.(api.CircuitLoad); ok {
+					lps = append(lps, cl)
+				}
+			}
+		}
+		if err := lp.site.GetCircuit().Update(lps); err != nil {
+			lp.log.ERROR.Println("circuit update:", err)
 		}
 	}
 

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -976,9 +976,9 @@ func (lp *Loadpoint) roundedCurrent(current float64) float64 {
 	return current
 }
 
-// maxChargeCurrent returns the current the loadpoint draws: the highest measured
-// phase current, or- without a charge meter- the offered current while charging
-func (lp *Loadpoint) maxChargeCurrent() float64 {
+// actualMaxChargeCurrent returns the maximum of all phase currents.
+// If currents not measured falls back to offered current.
+func (lp *Loadpoint) actualMaxChargeCurrent() float64 {
 	if lp.chargeCurrents != nil {
 		return lp.measuredMaxPhaseCurrent()
 	}
@@ -1952,7 +1952,7 @@ func (lp *Loadpoint) UpdateChargePowerAndCurrents() float64 {
 	}
 
 	// sampled here so that the circuit and setLimit cannot disagree within a cycle
-	current := lp.maxChargeCurrent()
+	current := lp.actualMaxChargeCurrent()
 
 	lp.Lock()
 	lp.chargeCurrent = current

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -813,22 +813,13 @@ func (lp *Loadpoint) GetChargePowerFlexibility(rates api.Rates) float64 {
 	return max(0, lp.GetChargePower()-lp.EffectiveMinPower())
 }
 
-// GetMaxPhaseCurrent returns the maximum charge current per phase or- if not available-
-// the offered current from either charger or charge meter
+// GetMaxPhaseCurrent returns the maximum charge current per phase as sampled by
+// UpdateChargePowerAndCurrents. Like chargePower it is a snapshot so that the
+// circuit and setLimit account the loadpoint with the same value.
 func (lp *Loadpoint) GetMaxPhaseCurrent() float64 {
 	lp.RLock()
 	defer lp.RUnlock()
-
-	if lp.chargeCurrents != nil {
-		return max(lp.chargeCurrents[0], lp.chargeCurrents[1], lp.chargeCurrents[2])
-	}
-
-	if lp.status == api.StatusC {
-		return lp.offeredCurrent
-	}
-
-	// not charging
-	return 0
+	return lp.chargeCurrent
 }
 
 // GetMinCurrent returns the min loadpoint current

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -818,10 +818,17 @@ func (lp *Loadpoint) GetChargePowerFlexibility(rates api.Rates) float64 {
 func (lp *Loadpoint) GetMaxPhaseCurrent() float64 {
 	lp.RLock()
 	defer lp.RUnlock()
-	if lp.chargeCurrents == nil {
+
+	if lp.chargeCurrents != nil {
+		return max(lp.chargeCurrents[0], lp.chargeCurrents[1], lp.chargeCurrents[2])
+	}
+
+	if lp.status == api.StatusC {
 		return lp.offeredCurrent
 	}
-	return max(lp.chargeCurrents[0], lp.chargeCurrents[1], lp.chargeCurrents[2])
+
+	// not charging
+	return 0
 }
 
 // GetMinCurrent returns the min loadpoint current

--- a/core/loadpoint_circuit_test.go
+++ b/core/loadpoint_circuit_test.go
@@ -7,57 +7,129 @@ import (
 	"github.com/benbjohnson/clock"
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/core/circuit"
-	"github.com/evcc-io/evcc/core/loadpoint"
+	"github.com/evcc-io/evcc/core/wrapper"
 	"github.com/evcc-io/evcc/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
-func TestSetLimitDeadlockPrevention(t *testing.T) {
-	Voltage = 230
-	ctrl := gomock.NewController(t)
-
-	// Create real unmetered circuit with 16A limit
-	c, err := circuit.New(util.NewLogger("circuit"), "main", 16, 0, nil, 0)
-	require.NoError(t, err)
-
-	charger := api.NewMockCharger(ctrl)
-
-	lp := &Loadpoint{
+// meterlessLoadpoint returns a loadpoint with a wrapped charge meter, i.e. without
+// measured currents
+func meterlessLoadpoint(chg api.Charger, c api.Circuit, status api.ChargeStatus, offered float64) *Loadpoint {
+	return &Loadpoint{
 		log:            util.NewLogger("lp"),
 		bus:            evbus.New(),
 		clock:          clock.New(),
-		charger:        charger,
+		charger:        chg,
+		chargeMeter:    new(wrapper.ChargeMeter),
 		circuit:        c,
 		wakeUpTimer:    NewTimer(),
-		chargeCurrents: nil,
-		offeredCurrent: 10,          // We offered 10A last time
-		status:         api.StatusB, // Not yet charging
+		status:         status,
+		offeredCurrent: offered,
 		enabled:        true,
 		minCurrent:     6,
 		maxCurrent:     16,
 		phases:         1,
 	}
+}
 
-	siteAPI := &stubSite{
-		circuit: c,
-		lps:     []loadpoint.API{lp},
+// siteCycle samples the loadpoints and updates the circuit, in the order site.update does
+func siteCycle(t *testing.T, c api.Circuit, lps ...*Loadpoint) {
+	t.Helper()
+
+	loads := make([]api.CircuitLoad, 0, len(lps))
+	for _, lp := range lps {
+		lp.UpdateChargePowerAndCurrents()
+		loads = append(loads, lp)
 	}
-	lp.site = siteAPI
 
-	// Initially update the circuit as site does
-	err = c.Update([]api.CircuitLoad{lp})
+	require.NoError(t, c.Update(loads))
+}
+
+// a loadpoint that has been offered current but is not charging yet must not be
+// blocked by its own offer
+func TestSetLimitDeadlockPrevention(t *testing.T) {
+	Voltage = 230
+	ctrl := gomock.NewController(t)
+
+	c, err := circuit.New(util.NewLogger("circuit"), "main", 16, 0, nil, 0)
 	require.NoError(t, err)
 
-	// Now it should be 0A, because we are not charging.
-	assert.Equal(t, 0.0, c.GetMaxPhaseCurrent())
+	chg := api.NewMockCharger(ctrl)
+	lp := meterlessLoadpoint(chg, c, api.StatusB, 10)
 
-	// We expect charger.MaxCurrent(16) to be called because it shouldn't be capped!
-	charger.EXPECT().MaxCurrent(int64(16)).Return(nil)
+	siteCycle(t, c, lp)
+	assert.Equal(t, 0.0, c.GetMaxPhaseCurrent(), "not charging, hence no load")
 
-	// Request 16A. It should succeed (not be capped to 0A)
-	err = lp.setLimit(16)
-	require.NoError(t, err)
+	chg.EXPECT().MaxCurrent(int64(16)).Return(nil)
+
+	require.NoError(t, lp.setLimit(16))
 	assert.Equal(t, 16.0, lp.offeredCurrent)
+}
+
+// the circuit limit is still enforced when the charger starts charging after the
+// circuit has been updated
+func TestSetLimitWithMeterlessCircuitAndMeterlessCharger(t *testing.T) {
+	Voltage = 230
+	ctrl := gomock.NewController(t)
+
+	c, err := circuit.New(util.NewLogger("circuit"), "main", 12, 0, nil, 0)
+	require.NoError(t, err)
+
+	chg := api.NewMockCharger(ctrl)
+	lp := meterlessLoadpoint(chg, c, api.StatusB, 10)
+
+	siteCycle(t, c, lp)
+
+	chg.EXPECT().Status().Return(api.StatusC, nil)
+	_, err = lp.updateChargerStatus()
+	require.NoError(t, err)
+
+	chg.EXPECT().MaxCurrent(int64(12)).Return(nil)
+
+	require.NoError(t, lp.setLimit(16))
+	assert.Equal(t, 12.0, lp.offeredCurrent)
+}
+
+// a loadpoint that has been offered current but never draws it must not block
+// another loadpoint on the same circuit
+func TestSetLimitMeterlessDoesNotBlockOtherLoadpoint(t *testing.T) {
+	Voltage = 230
+	ctrl := gomock.NewController(t)
+
+	c, err := circuit.New(util.NewLogger("circuit"), "main", 16, 0, nil, 0)
+	require.NoError(t, err)
+
+	lp1 := meterlessLoadpoint(api.NewMockCharger(ctrl), c, api.StatusB, 16)
+	chg2 := api.NewMockCharger(ctrl)
+	lp2 := meterlessLoadpoint(chg2, c, api.StatusB, 0)
+
+	siteCycle(t, c, lp1, lp2)
+
+	chg2.EXPECT().MaxCurrent(int64(16)).Return(nil)
+
+	require.NoError(t, lp2.setLimit(16))
+	assert.Equal(t, 16.0, lp2.offeredCurrent)
+}
+
+// once both loadpoints charge the circuit limit applies again
+func TestSetLimitMeterlessBothCharging(t *testing.T) {
+	Voltage = 230
+	ctrl := gomock.NewController(t)
+
+	c, err := circuit.New(util.NewLogger("circuit"), "main", 16, 0, nil, 0)
+	require.NoError(t, err)
+
+	lp1 := meterlessLoadpoint(api.NewMockCharger(ctrl), c, api.StatusC, 16)
+	chg2 := api.NewMockCharger(ctrl)
+	lp2 := meterlessLoadpoint(chg2, c, api.StatusC, 16)
+
+	siteCycle(t, c, lp1, lp2)
+	assert.Equal(t, 32.0, c.GetMaxPhaseCurrent())
+
+	chg2.EXPECT().Enable(false).Return(nil)
+
+	require.NoError(t, lp2.setLimit(16))
+	assert.Equal(t, 0.0, lp2.offeredCurrent)
 }

--- a/core/loadpoint_circuit_test.go
+++ b/core/loadpoint_circuit_test.go
@@ -1,0 +1,63 @@
+package core
+
+import (
+	"testing"
+
+	evbus "github.com/asaskevich/EventBus"
+	"github.com/benbjohnson/clock"
+	"github.com/evcc-io/evcc/api"
+	circuitpkg "github.com/evcc-io/evcc/core/circuit"
+	"github.com/evcc-io/evcc/core/loadpoint"
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestSetLimitDeadlockPrevention(t *testing.T) {
+	Voltage = 230
+	ctrl := gomock.NewController(t)
+
+	// Create real unmetered circuit with 16A limit
+	c, err := circuitpkg.New(util.NewLogger("circuit"), "main", 16, 0, nil, 0)
+	require.NoError(t, err)
+
+	charger := api.NewMockCharger(ctrl)
+
+	lp := &Loadpoint{
+		log:            util.NewLogger("lp"),
+		bus:            evbus.New(),
+		clock:          clock.New(),
+		charger:        charger,
+		circuit:        c,
+		wakeUpTimer:    NewTimer(),
+		chargeCurrents: nil,
+		offeredCurrent: 10,          // We offered 10A last time
+		status:         api.StatusB, // Not yet charging
+		enabled:        true,
+		minCurrent:     6,
+		maxCurrent:     16,
+		phases:         1,
+	}
+
+	siteAPI := &stubSite{
+		circuit: c,
+		lps:     []loadpoint.API{lp},
+	}
+	lp.site = siteAPI
+
+	// Initially update the circuit as site does
+	err = c.Update([]api.CircuitLoad{lp})
+	require.NoError(t, err)
+
+	// Now it should be 0A, because we are not charging.
+	assert.Equal(t, 0.0, c.GetMaxPhaseCurrent())
+
+	// We expect charger.MaxCurrent(16) to be called because it shouldn't be capped!
+	charger.EXPECT().MaxCurrent(int64(16)).Return(nil)
+
+	// Request 16A. It should succeed (not be capped to 0A)
+	err = lp.setLimit(16)
+	require.NoError(t, err)
+	assert.Equal(t, 16.0, lp.offeredCurrent)
+}

--- a/core/loadpoint_circuit_test.go
+++ b/core/loadpoint_circuit_test.go
@@ -6,7 +6,7 @@ import (
 	evbus "github.com/asaskevich/EventBus"
 	"github.com/benbjohnson/clock"
 	"github.com/evcc-io/evcc/api"
-	circuitpkg "github.com/evcc-io/evcc/core/circuit"
+	"github.com/evcc-io/evcc/core/circuit"
 	"github.com/evcc-io/evcc/core/loadpoint"
 	"github.com/evcc-io/evcc/util"
 	"github.com/stretchr/testify/assert"
@@ -19,7 +19,7 @@ func TestSetLimitDeadlockPrevention(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	// Create real unmetered circuit with 16A limit
-	c, err := circuitpkg.New(util.NewLogger("circuit"), "main", 16, 0, nil, 0)
+	c, err := circuit.New(util.NewLogger("circuit"), "main", 16, 0, nil, 0)
 	require.NoError(t, err)
 
 	charger := api.NewMockCharger(ctrl)

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -7,10 +7,8 @@ import (
 	evbus "github.com/asaskevich/EventBus"
 	"github.com/benbjohnson/clock"
 	"github.com/evcc-io/evcc/api"
-	"github.com/evcc-io/evcc/core/circuit"
 	"github.com/evcc-io/evcc/core/loadpoint"
 	"github.com/evcc-io/evcc/core/settings"
-	"github.com/evcc-io/evcc/core/site"
 	"github.com/evcc-io/evcc/core/soc"
 	"github.com/evcc-io/evcc/messenger"
 	"github.com/evcc-io/evcc/util"
@@ -1078,58 +1076,4 @@ func TestPVDisableContinuousDeviceShortfall(t *testing.T) {
 			}
 		})
 	}
-}
-
-type stubSite struct {
-	site.API
-	circuit api.Circuit
-	lps     []loadpoint.API
-}
-
-func (s *stubSite) GetCircuit() api.Circuit     { return s.circuit }
-func (s *stubSite) Loadpoints() []loadpoint.API { return s.lps }
-
-func TestSetLimitWithMeterlessCircuitAndMeterlessCharger(t *testing.T) {
-	Voltage = 230
-	ctrl := gomock.NewController(t)
-
-	// Create real unmetered circuit with 12A limit
-	c, err := circuit.New(util.NewLogger("circuit"), "main", 12, 0, nil, 0)
-	require.NoError(t, err)
-
-	charger := api.NewMockCharger(ctrl)
-	// Expect max current set to 12A (capped from requested 16A)
-	charger.EXPECT().MaxCurrent(int64(12)).Return(nil)
-
-	// Simulate status change from B to C
-	charger.EXPECT().Status().Return(api.StatusC, nil)
-
-	lp := &Loadpoint{
-		log:            util.NewLogger("foo"),
-		bus:            evbus.New(),
-		charger:        charger,
-		circuit:        c,
-		chargeCurrents: nil,         // unmetered / fake meter
-		status:         api.StatusB, // initially B
-		offeredCurrent: 10,          // currently offering 10A
-		enabled:        true,
-		minCurrent:     6,
-		maxCurrent:     16,
-		phases:         1,
-	}
-
-	siteAPI := &stubSite{
-		circuit: c,
-		lps:     []loadpoint.API{lp},
-	}
-	lp.site = siteAPI
-
-	// Trigger status update, which will update the circuit
-	_, err = lp.updateChargerStatus()
-	require.NoError(t, err)
-
-	// Request 16A. Circuit should cap it at 12A because current load is updated to 10A first.
-	err = lp.setLimit(16)
-	require.NoError(t, err)
-	assert.Equal(t, 12.0, lp.offeredCurrent)
 }

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -7,8 +7,10 @@ import (
 	evbus "github.com/asaskevich/EventBus"
 	"github.com/benbjohnson/clock"
 	"github.com/evcc-io/evcc/api"
+	circuitpkg "github.com/evcc-io/evcc/core/circuit"
 	"github.com/evcc-io/evcc/core/loadpoint"
 	"github.com/evcc-io/evcc/core/settings"
+	"github.com/evcc-io/evcc/core/site"
 	"github.com/evcc-io/evcc/core/soc"
 	"github.com/evcc-io/evcc/messenger"
 	"github.com/evcc-io/evcc/util"
@@ -1076,4 +1078,58 @@ func TestPVDisableContinuousDeviceShortfall(t *testing.T) {
 			}
 		})
 	}
+}
+
+type stubSite struct {
+	site.API
+	circuit api.Circuit
+	lps     []loadpoint.API
+}
+
+func (s *stubSite) GetCircuit() api.Circuit     { return s.circuit }
+func (s *stubSite) Loadpoints() []loadpoint.API { return s.lps }
+
+func TestSetLimitWithMeterlessCircuitAndMeterlessCharger(t *testing.T) {
+	Voltage = 230
+	ctrl := gomock.NewController(t)
+
+	// Create real unmetered circuit with 12A limit
+	c, err := circuitpkg.New(util.NewLogger("circuit"), "main", 12, 0, nil, 0)
+	require.NoError(t, err)
+
+	charger := api.NewMockCharger(ctrl)
+	// Expect max current set to 12A (capped from requested 16A)
+	charger.EXPECT().MaxCurrent(int64(12)).Return(nil)
+
+	// Simulate status change from B to C
+	charger.EXPECT().Status().Return(api.StatusC, nil)
+
+	lp := &Loadpoint{
+		log:            util.NewLogger("foo"),
+		bus:            evbus.New(),
+		charger:        charger,
+		circuit:        c,
+		chargeCurrents: nil,         // unmetered / fake meter
+		status:         api.StatusB, // initially B
+		offeredCurrent: 10,          // currently offering 10A
+		enabled:        true,
+		minCurrent:     6,
+		maxCurrent:     16,
+		phases:         1,
+	}
+
+	siteAPI := &stubSite{
+		circuit: c,
+		lps:     []loadpoint.API{lp},
+	}
+	lp.site = siteAPI
+
+	// Trigger status update, which will update the circuit
+	_, err = lp.updateChargerStatus()
+	require.NoError(t, err)
+
+	// Request 16A. Circuit should cap it at 12A because current load is updated to 10A first.
+	err = lp.setLimit(16)
+	require.NoError(t, err)
+	assert.Equal(t, 12.0, lp.offeredCurrent)
 }

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -7,7 +7,7 @@ import (
 	evbus "github.com/asaskevich/EventBus"
 	"github.com/benbjohnson/clock"
 	"github.com/evcc-io/evcc/api"
-	circuitpkg "github.com/evcc-io/evcc/core/circuit"
+	"github.com/evcc-io/evcc/core/circuit"
 	"github.com/evcc-io/evcc/core/loadpoint"
 	"github.com/evcc-io/evcc/core/settings"
 	"github.com/evcc-io/evcc/core/site"
@@ -1094,7 +1094,7 @@ func TestSetLimitWithMeterlessCircuitAndMeterlessCharger(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	// Create real unmetered circuit with 12A limit
-	c, err := circuitpkg.New(util.NewLogger("circuit"), "main", 12, 0, nil, 0)
+	c, err := circuit.New(util.NewLogger("circuit"), "main", 12, 0, nil, 0)
 	require.NoError(t, err)
 
 	charger := api.NewMockCharger(ctrl)


### PR DESCRIPTION
Replaces #21513, fixes #21293 #21303 #27522 #26270

# Problem
When a charger without current meter is used within a circuit without meter, the assumed circuit load can go out of sync with the assumed consumed currents. That happens because the loadpoint internally correctly assumes `offeredCurrent` as consumed only, when the loadpoint is actually charging (Status C), while the circuit update uses `GetMaxPhaseCurrent`, which returns `offeredCurrent` regardless of the status. The problematic scenario is the following:
1. In the first cycle, charging is triggered with e.g. 16 A, `offeredCurrent` becomes 16 A.
2. In the second cycle, the circuits are updated, the circuit load is assumed to be at 16 A.
3. In the same cylce, the loadpoint update is called. Imagine the charger has not yet started charging and the circuit limit is also 16 A: setLimit validates the current by calling `validateCurrent(0, 16)`. The validate fails, since the loadpoint request a current increase from 0 to 16 A, but the circuit load is already assumes to be at 16.

# Fix
1. Update `GetMaxPhaseCurrent` to respect the charging status: it only returns offeredCurrent, when its actually charging.
2. Update the circuit again from the loadpoint, when the status of a meterless charger has changed from A or B to C or from C to A or B. Without this part, the circuit is not up-to-date when the status changed between the cyles, since site calls `circuit.Update` before the loadpoint status is updated within  with the real charger status within `lp.Update`. This idea was raised in https://github.com/evcc-io/evcc/pull/21513#issuecomment-4098130544.
