### PR TITLE
Optimizer: apply active result slot

### DIFF
--- a/core/optimizer_schedule.go
+++ b/core/optimizer_schedule.go
@@ -1,0 +1,54 @@
+package core
+
+import (
+	"iter"
+	"time"
+)
+
+// Result indices keep their original intervals even after earlier slots expire.
+type optimizerSchedule struct {
+	timestamps []time.Time
+	dt         []int
+}
+
+func (s optimizerSchedule) len() int {
+	return min(len(s.timestamps), len(s.dt))
+}
+
+func (s optimizerSchedule) duration(slot int) time.Duration {
+	if slot < 0 || slot >= s.len() {
+		return 0
+	}
+	return time.Duration(s.dt[slot]) * time.Second
+}
+
+func (s optimizerSchedule) end(slot int) time.Time {
+	if slot < 0 || slot >= s.len() {
+		return time.Time{}
+	}
+	return s.timestamps[slot].Add(s.duration(slot))
+}
+
+func (s optimizerSchedule) activeSlot(at time.Time) int {
+	for i := range s.len() {
+		if at.Before(s.end(i)) {
+			return i
+		}
+	}
+	return -1
+}
+
+// Keep control policy separate so it cannot shift forecast intervals.
+func (s optimizerSchedule) controlSlot(at time.Time) int {
+	return s.activeSlot(at)
+}
+
+func (s optimizerSchedule) remainingSlots(at time.Time) iter.Seq[int] {
+	return func(yield func(int) bool) {
+		for i := s.activeSlot(at); i >= 0 && i < s.len(); i++ {
+			if !yield(i) {
+				return
+			}
+		}
+	}
+}

--- a/core/optimizer_schedule.go
+++ b/core/optimizer_schedule.go
@@ -38,12 +38,7 @@ func (s optimizerSchedule) activeSlot(at time.Time) int {
 	return -1
 }
 
