### PR TITLE
Mode UI: smart mode label and popover alignment

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -12,6 +12,8 @@ watchThemeChanges();
 // Setup global parameters
 export default {
   parameters: {
+    // keep the file order, but push the version group to the end
+    options: { storySort: { order: ["*", "Version"] } },
     controls: {
       matchers: {
         color: /(background|color)$/i,

--- a/assets/js/components/AboutModal.stories.ts
+++ b/assets/js/components/AboutModal.stories.ts
@@ -43,7 +43,7 @@ const releaseNotes = `
 `;
 
 export default {
-  title: "AboutModal",
+  title: "Version/AboutModal",
   component: AboutModal,
   argTypes: {
     installed: { control: "text" },

--- a/assets/js/components/Loadpoints/AlwaysChargeDropdown.vue
+++ b/assets/js/components/Loadpoints/AlwaysChargeDropdown.vue
@@ -128,6 +128,10 @@ export default defineComponent({
 
 <style scoped>
 .dropdown-menu {
-	--bs-dropdown-min-width: min(340px, calc(100vw - 2rem));
+	/* min-width would win over max-width, so size it with width instead.
+	   3rem leaves room for the popper gutters and a scrollbar */
+	--bs-dropdown-min-width: 0;
+	width: 340px;
+	max-width: calc(100vw - 3rem);
 }
 </style>

--- a/assets/js/components/Loadpoints/Mode.stories.ts
+++ b/assets/js/components/Loadpoints/Mode.stories.ts
@@ -1,5 +1,7 @@
 import Mode from "./Mode.vue";
 import type { Meta, StoryFn } from "@storybook/vue3";
+import sk from "../../../../i18n/sk.json";
+import { reactive, ref } from "vue";
 
 export default {
   title: "Loadpoints/Mode",
@@ -25,66 +27,126 @@ export default {
   },
 } as Meta<typeof Mode>;
 
-const Template: StoryFn<typeof Mode> = (args) => {
-  const story = () => ({
-    components: { Mode },
-    setup() {
-      return { args };
+const scenarios = [
+  { name: "Minimal", args: { mode: "now" } },
+  { name: "Smart", args: { mode: "smart", pvPossible: true, effectiveMinCurrent: 6 } },
+  {
+    name: "AlwaysCharge",
+    args: { mode: "smart", pvPossible: true, alwaysCharge: "on", effectiveMinCurrent: 6 },
+  },
+  {
+    name: "AlwaysChargeCharging",
+    args: {
+      mode: "smart",
+      pvPossible: true,
+      alwaysCharge: "on",
+      charging: true,
+      effectiveMinCurrent: 6,
     },
-    template: '<Mode v-bind="args" />',
-  });
-  story.args = args;
-  return story;
-};
+  },
+  { name: "SwitchDevice", args: { mode: "smart", pvPossible: true, switchDevice: true } },
+  {
+    name: "HeatpumpSGReady",
+    args: { mode: "smart", pvPossible: true, heating: true, continuous: true, switchDevice: true },
+  },
+  {
+    name: "HeatpumpControllable",
+    args: {
+      mode: "smart",
+      pvPossible: true,
+      heating: true,
+      continuous: true,
+      alwaysCharge: "on",
+      effectiveMinCurrent: 6,
+    },
+  },
+];
+
+const byName = (name: string) => scenarios.find((s) => s.name === name)?.args;
+
+type Scenario = (typeof scenarios)[number];
+
+// shared mode across all examples, so switching one switches all
+function overviewState() {
+  const mode = ref("smart");
+  const rows = reactive(scenarios.map((s) => ({ ...s, args: { ...s.args } })));
+  const smartPossible = (s: Scenario) => "pvPossible" in s.args || "smartCostAvailable" in s.args;
+  return {
+    rows,
+    setMode: (value: string) => (mode.value = value),
+    modeFor: (s: Scenario) => (smartPossible(s) || mode.value !== "smart" ? mode.value : "now"),
+  };
+}
+
+const overviewTemplate = `
+  <div class="p-3" style="display: grid; grid-template-columns: auto minmax(440px, 1fr) minmax(0, 2fr); gap: 1rem 1.5rem; align-items: center">
+    <div></div>
+    <div class="evcc-gray">condensed</div>
+    <div class="evcc-gray">full width</div>
+    <template v-for="s in rows" :key="s.name">
+      <div class="evcc-gray">{{ s.name }}</div>
+      <div class="d-flex">
+        <Mode v-bind="s.args" :mode="modeFor(s)" @updated="setMode" @always-charge-updated="s.args.alwaysCharge = $event" />
+      </div>
+      <div class="d-flex">
+        <Mode v-bind="s.args" :mode="modeFor(s)" class="flex-grow-1" @updated="setMode" @always-charge-updated="s.args.alwaysCharge = $event" />
+      </div>
+    </template>
+  </div>
+`;
+
+// rows: scenario, columns: condensed (wide screens) and stretched (narrow screens)
+export const Overview: StoryFn<typeof Mode> = () => ({
+  components: { Mode },
+  setup: overviewState,
+  template: overviewTemplate,
+});
+Overview.parameters = { controls: { disable: true }, layout: "fullscreen" };
+
+// same matrix with a verbose locale, shows how long labels behave
+export const OverviewLongLabels: StoryFn<typeof Mode> = () => ({
+  components: { Mode },
+  setup: overviewState,
+  data() {
+    return { previousLocale: "" };
+  },
+  mounted() {
+    this.previousLocale = this.$i18n.locale;
+    this.$i18n.setLocaleMessage("sk", sk);
+    this.$i18n.locale = "sk";
+  },
+  unmounted() {
+    this.$i18n.locale = this.previousLocale;
+  },
+  template: overviewTemplate,
+});
+OverviewLongLabels.parameters = { controls: { disable: true }, layout: "fullscreen" };
+
+const Template: StoryFn<typeof Mode> = (args) => ({
+  components: { Mode },
+  setup() {
+    return { args };
+  },
+  template: '<Mode v-bind="args" />',
+});
 
 export const Minimal = Template.bind({});
-Minimal.args = { mode: "now" };
+Minimal.args = byName("Minimal");
 
-export const Full = Template.bind({});
-Full.args = {
-  mode: "smart",
-  pvPossible: true,
-  smartCostAvailable: true,
-  effectiveMinCurrent: 6,
-};
-
-export const SmartGridOnly = Template.bind({});
-SmartGridOnly.args = {
-  mode: "smart",
-  pvPossible: false,
-  smartCostAvailable: true,
-  effectiveMinCurrent: 6,
-};
+export const Smart = Template.bind({});
+Smart.args = byName("Smart");
 
 export const AlwaysCharge = Template.bind({});
-AlwaysCharge.args = {
-  mode: "smart",
-  pvPossible: true,
-  alwaysCharge: "on",
-  effectiveMinCurrent: 6,
-};
+AlwaysCharge.args = byName("AlwaysCharge");
 
-export const AlwaysChargeOnce = Template.bind({});
-AlwaysChargeOnce.args = {
-  mode: "smart",
-  pvPossible: true,
-  alwaysCharge: "once",
-  effectiveMinCurrent: 6,
-};
+export const AlwaysChargeCharging = Template.bind({});
+AlwaysChargeCharging.args = byName("AlwaysChargeCharging");
 
 export const SwitchDevice = Template.bind({});
-SwitchDevice.args = {
-  mode: "smart",
-  pvPossible: true,
-  switchDevice: true,
-};
+SwitchDevice.args = byName("SwitchDevice");
 
-export const ContinuousHeatpump = Template.bind({});
-ContinuousHeatpump.args = {
-  mode: "smart",
-  pvPossible: true,
-  continuous: true,
-  heating: true,
-  alwaysCharge: "on",
-  effectiveMinCurrent: 6,
-};
+export const HeatpumpSGReady = Template.bind({});
+HeatpumpSGReady.args = byName("HeatpumpSGReady");
+
+export const HeatpumpControllable = Template.bind({});
+HeatpumpControllable.args = byName("HeatpumpControllable");

--- a/assets/js/components/Loadpoints/Mode.vue
+++ b/assets/js/components/Loadpoints/Mode.vue
@@ -1,19 +1,15 @@
 <template>
-	<div
-		ref="root"
-		class="mode-group border d-inline-flex position-relative"
-		role="group"
-		data-testid="mode"
-	>
+	<div class="mode-group border d-inline-flex position-relative" role="group" data-testid="mode">
 		<template v-for="m in modes" :key="m">
 			<div
 				v-if="m === SMART && alwaysChargePossible"
 				class="smart-pill d-flex"
 				:class="{ active: isActive(m) }"
 			>
+				<span class="pill-balance" aria-hidden="true"></span>
 				<button
 					type="button"
-					class="btn smart-btn flex-grow-1 flex-shrink-1 text-truncate-xs-only d-flex align-items-center justify-content-center"
+					class="btn smart-btn d-flex align-items-center justify-content-center"
 					:class="{ active: isActive(m) }"
 					tabindex="0"
 					@click="setTargetMode(m)"
@@ -26,6 +22,7 @@
 					class="btn chevron-btn d-flex align-items-center"
 					:class="{ active: isActive(m) }"
 					data-bs-toggle="dropdown"
+					data-bs-reference="parent"
 					data-bs-auto-close="outside"
 					data-bs-offset="0,10"
 					aria-expanded="false"
@@ -34,6 +31,7 @@
 				>
 					<AlwaysChargeIcon
 						v-if="alwaysChargeActive"
+						class="always-charge-icon"
 						:class="{ 'text-evcc': charging && isActive(m) }"
 						aria-hidden="true"
 					/>
@@ -50,7 +48,7 @@
 			<button
 				v-else
 				type="button"
-				class="btn flex-grow-1 flex-shrink-1 text-truncate-xs-only"
+				class="btn flex-grow-1 flex-shrink-1"
 				:class="{ active: isActive(m) }"
 				tabindex="0"
 				@click="setTargetMode(m)"
@@ -69,6 +67,9 @@ import chargeModeLabelKey from "@/utils/chargeModeLabel";
 import AlwaysChargeIcon from "../MaterialIcon/AlwaysCharge.vue";
 import DropdownIcon from "../MaterialIcon/Dropdown.vue";
 import AlwaysChargeDropdown from "./AlwaysChargeDropdown.vue";
+import type { Options as PopperOptions } from "@popperjs/core";
+
+type PopperConfig = Partial<PopperOptions> & { modifiers: NonNullable<PopperOptions["modifiers"]> };
 
 const { OFF, SMART, NOW } = CHARGE_MODE;
 
@@ -105,12 +106,11 @@ export default defineComponent({
 			return this.alwaysCharge !== ALWAYS_CHARGE.OFF;
 		},
 	},
+	mounted() {
+		this.syncDropdown();
+	},
 	updated() {
-		// dispose when the smart pill is reactively removed
-		if (this.bsDropdown && !this.$refs["chevron"]) {
-			this.bsDropdown.dispose();
-			this.bsDropdown = null;
-		}
+		this.syncDropdown();
 	},
 	beforeUnmount() {
 		this.bsDropdown?.dispose();
@@ -129,11 +129,28 @@ export default defineComponent({
 		updateAlwaysCharge(value: ALWAYS_CHARGE) {
 			this.$emit("always-charge-updated", value);
 		},
+		syncDropdown() {
+			// ref lives inside v-for, so vue collects it into an array
+			const chevron = (this.$refs["chevron"] as HTMLElement[] | undefined)?.[0];
+			if (!chevron) {
+				this.bsDropdown?.dispose();
+				this.bsDropdown = null;
+			} else if (!this.bsDropdown) {
+				// bootstrap's delegated toggle runs in the capture phase, so the instance
+				// has to exist before the first click for these options to apply
+				this.bsDropdown = new Dropdown(chevron, {
+					popperConfig: (config: PopperConfig) => {
+						// keep some distance to the screen edges
+						config.modifiers.push({
+							name: "preventOverflow",
+							options: { padding: 16 },
+						});
+						return config;
+					},
+				});
+			}
+		},
 		ensureSmart() {
-			// anchor to the whole group; created lazily before bootstrap's delegated toggle handler runs
-			this.bsDropdown ??= Dropdown.getOrCreateInstance(this.$refs["chevron"] as HTMLElement, {
-				reference: this.$refs["root"] as HTMLElement,
-			});
 			if (this.mode !== SMART) {
 				this.$emit("updated", SMART);
 			}
@@ -177,21 +194,46 @@ export default defineComponent({
 }
 
 .smart-pill {
-	flex-grow: 1.5;
-	flex-basis: 0;
+	/* equal share when there is room, content width when there is not.
+	   the basis mirrors .btn's padding floor (0.8em at its 1rem font size),
+	   so the pill and the plain modes end up the same width */
+	flex-grow: 1;
+	flex-basis: 1.6rem;
 	border-radius: 18px;
 }
+.smart-pill.active {
+	background: var(--evcc-default-text);
+}
+.smart-pill .btn.active {
+	background: none;
+}
+/* mirrors the chevron side, so the label sits in the middle of the whole pill.
+   both are flexible, on tight space they collapse to the chevron content */
+.smart-pill .pill-balance {
+	flex: 1 1 0;
+}
 .smart-pill .smart-btn {
+	flex: 0 1 auto;
 	border-radius: 18px 0 0 18px;
+	/* fixed inset, the label must not touch the pill edge on small screens */
+	padding-left: 0.8em;
 	padding-right: 0;
 }
 .smart-pill .chevron-btn {
-	flex-grow: 0;
-	flex-basis: auto;
+	flex: 1 1 0;
+	justify-content: flex-end;
 	gap: 3px;
 	border-radius: 0 18px 18px 0;
 	padding-left: 0.3em;
-	padding-right: 0.5em;
+	/* the chevron glyph carries whitespace, so less than the label side */
+	padding-right: 0.3em;
+}
+.smart-pill .chevron-btn svg {
+	flex-shrink: 0;
+}
+/* the chevron glyph carries whitespace, the infinity glyph does not */
+.always-charge-icon {
+	margin-left: 0.4em;
 }
 /* full ring around the whole pill when the mode button is focused */
 .smart-pill:has(.smart-btn:focus-visible) {
@@ -201,12 +243,8 @@ export default defineComponent({
 	outline: none;
 }
 @media (max-width: 576px) {
-	.smart-pill .smart-btn {
-		padding-right: 0.1em;
-	}
-	.smart-pill .chevron-btn {
-		padding-left: 0;
-		padding-right: 0.2em;
+	.smart-pill {
+		flex-basis: 0.4rem;
 	}
 }
 .chevron-btn.show .chevron {

--- a/assets/js/i18n.ts
+++ b/assets/js/i18n.ts
@@ -46,7 +46,9 @@ const htmlLang = document.querySelector("html")?.getAttribute("lang");
 const DEFAULT_BROWSER_LOCALE = htmlLang?.length == 2 ? htmlLang : DEFAULT_LOCALE;
 
 export function getLocalePreference() {
-  return settings.locale;
+  // ignore unknown values, a broken locale would crash every Intl formatter
+  const locale = settings.locale;
+  return locale && locale in LOCALES ? locale : null;
 }
 
 export function removeLocalePreference(i18n: VueI18nInstance) {


### PR DESCRIPTION
The mode select looked unbalanced on narrow loadpoints, and the always charge popover could end up flush against the screen edge.

Before (via @andig)
<img width="300"  alt="IMG_4120" src="https://github.com/user-attachments/assets/d637c960-82a6-460e-b0a7-abe02e610067" />


- all three modes get the same width when there is room, otherwise each takes what it needs, no cut off labels
- the smart label sits centered between matching gaps on both sides
- the always charge icon and the chevron keep their size at any width
- the popover keeps a margin to the screen edges and shrinks on small screens instead of running out of view
- storybook stories updated

**Screenshots & Videos**

grow/shrink behavior of labels (i18n texts are required to stay short)

[Bildschirmaufnahme 2026-09-04 um 14.28.52.webm](https://github.com/user-attachments/assets/552a20c6-74bd-4b76-a3c5-c0fbdcf5d9fa)


popover alignment (stay inside viewport, safe-margin left and right)

<img width="352" height="297" alt="Bildschirmfoto 2026-09-04 um 14 28 32" src="https://github.com/user-attachments/assets/314823f5-7558-4091-a9e8-a6b9f042676b" />

<img width="849" height="321" alt="Bildschirmfoto 2026-09-04 um 14 28 22" src="https://github.com/user-attachments/assets/41ddde14-42b4-44a4-a55a-fb39922be718" />

