### PR TITLE
Meter (Deye): add HTTP micro inverter logger template

### DIFF
--- a/templates/definition/meter/deye-mi-http.yaml
+++ b/templates/definition/meter/deye-mi-http.yaml
@@ -1,0 +1,33 @@
+template: deye-mi-http
+products:
+  - brand: Deye
+    description:
+      generic: Micro inverter (WiFi logger)
+params:
+  - name: usage
+    choice: ["pv"]
+  - name: host
+  - name: user
+    default: admin
+  - name: password
+    default: admin
+render: |
+  type: custom
+  power:
+    source: http
+    uri: http://{{ .host }}/status.html
+    auth:
+      type: basic
+      user: {{ .user }}
+      password: {{ .password }}
+    regex: webdata_now_p\s*=\s*\"([0-9.]+)\"
+    cache: 1s
+  energy:
+    source: http
+    uri: http://{{ .host }}/status.html
+    auth:
+      type: basic
+      user: {{ .user }}
+      password: {{ .password }}
+    regex: webdata_total_e\s*=\s*\"([0-9.]+)\"
+    cache: 1s


### PR DESCRIPTION
Add a Deye micro inverter template for WiFi loggers that expose production data through `status.html`.

- Reads current power and total energy using HTTP Basic authentication.
- Adds a dedicated Deye selection without Modbus connection fields.
- The existing Deye micro inverter template could not be used because it requires Modbus TCP or RS485. This WiFi logger only exposes its measurements through HTTP.

**Screenshots**

Deye micro inverter WiFi logger configuration:

<img width="548" height="916" alt="Bildschirmfoto 2026-09-04 um 17 31 33" src="https://github.com/user-attachments/assets/22ab81f1-dadd-4a0a-aa53-bcf231a12a8f" />

Configured PV system showing live production data:

<img width="368" height="268" alt="Bildschirmfoto 2026-09-04 um 17 31 41" src="https://github.com/user-attachments/assets/b4161656-faa9-4202-8dd9-fdd204739dae" />