### PR TITLE
Zendure Solarflow: suggest battery serial via HTTP

### DIFF
--- a/templates/definition/meter/zendure-solarflow-battery.yaml
+++ b/templates/definition/meter/zendure-solarflow-battery.yaml
@@ -18,6 +18,7 @@ params:
     choice: ["battery"]
   - name: host
   - name: serial
+    service: http/get?uri=http://{host}/properties/report&jq=.sn
     example: WOB1NHMAMXXXXX3
     help:
       de: Nur für die aktive Batteriesteuerung. Seriennummer des Geräts (zu finden in der Zendure App)


### PR DESCRIPTION
Follows up #33505

Suggest the Solarflow device serial from its local HTTP API during battery configuration, avoiding a manual lookup in the Zendure app.

- Reuse the existing HTTP parameter service to read the top-level `sn` from `/properties/report`, not the individual battery-pack serials.
- Keep the serial optional and manually editable. Discovery alone does not enable active battery control.

Generated with [OpenCode](https://opencode.ai)