-// Keep control policy separate so it cannot shift forecast intervals.
-func (s optimizerSchedule) controlSlot(at time.Time) int {
-	return s.activeSlot(at)
-}
-
-func (s optimizerSchedule) remainingSlots(at time.Time) iter.Seq[int] {
+func (s optimizerSchedule) endsAfter(at time.Time) iter.Seq[int] {
 	return func(yield func(int) bool) {
 		for i := s.activeSlot(at); i >= 0 && i < s.len(); i++ {
 			if !yield(i) {

--- a/core/optimizer_schedule_test.go
+++ b/core/optimizer_schedule_test.go
@@ -34,8 +34,7 @@ func TestOptimizerSchedule(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.want, schedule.activeSlot(tc.at))
-			assert.Equal(t, tc.want, schedule.controlSlot(tc.at))
-			assert.Equal(t, tc.remaining, slices.Collect(schedule.remainingSlots(tc.at)))
+			assert.Equal(t, tc.remaining, slices.Collect(schedule.endsAfter(tc.at)))
 		})
 	}
 
@@ -54,7 +53,7 @@ func TestOptimizerSchedule(t *testing.T) {
 		{dt: []int{900}},
 	} {
 		assert.Equal(t, -1, empty.activeSlot(boundary))
-		assert.Empty(t, slices.Collect(empty.remainingSlots(boundary)))
+		assert.Empty(t, slices.Collect(empty.endsAfter(boundary)))
 	}
 }
 

--- a/core/optimizer_schedule_test.go
+++ b/core/optimizer_schedule_test.go
@@ -1,0 +1,118 @@
+package core
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
+	optimizer "github.com/evcc-io/optimizer/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptimizerSchedule(t *testing.T) {
+	boundary := time.Date(2025, 1, 1, 12, 15, 0, 0, time.UTC)
+	schedule := optimizerSchedule{
+		timestamps: []time.Time{boundary.Add(-2 * time.Second), boundary, boundary.Add(15 * time.Minute)},
+		dt:         []int{2, 900, 900},
+	}
+
+	for _, tc := range []struct {
+		name      string
+		at        time.Time
+		want      int
+		remaining []int
+	}{
+		{"partial slot", boundary.Add(-time.Second), 0, []int{0, 1, 2}},
+		{"last instant", boundary.Add(-time.Nanosecond), 0, []int{0, 1, 2}},
+		{"next slot at boundary", boundary, 1, []int{1, 2}},
+		{"delayed response", boundary.Add(4 * time.Second), 1, []int{1, 2}},
+		{"following slot", boundary.Add(15 * time.Minute), 2, []int{2}},
+		{"expired result", boundary.Add(30 * time.Minute), -1, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, schedule.activeSlot(tc.at))
+			assert.Equal(t, tc.want, schedule.controlSlot(tc.at))
+			assert.Equal(t, tc.remaining, slices.Collect(schedule.remainingSlots(tc.at)))
+		})
+	}
+
+	assert.Equal(t, boundary, schedule.end(0))
+	assert.Equal(t, boundary.Add(15*time.Minute), schedule.end(1))
+	assert.Equal(t, 2*time.Second, schedule.duration(0))
+	assert.Equal(t, 15*time.Minute, schedule.duration(1))
+	for _, slot := range []int{-1, 3} {
+		assert.Zero(t, schedule.end(slot))
+		assert.Zero(t, schedule.duration(slot))
+	}
+
+	for _, empty := range []optimizerSchedule{
+		{},
+		{timestamps: []time.Time{boundary}},
+		{dt: []int{900}},
+	} {
+		assert.Equal(t, -1, empty.activeSlot(boundary))
+		assert.Empty(t, slices.Collect(empty.remainingSlots(boundary)))
+	}
+}
+
+func TestApplyOptimizerResultSchedule(t *testing.T) {
+	boundary := time.Date(2025, 1, 1, 12, 15, 0, 0, time.UTC)
+	schedule := optimizerSchedule{
+		timestamps: []time.Time{boundary.Add(-2 * time.Second), boundary, boundary.Add(15 * time.Minute)},
+		dt:         []int{2, 900, 900},
+	}
+	req := optimizer.OptimizationInput{
+		TimeSeries: optimizer.TimeSeries{Dt: schedule.dt},
+		Batteries:  []optimizer.BatteryConfig{{SCapacity: 1000, SInitial: 500, SMax: 1000}},
+	}
+	details := requestDetails{
+		Timestamps:     schedule.timestamps,
+		BatteryDetails: []batteryDetail{{Type: batteryTypeBattery, Name: "home", controllable: true}},
+	}
+	res := optimizer.OptimizationResult{
+		GridImport: []float32{1, 250, 0},
+		Batteries: []optimizer.BatteryResult{{
+			ChargingPower:    []float32{1, 250, 0},
+			DischargingPower: []float32{0, 0, 0},
+			StateOfCharge:    []float32{1000, 500, 800},
+		}},
+	}
+
+	for _, tc := range []struct {
+		name    string
+		at      time.Time
+		power   float64
+		full    time.Time
+		highest time.Time
+	}{
+		{"partial slot", boundary.Add(-time.Second), 1800, boundary, boundary},
+		{"delayed response", boundary.Add(4 * time.Second), 1000, time.Time{}, boundary.Add(30 * time.Minute)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			values := make(chan util.Param, 10)
+			site := &Site{valueChan: values}
+			site.applyOptimizerResult(req, details, res, schedule, tc.at)
+
+			s, ok := site.suggestions[batteryKey("home")]
+			require.True(t, ok)
+			assert.Equal(t, api.BatteryCharge.String(), s.Action)
+			assert.InDelta(t, tc.power, s.Charge, 1e-3)
+			require.NotNil(t, site.battery.Forecast)
+			require.NotNil(t, site.battery.Forecast.Highest)
+			assert.Equal(t, tc.highest, site.battery.Forecast.Highest.Time)
+
+			close(values)
+			var batteries []batteryResult
+			for val := range values {
+				if val.Key == "evopt-batteries" {
+					batteries = val.Val.([]batteryResult)
+				}
+			}
+			require.Len(t, batteries, 1)
+			assert.Equal(t, tc.full, batteries[0].Full)
+		})
+	}
+}

