### PR TITLE
Marstek Venus A/D: derive battery power from AC power minus MPPT

### DIFF
--- a/templates/definition/meter/marstek-venus-a.yaml
+++ b/templates/definition/meter/marstek-venus-a.yaml
@@ -77,14 +77,46 @@ render: |
       scale: 0.1
   {{- end }}
   {{- if eq .usage "battery" }}
+  # Register 30001 only covers the AC-side charge/discharge transaction and misses
+  # solar that charges the battery straight from the MPPT inputs over the DC bus.
+  # Battery power is therefore derived as AC power minus the device's own MPPT yield.
   power:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      address: 30001 # Battery power (W)
-      type: holding
-      decode: int16
-    scale: -1
+    source: calc
+    add:
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 30006 # AC power (W), positive = discharge
+        type: holding
+        decode: int16
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 30037 # MPPT1 power (W)
+        type: holding
+        decode: uint16
+      scale: -0.1
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 30038 # MPPT2 power (W)
+        type: holding
+        decode: uint16
+      scale: -0.1
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 30039 # MPPT3 power (W)
+        type: holding
+        decode: uint16
+      scale: -0.1
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 30040 # MPPT4 power (W)
+        type: holding
+        decode: uint16
+      scale: -0.1
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}


### PR DESCRIPTION
Venus A and D read register 30001 for battery power. It only covers the AC-side
transaction and misses solar charging the battery over the unit's own DC bus, so
passthrough is booked as discharge and the site balance breaks when the same
device is configured as both `pv` and `battery` (#31585).

`power` now reads AC power (30006) minus the MPPT1-4 sum (30037-30040), so
`pv + battery` equals what actually leaves the device. Without panels the MPPT
registers read 0 and the formula reduces to plain AC power, matching what
`marstek-venus-e` already does for the AC-only models.

Logged a Venus D for six days at 30 s intervals, 17287 samples of AC power, MPPT
sum and register 30001. Fitting 30001 against the other two gives

    30001 = 1.008 * AC + 0.032 * MPPT + 26 W     (R2 = 0.996)

so the register is AC power plus a small offset, and the MPPT term is absent. If
30001 did account for the solar contribution its MPPT coefficient would have to
be -1; it is +0.03. Refitting on only the 5621 samples with MPPT above 200 W,
where a real MPPT term would be most visible, gives the same answer: 0.999 and
+0.037. The device simply does not look at its own DC inputs when reporting
battery power.

That shows up directly in the site balance. evcc adds `pv + battery`, but only
the AC power ever leaves the device. All energies in Wh per day:

| day | solar in | AC out | 30001 reports | evcc counts | overcount | SoC |
|---|---|---|---|---|---|---|
| Aug 28 | 4125 | 3908 | 4657 discharge | 8782 | +4874 | -17% |
| Aug 29 | 5387 | 4139 | 4997 discharge | 10384 | +6245 | +17% |
| Aug 30 | 6180 | 6049 | 6900 discharge | 13080 | +7031 | -21% |
| Aug 31 | 4038 | 2779 | 3578 discharge | 7616 | +4836 | +20% |
| Sep 1 | 5525 | 5215 | 6039 discharge | 11564 | +6349 | -17% |
| Sep 2 | 6233 | 4875 | 5594 discharge | 11827 | +6952 | +30% |

"evcc counts" is solar plus 30001, what the site adds up today; "AC out" is what
the device actually delivered. Over the six days that is 36.3 kWh of phantom
energy against 27.0 kWh really delivered.

Note the three days where SoC went up by 17%, 20% and 30%: the battery gained
charge, and 30001 still reported 5.0, 3.6 and 5.6 kWh of discharge. AC minus MPPT
gives 1.2, 1.3 and 1.4 kWh of charge for those days, with the correct sign.
Against the SoC series `30001 - MPPT` matches the sign on all six days and the
magnitude to within 11-25%, while 30001 alone is off by 750-1200%.

Addresses cross-checked against ViperRNMC/marstek_venus_modbus
(`registers/a.yaml`, `registers/d.yaml`): both models carry MPPT1-4 at
30037-30040 and `ac_power` at 30006, and a Venus A owner confirms four MPPT DC
inputs in #31585.

`energy` (33002) is left unchanged but has the same blind spot. Over the six
logged days the lifetime counters moved 7.36 kWh charged against 34.83 kWh
discharged, 4.7 to 1 on a 2.56 kWh battery. Their difference of 27.47 kWh matches
the AC integral of 27.33 kWh to 0.5%, so both counters are AC-side and book
passthrough as discharge. There is no cumulative MPPT energy register to correct
them with, so that needs a separate fix.

`go test ./meter/... -run TestTemplates` passes.