### PR TITLE
CI: disable Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review-run.yml
+++ b/.github/workflows/claude-code-review-run.yml
@@ -19,6 +19,7 @@ jobs:
   gate:
     # Only react to PR runs that finished successfully.
     if: >
+      false &&
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest

--- a/.github/workflows/claude-code-review-run.yml
+++ b/.github/workflows/claude-code-review-run.yml
@@ -1,5 +1,7 @@
 name: Claude Code Review (run)
 
+# Disabled; original job conditions are retained for re-enablement.
+
 # Stage 2 (privileged): triggered when the "Claude Code Review" workflow above
 # completes. workflow_run executes in the base-repo context, so it has access
 # to secrets and id-token even for PRs from forks. This is what makes reviewing

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   prepare:
     # Skip draft PRs
-    if: github.event.pull_request.draft == false
+    if: ${{ false && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,5 +1,7 @@
 name: Claude Code Review
 
+# Disabled; original job conditions are retained for re-enablement.
+
 # Stage 1 (unprivileged): runs on every PR, including forks. Fork PRs get a
 # read-only token and no secrets, so the review itself cannot run here. This
 # job only records the PR number; the privileged "Claude Code Review (run)"

--- a/.github/workflows/claude-issue-agent.yml
+++ b/.github/workflows/claude-issue-agent.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   agent:
     name: Issue triage
-    if: github.event_name == 'issues'
+    if: ${{ false && github.event_name == 'issues' }}
     permissions:
       contents: write # create branch + push PR fix
       issues: write # add labels + comment analysis
@@ -40,6 +40,7 @@ jobs:
     # the label is read from the event payload, which predates the removal that
     # waiting-feedback.yml performs on this same event
     if: |
+      false &&
       github.event_name == 'issue_comment' &&
       !github.event.issue.pull_request &&
       github.event.comment.user.login == github.event.issue.user.login &&
@@ -91,6 +92,7 @@ jobs:
     # unless allowlisted, and bots already label their own PRs. backports are
     # skipped as well, they carry the backport label and nothing else
     if: |
+      false &&
       github.event_name == 'pull_request_target' &&
       github.event.pull_request.user.type != 'Bot' &&
       !startsWith(github.event.pull_request.head.ref, 'backport/')

--- a/.github/workflows/claude-issue-agent.yml
+++ b/.github/workflows/claude-issue-agent.yml
@@ -1,5 +1,7 @@
 name: Claude Issue & PR Agent
 
+# Disabled; original job conditions are retained for re-enablement.
+
 on:
   issues:
     types: [opened]

--- a/.github/workflows/command-analyze.yml
+++ b/.github/workflows/command-analyze.yml
@@ -1,5 +1,7 @@
 name: Claude Analyze Command
 
+# Disabled; original job conditions are retained for re-enablement.
+
 on:
   issue_comment:
     types: [created]

--- a/.github/workflows/command-analyze.yml
+++ b/.github/workflows/command-analyze.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze on demand
-    if: startsWith(github.event.comment.body, '/analyze')
+    if: ${{ false && startsWith(github.event.comment.body, '/analyze') }}
     permissions:
       contents: read # explore the codebase for the answer; no fix/PR in analyze mode
       issues: write # comment + minimize the calling comment

--- a/.github/workflows/command-fix.yml
+++ b/.github/workflows/command-fix.yml
@@ -12,6 +12,7 @@ jobs:
   fix:
     name: Fix on demand
     if: |
+      false &&
       startsWith(github.event.comment.body, '/fix') &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     permissions:

--- a/.github/workflows/command-fix.yml
+++ b/.github/workflows/command-fix.yml
@@ -1,5 +1,7 @@
 name: Claude Fix Command
 
+# Disabled; original job conditions are retained for re-enablement.
+
 on:
   issue_comment:
     types: [created]


### PR DESCRIPTION
pairs with #33506

Stops the failing Claude automation independently of the GPT-Astra migration. The disable guards take effect once merged into the default branch.

- Disables PR review and labeling, issue triage and reanalysis, and the `/analyze` and `/fix` commands.
- Preserves workflow definitions, existing trigger conditions, and permission checks for deliberate re-enablement.
- Leaves other CI workflows unchanged. The replacement migration must remove these guards when activating GPT-Astra.

🤖 Generated with [OpenCode](https://opencode.ai)