### PR TITLE
EEBus: fix test callback and logging races

### DIFF
--- a/server/eebus/test/controlbox.go
+++ b/server/eebus/test/controlbox.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/enbility/eebus-go/api"
@@ -30,7 +31,7 @@ type controlbox struct {
 	remoteEntities map[api.EventType][]spineapi.EntityRemoteInterface
 	remoteEventC   chan<- api.EventType
 
-	isConnected bool
+	isConnected atomic.Bool
 }
 
 func createControlbox(ctx context.Context, remoteSki string, port int) (*controlbox, error) {
@@ -126,7 +127,7 @@ func (h *controlbox) registerRemoteEntity(entity spineapi.EntityRemoteInterface,
 
 // LPC
 func (h *controlbox) OnLPCEvent(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
-	if !h.isConnected {
+	if !h.isConnected.Load() {
 		return
 	}
 
@@ -146,7 +147,7 @@ func (h *controlbox) OnLPCEvent(ski string, device spineapi.DeviceRemoteInterfac
 
 // LPP
 func (h *controlbox) OnLPPEvent(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
-	if !h.isConnected {
+	if !h.isConnected.Load() {
 		return
 	}
 
@@ -165,11 +166,11 @@ func (h *controlbox) OnLPPEvent(ski string, device spineapi.DeviceRemoteInterfac
 // EEBUSServiceHandler
 
 func (h *controlbox) RemoteServiceConnected(service api.ServiceInterface, identity shipapi.ServiceIdentity) {
-	h.isConnected = true
+	h.isConnected.Store(true)
 }
 
 func (h *controlbox) RemoteServiceDisconnected(service api.ServiceInterface, identity shipapi.ServiceIdentity) {
-	h.isConnected = false
+	h.isConnected.Store(false)
 }
 
 func (h *controlbox) VisibleRemoteMdnsServicesUpdated(service api.ServiceInterface, entries []shipapi.RemoteMdnsService) {

--- a/server/eebus/test/controlbox_test.go
+++ b/server/eebus/test/controlbox_test.go
@@ -1,0 +1,39 @@
+package eebus
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/enbility/eebus-go/usecases/eg/lpc"
+	"github.com/enbility/eebus-go/usecases/eg/lpp"
+	shipapi "github.com/enbility/ship-go/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestControlboxConnectionEvents(t *testing.T) {
+	var box controlbox
+	var identity shipapi.ServiceIdentity
+	var wg sync.WaitGroup
+
+	wg.Go(func() {
+		for range 1000 {
+			box.RemoteServiceConnected(nil, identity)
+			box.RemoteServiceDisconnected(nil, identity)
+		}
+	})
+	wg.Go(func() {
+		for range 1000 {
+			box.OnLPCEvent("", nil, nil, lpc.DataUpdateLimit)
+			box.OnLPPEvent("", nil, nil, lpp.UseCaseSupportUpdate)
+		}
+	})
+	wg.Wait()
+
+	before := len(box.remoteEntity(lpc.DataUpdateLimit))
+	box.RemoteServiceConnected(nil, identity)
+	box.OnLPCEvent("", nil, nil, lpc.DataUpdateLimit)
+	assert.Len(t, box.remoteEntity(lpc.DataUpdateLimit), before+1)
+	box.RemoteServiceDisconnected(nil, identity)
+	box.OnLPCEvent("", nil, nil, lpc.DataUpdateLimit)
+	assert.Len(t, box.remoteEntity(lpc.DataUpdateLimit), before+1)
+}

--- a/server/eebus/test/cs_test.go
+++ b/server/eebus/test/cs_test.go
@@ -1,6 +1,7 @@
 package eebus
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -18,9 +19,13 @@ import (
 
 const remotePort = 9001
 
-func TestEEBus(t *testing.T) {
+func TestMain(m *testing.M) {
+	// Configure logging before service goroutines can access the shared loggers.
 	util.LogLevel("error", map[string]string{"eebus": "trace"})
+	os.Exit(m.Run())
+}
 
+func TestEEBus(t *testing.T) {
 	certificate, err := cert.CreateCertificate("Demo", "Demo", "DE", "Demo-Server-01")
 	require.NoError(t, err, "certificate")
 

--- a/server/eebus/test/gridguard_test.go
+++ b/server/eebus/test/gridguard_test.go
@@ -8,15 +8,12 @@ import (
 	"github.com/evcc-io/evcc/hems/eebus"
 	hems "github.com/evcc-io/evcc/hems/eebus"
 	server "github.com/evcc-io/evcc/server/eebus"
-	"github.com/evcc-io/evcc/util"
 	"github.com/stretchr/testify/require"
 )
 
 // TestControlBoxGridGuardHeartbeat covers issue #31561: a real ControlBox exposes LPC/LPP
 // only on a GridGuard entity; if eebus-go's cs/lpc validEntityTypes ever drops it again, the heartbeat subscription silently never happens and the LPC failsafe eventually trips.
 func TestControlBoxGridGuardHeartbeat(t *testing.T) {
-	util.LogLevel("error", map[string]string{"eebus": "trace"})
-
 	// tear down a server instance left over from other tests in this package
 	if inst, err := server.Instance(); err == nil {
 		inst.Shutdown()

--- a/server/eebus/test/pairing_test.go
+++ b/server/eebus/test/pairing_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/evcc-io/evcc/db/settings"
 	hems "github.com/evcc-io/evcc/hems/eebus"
 	server "github.com/evcc-io/evcc/server/eebus"
-	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/test"
 	"github.com/stretchr/testify/require"
 )
@@ -112,8 +111,6 @@ func findPairing(pairings []server.PairingInfo, source server.PairingSource) (se
 
 func TestShipPairing(t *testing.T) {
 	test.SkipCI(t) // flaky: SHIP mDNS/pairing races, see evcc #31617 and ship-go #89
-
-	util.LogLevel("error", map[string]string{"eebus": "trace"})
 
 	// tear down a server instance left over from other tests in this package
 	if inst, err := server.Instance(); err == nil {


### PR DESCRIPTION
Found while validating #33378.

Fixes two data races reproduced in the EEBus test suite on master: connection callbacks access the control-box flag concurrently, and per-test log-level changes rebuild shared loggers while earlier service goroutines are still logging.

- Use an atomic connection flag for LPC/LPP callbacks and connection notifications.
- Configure logging once before the suite starts instead of changing it between tests.
- Exercise concurrent connection and use-case callbacks without network setup.

The changes are limited to test code; production logging and EEBus behavior are unchanged. A separate race between heartbeat initialization and reads inside `eebus-go` remains outside this change.

🤖 Generated with [OpenCode](https://opencode.ai)