--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -647,7 +647,7 @@ func (site *Site) optimizerUpdate(battery []types.Measurement) error {
 // applyOptimizerResult maps the optimizer response onto suggestions, battery
 // forecast and notifications
 func (site *Site) applyOptimizerResult(req optimizer.OptimizationInput, details requestDetails, res optimizer.OptimizationResult, schedule optimizerSchedule, now time.Time) {
-	slot := schedule.controlSlot(now)
+	slot := schedule.activeSlot(now)
 	slotHours := schedule.duration(slot).Hours()
 	gridImporting := slot >= 0 && slot < len(res.GridImport) && res.GridImport[slot] > 0
 	gridExporting := slot >= 0 && slot < len(res.GridExport) && res.GridExport[slot] > 0
@@ -760,7 +760,7 @@ func batteryForecastSocExtremes(req []optimizer.BatteryConfig, resp []optimizer.
 	})
 
 	var high, low *batteryForecastSlot
-	for i := range schedule.remainingSlots(now) {
+	for i := range schedule.endsAfter(now) {
 		if i >= len(resp[homeIndices[0]].StateOfCharge) {
 			break
 		}
@@ -950,7 +950,7 @@ func (site *Site) batteryRequest(dev config.Device[api.Meter], b types.Measureme
 
 // matchSoc returns the end of the first slot whose soc satisfies fun.
 func matchSoc(ts []float32, schedule optimizerSchedule, now time.Time, fun func(float32) bool) time.Time {
-	for i := range schedule.remainingSlots(now) {
+	for i := range schedule.endsAfter(now) {
 		if i >= len(ts) {
 			break
 		}

--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -159,18 +159,18 @@ func suggestionEvent(detail batteryDetail, s types.Suggestion) messenger.Event {
 	return ev
 }
 
-// currentSlotSuggestion maps the optimizer's first-slot corner result onto an advisory action.
-// Because the optimization is linear, the first slot is at an operating-range extreme, so it
+// currentSlotSuggestion maps the optimizer's active-slot result onto an advisory action.
+// Because the optimization is linear, the slot is at an operating-range extreme, so it
 // maps cleanly onto the discrete battery mode / loadpoint intent that control would later apply.
 // An idle battery is interpreted from the grid flow: importing means discharge is withheld
 // (hold), exporting means charging is withheld (holdcharge).
-func currentSlotSuggestion(detail batteryDetail, res optimizer.BatteryResult, gridImporting, gridExporting bool, slotHours float64) types.Suggestion {
-	if slotHours <= 0 || len(res.ChargingPower) == 0 || len(res.DischargingPower) == 0 {
+func currentSlotSuggestion(detail batteryDetail, res optimizer.BatteryResult, slot int, gridImporting, gridExporting bool, slotHours float64) types.Suggestion {
+	if slot < 0 || slotHours <= 0 || slot >= len(res.ChargingPower) || slot >= len(res.DischargingPower) {
 		return types.Suggestion{}
 	}
 
-	charge := float64(res.ChargingPower[0]) / slotHours
-	discharge := float64(res.DischargingPower[0]) / slotHours
+	charge := float64(res.ChargingPower[slot]) / slotHours
+	discharge := float64(res.DischargingPower[slot]) / slotHours
 
 	s := types.Suggestion{Charge: charge, Discharge: discharge}
 
@@ -629,37 +629,47 @@ func (site *Site) optimizerUpdate(battery []types.Measurement) error {
 		return errors.New(string(status))
 	}
 
-	site.applyOptimizerResult(req, details.BatteryDetails, *resp.JSON200)
+	if len(details.Timestamps) != len(req.TimeSeries.Dt) || len(req.Batteries) != len(resp.JSON200.Batteries) {
+		return errors.New("inconsistent optimizer result dimensions")
+	}
+
+	now := time.Now()
+	schedule := optimizerSchedule{timestamps: details.Timestamps, dt: req.TimeSeries.Dt}
+	if schedule.activeSlot(now) < 0 {
+		return errors.New("optimizer result expired")
+	}
+
+	site.applyOptimizerResult(req, details, *resp.JSON200, schedule, now)
 
 	return nil
 }
 
 // applyOptimizerResult maps the optimizer response onto suggestions, battery
 // forecast and notifications
-func (site *Site) applyOptimizerResult(req optimizer.OptimizationInput, details []batteryDetail, res optimizer.OptimizationResult) {
-	now := time.Now()
-	slotHours := (time.Duration(req.TimeSeries.Dt[0]) * time.Second).Hours()
-	gridImporting := len(res.GridImport) > 0 && res.GridImport[0] > 0
-	gridExporting := len(res.GridExport) > 0 && res.GridExport[0] > 0
+func (site *Site) applyOptimizerResult(req optimizer.OptimizationInput, details requestDetails, res optimizer.OptimizationResult, schedule optimizerSchedule, now time.Time) {
+	slot := schedule.controlSlot(now)
+	slotHours := schedule.duration(slot).Hours()
+	gridImporting := slot >= 0 && slot < len(res.GridImport) && res.GridImport[slot] > 0
+	gridExporting := slot >= 0 && slot < len(res.GridExport) && res.GridExport[slot] > 0
 
 	var batteries []batteryResult
 	suggestions := make(map[string]types.Suggestion, len(req.Batteries))
 
 	for i, batReq := range req.Batteries {
 		batRes := res.Batteries[i]
-		detail := details[i]
+		detail := details.BatteryDetails[i]
 
 		batteries = append(batteries, batteryResult{
 			batteryDetail: detail,
-			Full: matchSoc(batRes.StateOfCharge, now, func(soc float32) bool {
+			Full: matchSoc(batRes.StateOfCharge, schedule, now, func(soc float32) bool {
 				return soc >= batReq.SMax
 			}),
-			Empty: matchSoc(batRes.StateOfCharge, now, func(soc float32) bool {
+			Empty: matchSoc(batRes.StateOfCharge, schedule, now, func(soc float32) bool {
 				return soc <= batReq.SMin
 			}),
 		})
 
-		suggestion := currentSlotSuggestion(detail, batRes, gridImporting, gridExporting, slotHours)
+		suggestion := currentSlotSuggestion(detail, batRes, slot, gridImporting, gridExporting, slotHours)
 		if suggestion.Action == "" {
 			continue
 		}
@@ -673,7 +683,7 @@ func (site *Site) applyOptimizerResult(req optimizer.OptimizationInput, details 
 	site.publish("evopt-batteries", batteries)
 
 	site.setSuggestions(suggestions)
-	site.setBatteryForecast(site.addBatteryForecastTotals(req.Batteries, res.Batteries))
+	site.setBatteryForecast(site.addBatteryForecastTotals(req.Batteries, res.Batteries, schedule, now))
 
 	site.publishBattery()
 
@@ -681,29 +691,27 @@ func (site *Site) applyOptimizerResult(req optimizer.OptimizationInput, details 
 	site.publishSuggestions()
 
 	// notify on actionable suggestion changes (advisory only, see #31903)
-	for _, ev := range site.diffSuggestions(site.pendingSuggestions(details)) {
+	for _, ev := range site.diffSuggestions(site.pendingSuggestions(details.BatteryDetails)) {
 		site.pushEvent(ev)
 	}
 }
 
-func (site *Site) addBatteryForecastTotals(req []optimizer.BatteryConfig, resp []optimizer.BatteryResult) *types.BatteryForecast {
+func (site *Site) addBatteryForecastTotals(req []optimizer.BatteryConfig, resp []optimizer.BatteryResult, schedule optimizerSchedule, now time.Time) *types.BatteryForecast {
 	if len(resp) == 0 || len(resp[0].StateOfCharge) == 0 {
 		return nil
 	}
 
-	high, low := batteryForecastSocExtremes(req, resp)
+	high, low := batteryForecastSocExtremes(req, resp, schedule, now)
 	if high == nil && low == nil {
 		return nil
 	}
 
-	cutoff := time.Now()
-	now := cutoff.Round(tariff.SlotDuration)
 	point := func(p *batteryForecastSlot) *types.BatteryForecastPoint {
 		if p == nil {
 			return nil
 		}
-		ts := now.Add(time.Duration(p.slot) * tariff.SlotDuration)
-		if !ts.After(cutoff) {
+		ts := schedule.end(p.slot)
+		if !ts.After(now) {
 			return nil
 		}
 		return &types.BatteryForecastPoint{Soc: p.soc, Time: ts, Limit: p.limit}
@@ -732,20 +740,30 @@ type batteryForecastSlot struct {
 // the battery is forecasted to become fully charged or empty.
 // Returns nil for either point when no home battery is present or when the
 // battery already is at the respective limit.
-func batteryForecastSocExtremes(req []optimizer.BatteryConfig, resp []optimizer.BatteryResult) (*batteryForecastSlot, *batteryForecastSlot) {
+func batteryForecastSocExtremes(req []optimizer.BatteryConfig, resp []optimizer.BatteryResult, schedule optimizerSchedule, now time.Time) (*batteryForecastSlot, *batteryForecastSlot) {
+	slot := schedule.activeSlot(now)
 	homeIndices := lo.FilterMap(req, func(b optimizer.BatteryConfig, i int) (int, bool) {
 		return i, b.SCapacity > 0
 	})
-	if len(homeIndices) == 0 || len(resp) == 0 {
+	if len(homeIndices) == 0 || len(resp) == 0 || slot < 0 || slot >= len(resp[homeIndices[0]].StateOfCharge) {
 		return nil, nil
 	}
 
 	totalCapacity := lo.SumBy(homeIndices, func(i int) float32 { return req[i].SCapacity })
 	totalSMax := lo.SumBy(homeIndices, func(i int) float32 { return req[i].SMax })
 	totalSMin := lo.SumBy(homeIndices, func(i int) float32 { return req[i].SMin })
+	totalSInitial := lo.SumBy(homeIndices, func(i int) float32 {
+		if slot > 0 {
+			return resp[i].StateOfCharge[slot-1]
+		}
+		return req[i].SInitial
+	})
 
 	var high, low *batteryForecastSlot
-	for i := range resp[homeIndices[0]].StateOfCharge {
+	for i := range schedule.remainingSlots(now) {
+		if i >= len(resp[homeIndices[0]].StateOfCharge) {
+			break
+		}
 		sum := lo.SumBy(homeIndices, func(idx int) float32 { return resp[idx].StateOfCharge[i] })
 		soc := float64(sum/totalCapacity) * 100
 		fullReached := totalSMax > 0 && sum >= totalSMax
@@ -762,10 +780,10 @@ func batteryForecastSocExtremes(req []optimizer.BatteryConfig, resp []optimizer.
 	}
 
 	// battery is already at the limit - announcing it will become full/empty is pointless
-	if high != nil && high.limit && high.slot == 0 {
+	if high != nil && high.limit && high.slot == slot && totalSInitial >= totalSMax {
 		high = nil
 	}
-	if low != nil && low.limit && low.slot == 0 {
+	if low != nil && low.limit && low.slot == slot && totalSInitial <= totalSMin {
 		low = nil
 	}
 
@@ -931,13 +949,13 @@ func (site *Site) batteryRequest(dev config.Device[api.Meter], b types.Measureme
 }
 
 // matchSoc returns the end of the first slot whose soc satisfies fun.
-// Slot 0 is the remainder of the current slot, so it ends at the next slot boundary.
-func matchSoc(ts []float32, now time.Time, fun func(float32) bool) time.Time {
-	eos := now.Truncate(tariff.SlotDuration).Add(tariff.SlotDuration)
-
-	for i, soc := range ts {
-		if fun(soc) {
-			return eos.Add(time.Duration(i) * tariff.SlotDuration)
+func matchSoc(ts []float32, schedule optimizerSchedule, now time.Time, fun func(float32) bool) time.Time {
+	for i := range schedule.remainingSlots(now) {
+		if i >= len(ts) {
+			break
+		}
+		if fun(ts[i]) {
+			return schedule.end(i)
 		}
 	}
 

--- a/core/site_optimizer_matchsoc_test.go
+++ b/core/site_optimizer_matchsoc_test.go
@@ -14,6 +14,9 @@ func TestMatchSoc(t *testing.T) {
 	// 10 minutes into the 12:00-12:15 slot
 	now := time.Date(2025, 1, 1, 12, 10, 0, 0, time.UTC)
 	eos := time.Date(2025, 1, 1, 12, 15, 0, 0, time.UTC)
+	timestamps := []time.Time{now, eos, eos.Add(tariff.SlotDuration)}
+	dt := []int{300, 900, 900}
+	schedule := optimizerSchedule{timestamps: timestamps, dt: dt}
 
 	for _, tc := range []struct {
 		ts       []float32
@@ -27,10 +30,13 @@ func TestMatchSoc(t *testing.T) {
 		{[]float32{0, 0, 0}, time.Time{}},
 		{nil, time.Time{}},
 	} {
-		assert.Equal(t, tc.expected, matchSoc(tc.ts, now, atLeast50), "%v", tc.ts)
+		assert.Equal(t, tc.expected, matchSoc(tc.ts, schedule, now, atLeast50), "%v", tc.ts)
 	}
 
 	// called exactly on a slot boundary the current slot is full length
 	onBoundary := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
-	assert.Equal(t, onBoundary.Add(tariff.SlotDuration), matchSoc([]float32{50}, onBoundary, atLeast50))
+	fullSlot := optimizerSchedule{timestamps: []time.Time{onBoundary}, dt: []int{900}}
+	assert.Equal(t, onBoundary.Add(tariff.SlotDuration), matchSoc([]float32{50}, fullSlot, onBoundary, atLeast50))
+	assert.Equal(t, eos.Add(2*tariff.SlotDuration), matchSoc([]float32{50, 0, 50}, schedule, eos, atLeast50))
+	assert.Zero(t, matchSoc([]float32{50, 0, 50}, schedule, eos.Add(2*tariff.SlotDuration), atLeast50))
 }

--- a/core/site_optimizer_test.go
+++ b/core/site_optimizer_test.go
@@ -552,7 +552,6 @@ func TestCurrentSlotSuggestion(t *testing.T) {
 	// no result yields an empty suggestion
 	assert.Empty(t, currentSlotSuggestion(batteryDetail{Type: batteryTypeBattery}, optimizer.BatteryResult{}, 0, true, false, 1))
 
-	// a delayed result uses the slot active when it is applied
 	res := optimizer.BatteryResult{
 		ChargingPower:    []float32{100, 0},
 		DischargingPower: []float32{0, 0},

--- a/core/site_optimizer_test.go
+++ b/core/site_optimizer_test.go
@@ -182,6 +182,12 @@ func TestUnmodelledPower(t *testing.T) {
 }
 
 func TestBatteryForecastSocExtremes(t *testing.T) {
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	schedule := optimizerSchedule{
+		timestamps: []time.Time{now, now.Add(tariff.SlotDuration), now.Add(2 * tariff.SlotDuration)},
+		dt:         []int{900, 900, 900},
+	}
+
 	for _, tc := range []struct {
 		name      string
 		req       []optimizer.BatteryConfig
@@ -250,14 +256,14 @@ func TestBatteryForecastSocExtremes(t *testing.T) {
 		},
 		{
 			"already full — no highest",
-			[]optimizer.BatteryConfig{{SCapacity: 1000, SMax: 1000}},
+			[]optimizer.BatteryConfig{{SCapacity: 1000, SMax: 1000, SInitial: 1000}},
 			[][]float32{{1000, 1000, 500}},
 			nil,
 			&batteryForecastSlot{slot: 2, soc: 50, limit: false},
 		},
 		{
 			"already empty — no lowest",
-			[]optimizer.BatteryConfig{{SCapacity: 1000, SMax: 1000, SMin: 100}},
+			[]optimizer.BatteryConfig{{SCapacity: 1000, SMax: 1000, SMin: 100, SInitial: 100}},
 			[][]float32{{100, 100, 500}},
 			&batteryForecastSlot{slot: 2, soc: 50, limit: false},
 			nil,
@@ -276,7 +282,7 @@ func TestBatteryForecastSocExtremes(t *testing.T) {
 				resp[i] = optimizer.BatteryResult{StateOfCharge: s}
 			}
 
-			high, low := batteryForecastSocExtremes(tc.req, resp)
+			high, low := batteryForecastSocExtremes(tc.req, resp, schedule, now)
 
 			if tc.high == nil {
 				assert.Nil(t, high, "high")
@@ -296,6 +302,45 @@ func TestBatteryForecastSocExtremes(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBatteryForecastActiveSlot(t *testing.T) {
+	req := []optimizer.BatteryConfig{{SCapacity: 1000, SMax: 1000}}
+	resp := []optimizer.BatteryResult{{StateOfCharge: []float32{1000, 500, 800}}}
+	base := time.Date(2025, 1, 1, 12, 15, 0, 0, time.UTC)
+	timestamps := []time.Time{base.Add(-time.Second), base, base.Add(tariff.SlotDuration)}
+	schedule := optimizerSchedule{timestamps: timestamps, dt: []int{1, 900, 900}}
+	now := base.Add(4 * time.Second)
+
+	high, low := batteryForecastSocExtremes(req, resp, schedule, now)
+	require.NotNil(t, high)
+	require.NotNil(t, low)
+	assert.Equal(t, 2, high.slot)
+	assert.InDelta(t, 80, high.soc, 1e-3)
+	assert.Equal(t, 1, low.slot)
+	assert.InDelta(t, 50, low.soc, 1e-3)
+
+	forecast := (&Site{}).addBatteryForecastTotals(req, resp, schedule, now)
+	require.NotNil(t, forecast)
+	require.NotNil(t, forecast.Highest)
+	require.NotNil(t, forecast.Lowest)
+	assert.Equal(t, timestamps[2].Add(tariff.SlotDuration), forecast.Highest.Time)
+	assert.Equal(t, timestamps[1].Add(tariff.SlotDuration), forecast.Lowest.Time)
+
+	resp[0].StateOfCharge = []float32{500, 1000, 800}
+	forecast = (&Site{}).addBatteryForecastTotals(req, resp, schedule, now)
+	require.NotNil(t, forecast)
+	require.NotNil(t, forecast.Highest)
+	assert.True(t, forecast.Highest.Limit)
+	assert.Equal(t, timestamps[1].Add(tariff.SlotDuration), forecast.Highest.Time)
+
+	resp[0].StateOfCharge = []float32{500, 0, 200}
+	forecast = (&Site{}).addBatteryForecastTotals(req, resp, schedule, now)
+	require.NotNil(t, forecast)
+	require.NotNil(t, forecast.Lowest)
+	assert.True(t, forecast.Lowest.Limit)
+	assert.Equal(t, timestamps[1].Add(tariff.SlotDuration), forecast.Lowest.Time)
+	assert.Nil(t, (&Site{}).addBatteryForecastTotals(req, resp, schedule, base.Add(2*tariff.SlotDuration)))
 }
 
 // TestBatteryRequestSocLimitsClamp ensures the reported soc is always clamped into
@@ -497,7 +542,7 @@ func TestCurrentSlotSuggestion(t *testing.T) {
 				ChargingPower:    []float32{tc.charge},
 				DischargingPower: []float32{tc.disch},
 			}
-			s := currentSlotSuggestion(batteryDetail{Type: tc.typ}, res, tc.importing, tc.export, 1)
+			s := currentSlotSuggestion(batteryDetail{Type: tc.typ}, res, 0, tc.importing, tc.export, 1)
 			assert.Equal(t, tc.want, s.Action)
 			assert.InDelta(t, tc.charge, s.Charge, 1e-3)
 			assert.InDelta(t, tc.disch, s.Discharge, 1e-3)
@@ -505,7 +550,15 @@ func TestCurrentSlotSuggestion(t *testing.T) {
 	}
 
 	// no result yields an empty suggestion
-	assert.Empty(t, currentSlotSuggestion(batteryDetail{Type: batteryTypeBattery}, optimizer.BatteryResult{}, true, false, 1))
+	assert.Empty(t, currentSlotSuggestion(batteryDetail{Type: batteryTypeBattery}, optimizer.BatteryResult{}, 0, true, false, 1))
+
+	// a delayed result uses the slot active when it is applied
+	res := optimizer.BatteryResult{
+		ChargingPower:    []float32{100, 0},
+		DischargingPower: []float32{0, 0},
+	}
+	s := currentSlotSuggestion(batteryDetail{Type: batteryTypeBattery}, res, 1, true, false, 1)
+	assert.Equal(t, api.BatteryHold.String(), s.Action)
 }
 
 // TestSuggestionActionable ensures the actionable flag follows the current state


### PR DESCRIPTION
Fix #33509

A solve started shortly before a slot boundary may return after that boundary. Select the active result slot from the request timestamps and durations instead of always applying slot zero.

- Use the active slot for battery and loadpoint suggestions and grid import/export values.
- Ignore expired slots in per-device and aggregate SoC forecasts, using the original request timestamps and durations.
- Distinguish reaching full or empty during the active slot from already being at that limit at its start.
- Leave the request and response unchanged, including optimizer diagnostics; only reject an expired result when no slots remain.

The existing time-step rounding and retained-schedule policy are unchanged.

🤖 Generated with [OpenCode](https://opencode.ai)
