### PR TITLE
eebus-ohpcf: fail setup when the device does not support OHPCF

### DIFF
--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -3,6 +3,7 @@ package charger
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -117,6 +118,13 @@ func NewEEBusOHPCF(ctx context.Context, embed *embed, ski, ip string, reboost ti
 	if err := c.connector.WaitUseCase(ctx); err != nil {
 		inst.UnregisterDevice(ski, c)
 		return nil, err
+	}
+
+	// a device without OHPCF never announces a compressor and would error on
+	// every cycle instead of failing here (#33461)
+	if _, ok := c.connectedCompressor(); !ok {
+		inst.UnregisterDevice(ski, c)
+		return nil, fmt.Errorf("missing use case: %s", model.UseCaseNameTypeOptimizationOfSelfConsumptionByHeatPumpCompressorFlexibility)
 	}
 
 	// unregister device when context is cancelled (e.g. UI config validation)


### PR DESCRIPTION
fixes #33461

A heat pump that announces neither the OHPCF use case nor a `SmartEnergyManagementPs` server feature never announces a compressor entity. `WaitUseCase` deliberately treats its timeout as success, so the charger was created anyway and then reported `not connected` on every cycle, forever.

- fail device setup with a message naming the missing use case instead of creating a permanently broken charger
- MPC power measurement and LPC dimming are unaffected; such a device is simply not controllable via OHPCF

🤖 Generated with [Claude Code](https://claude.com/claude-code)