### PR TITLE
Zaptec: fix Go model detection

### DIFF
--- a/charger/zaptec.go
+++ b/charger/zaptec.go
@@ -18,6 +18,7 @@ package charger
 // SOFTWARE.
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -202,7 +203,7 @@ func (c *Zaptec) detectVersion() (int, error) {
 		}
 	}
 
-	switch capabilities.ProductVariant {
+	switch cmp.Or(capabilities.ProductVariant, capabilities.DeviceType) {
 	case "Go":
 		return zaptec.ZaptecGo, nil
 	case "Go2":

--- a/charger/zaptec.go
+++ b/charger/zaptec.go
@@ -18,7 +18,6 @@ package charger
 // SOFTWARE.
 
 import (
-	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -203,13 +202,13 @@ func (c *Zaptec) detectVersion() (int, error) {
 		}
 	}
 
-	switch cmp.Or(capabilities.ProductVariant, capabilities.DeviceType) {
-	case "Go":
-		return zaptec.ZaptecGo, nil
-	case "Go2":
+	switch {
+	case capabilities.ProductVariant == "Go2":
 		return zaptec.ZaptecGo2, nil
-	default:
+	case capabilities.ProductVariant == "ProMID" || capabilities.DeviceType == "Pro":
 		return zaptec.ZaptecPro, nil
+	default:
+		return zaptec.ZaptecGo, nil
 	}
 }
 

--- a/charger/zaptec_test.go
+++ b/charger/zaptec_test.go
@@ -1,0 +1,87 @@
+package charger
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/evcc-io/evcc/charger/zaptec"
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestZaptecDetectVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		state   zaptec.StateResponse
+		err     error
+		want    int
+		wantErr bool
+	}{
+		{
+			name:  "Go",
+			state: zaptec.StateResponse{{StateId: zaptec.Capabilities, ValueAsString: `{"DeviceType":"Go"}`}},
+			want:  zaptec.ZaptecGo,
+		},
+		{
+			name:  "Go2",
+			state: zaptec.StateResponse{{StateId: zaptec.Capabilities, ValueAsString: `{"DeviceType":"Go","ProductVariant":"Go2"}`}},
+			want:  zaptec.ZaptecGo2,
+		},
+		{
+			name:  "Pro without device type",
+			state: zaptec.StateResponse{{StateId: zaptec.Capabilities, ValueAsString: `{"ProductVariant":"ProMID"}`}},
+			want:  zaptec.ZaptecPro,
+		},
+		{
+			name:  "Pro with device type",
+			state: zaptec.StateResponse{{StateId: zaptec.Capabilities, ValueAsString: `{"DeviceType":"Pro","ProductVariant":"ProMID"}`}},
+			want:  zaptec.ZaptecPro,
+		},
+		{
+			name: "missing capabilities",
+			want: zaptec.ZaptecPro,
+		},
+		{
+			name:  "empty capabilities",
+			state: zaptec.StateResponse{{StateId: zaptec.Capabilities}},
+			want:  zaptec.ZaptecPro,
+		},
+		{
+			name:  "missing model fields",
+			state: zaptec.StateResponse{{StateId: zaptec.Capabilities, ValueAsString: `{}`}},
+			want:  zaptec.ZaptecPro,
+		},
+		{
+			name:    "invalid capabilities",
+			state:   zaptec.StateResponse{{StateId: zaptec.Capabilities, ValueAsString: `{`}},
+			wantErr: true,
+		},
+		{
+			name:    "state error",
+			err:     errors.New("state unavailable"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Zaptec{
+				statusG: util.ResettableCached(func() (zaptec.StateResponse, error) {
+					return tt.state, tt.err
+				}, 0),
+			}
+
+			got, err := c.detectVersion()
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.err != nil {
+					assert.ErrorIs(t, err, tt.err)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/charger/zaptec_test.go
+++ b/charger/zaptec_test.go
@@ -29,6 +29,11 @@ func TestZaptecDetectVersion(t *testing.T) {
 			want:  zaptec.ZaptecGo2,
 		},
 		{
+			name:  "Go2 takes precedence over Pro",
+			state: zaptec.StateResponse{{StateId: zaptec.Capabilities, ValueAsString: `{"DeviceType":"Pro","ProductVariant":"Go2"}`}},
+			want:  zaptec.ZaptecGo2,
+		},
+		{
 			name:  "Pro without device type",
 			state: zaptec.StateResponse{{StateId: zaptec.Capabilities, ValueAsString: `{"ProductVariant":"ProMID"}`}},
 			want:  zaptec.ZaptecPro,
@@ -39,18 +44,28 @@ func TestZaptecDetectVersion(t *testing.T) {
 			want:  zaptec.ZaptecPro,
 		},
 		{
+			name:  "Pro without product variant",
+			state: zaptec.StateResponse{{StateId: zaptec.Capabilities, ValueAsString: `{"DeviceType":"Pro"}`}},
+			want:  zaptec.ZaptecPro,
+		},
+		{
+			name:  "unknown model",
+			state: zaptec.StateResponse{{StateId: zaptec.Capabilities, ValueAsString: `{"DeviceType":"Unknown","ProductVariant":"Unknown"}`}},
+			want:  zaptec.ZaptecGo,
+		},
+		{
 			name: "missing capabilities",
-			want: zaptec.ZaptecPro,
+			want: zaptec.ZaptecGo,
 		},
 		{
 			name:  "empty capabilities",
 			state: zaptec.StateResponse{{StateId: zaptec.Capabilities}},
-			want:  zaptec.ZaptecPro,
+			want:  zaptec.ZaptecGo,
 		},
 		{
 			name:  "missing model fields",
 			state: zaptec.StateResponse{{StateId: zaptec.Capabilities, ValueAsString: `{}`}},
-			want:  zaptec.ZaptecPro,
+			want:  zaptec.ZaptecGo,
 		},
 		{
 			name:    "invalid capabilities",


### PR DESCRIPTION
Fixes #33482, follows up #33484

Original Zaptec Go chargers report `DeviceType: "Go"` without `ProductVariant`, so checking only `ProductVariant` incorrectly classifies them as Pro and exposes phase switching.

- Detect Go 2 first via `ProductVariant: "Go2"`, then Pro via `ProductVariant: "ProMID"` or `DeviceType: "Pro"`. Go 2 also reports `DeviceType: "Go"`, so the order matters.
- Default to Go when neither model matches, including missing capabilities or model fields, without exposing phase switching for unidentified devices.
- Cover the observed model combinations, missing/empty capabilities, malformed JSON, and state retrieval errors with regression tests.

Capabilities observations from `StateId: 100` in charger `/state` responses, collected across 38 Zaptec issues and PR #33484. "Absent" means the JSON key is missing, not an explicit empty string.

| Device | `DeviceType` | `ProductVariant` | Observed Schemas | Evidence |
|---|---|---|---|---|
| Original Go | `"Go"` | **Absent** | `2.1` | [#14550](https://github.com/evcc-io/evcc/issues/14550), [#20009](https://github.com/evcc-io/evcc/issues/20009), [#33482 trace](https://github.com/user-attachments/files/31840252/evcc-20260904-160202-trace.log) |
| Go 2 | `"Go"` | `"Go2"` | `2.2`, `2.8` | [#21673 trace](https://github.com/user-attachments/files/20623533/evcc-20250606-091522-trace.log), [#26184 trace](https://github.com/user-attachments/files/24340878/evcc-20251225-134840-trace.log), [#30554 trace](https://github.com/user-attachments/files/29024242/evcc-20260616-184103-trace.log.txt) |
| Pro MID, older payload | **Absent** | `"ProMID"` | `2.0` | [#22141 inline trace](https://github.com/evcc-io/evcc/issues/22141#issuecomment-3045675576) |
| Pro MID, newer payload | `"Pro"` | `"ProMID"` | `2.6` | [#33484 capabilities comment](https://github.com/evcc-io/evcc/pull/33484#issuecomment-5550252570) |

#33303 separately reports a Pro with the entire capabilities observation absent, without a raw response to independently verify it. No inspected payload reports `ProductVariant: "Go"` or `DeviceType: "Go2"`.

Generated with [OpenCode](https://opencode.ai)
