### PR TITLE
OCPP: allow transaction-specific charging profiles

### DIFF
--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -48,6 +48,9 @@ type OCPP struct {
 
 	stackLevelZero      bool
 	profileKindRelative bool
+	txProfile           bool
+	profileCurrent      float64
+	transactionID       int
 }
 
 const defaultIdTag = "evcc" // RemoteStartTransaction only
@@ -78,14 +81,19 @@ func NewOCPPFromConfig(ctx context.Context, other map[string]any) (api.Charger, 
 		ProfileKindRelative  bool
 		RemoteStart          bool
 		NoChangeAvailability *bool
+		ChargingProfile      types.ChargingProfilePurposeType
 	}{
-		Connector:      1,
-		MeterInterval:  10 * time.Second,
-		ConnectTimeout: 5 * time.Minute,
+		Connector:       1,
+		MeterInterval:   10 * time.Second,
+		ConnectTimeout:  5 * time.Minute,
+		ChargingProfile: types.ChargingProfilePurposeTxDefaultProfile,
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
+	}
+	if cc.ChargingProfile != types.ChargingProfilePurposeTxDefaultProfile && cc.ChargingProfile != types.ChargingProfilePurposeTxProfile {
+		return nil, fmt.Errorf("invalid charging profile: %s", cc.ChargingProfile)
 	}
 
 	stackLevelZero := cc.StackLevelZero != nil && *cc.StackLevelZero
@@ -104,6 +112,7 @@ func NewOCPPFromConfig(ctx context.Context, other map[string]any) (api.Charger, 
 	if !sponsor.IsAuthorized() {
 		return nil, api.ErrSponsorRequired
 	}
+	c.txProfile = cc.ChargingProfile == types.ChargingProfilePurposeTxProfile
 
 	if c.cp.HasMeasurement(types.MeasurandPowerActiveImport) {
 		implement.Has(c, implement.Meter(c.conn.CurrentPower))
@@ -212,6 +221,18 @@ func (c *OCPP) Status() (api.ChargeStatus, error) {
 	if err != nil {
 		return api.StatusNone, err
 	}
+	if c.txProfile {
+		transactionID, err := c.conn.TransactionID()
+		if err != nil {
+			return api.StatusNone, err
+		}
+		// Transaction profiles expire even when the requested current stays unchanged.
+		if transactionID != c.transactionID {
+			if err := c.setCurrent(c.profileCurrent); err != nil {
+				return api.StatusNone, err
+			}
+		}
+	}
 
 	switch status {
 	case
@@ -304,18 +325,38 @@ func (c *OCPP) Enable(enable bool) error {
 	return err
 }
 
-// setCurrent sets the TxDefaultChargingProfile with given current
+// setCurrent applies the charging profile with the given current.
 func (c *OCPP) setCurrent(current float64) error {
-	err := c.conn.SetChargingProfileRequest(c.createTxDefaultChargingProfile(math.Trunc(10*current) / 10))
-	if err != nil {
-		err = fmt.Errorf("set charging profile: %w", err)
+	var transactionID int
+	if c.txProfile {
+		var err error
+		transactionID, err = c.conn.TransactionID()
+		if err != nil {
+			return err
+		}
+		if transactionID == 0 {
+			status, err := c.conn.Status()
+			if err != nil {
+				return err
+			}
+			// After reconnect, wait for MeterValues to recover an active transaction ID.
+			switch status {
+			case core.ChargePointStatusCharging, core.ChargePointStatusSuspendedEV, core.ChargePointStatusSuspendedEVSE:
+				return fmt.Errorf("transaction id: %w", api.ErrNotAvailable)
+			}
+		}
 	}
 
-	return err
+	if err := c.conn.SetChargingProfileRequest(c.createChargingProfile(math.Trunc(10*current)/10, transactionID)); err != nil {
+		return fmt.Errorf("set charging profile: %w", err)
+	}
+	c.transactionID = transactionID
+	c.profileCurrent = current
+	return nil
 }
 
-// createTxDefaultChargingProfile returns a TxDefaultChargingProfile with given current
-func (c *OCPP) createTxDefaultChargingProfile(current float64) *types.ChargingProfile {
+// createChargingProfile returns the charging profile for the current transaction.
+func (c *OCPP) createChargingProfile(current float64, transactionID int) *types.ChargingProfile {
 	phases := c.phases
 	period := types.NewChargingSchedulePeriod(0, current)
 
@@ -344,6 +385,10 @@ func (c *OCPP) createTxDefaultChargingProfile(current float64) *types.ChargingPr
 			ChargingRateUnit:       c.cp.ChargingRateUnit,
 			ChargingSchedulePeriod: []types.ChargingSchedulePeriod{period},
 		},
+	}
+	if c.txProfile && transactionID != 0 {
+		res.ChargingProfilePurpose = types.ChargingProfilePurposeTxProfile
+		res.TransactionId = transactionID
 	}
 
 	if c.profileKindRelative {

--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -95,6 +95,9 @@ func NewOCPPFromConfig(ctx context.Context, other map[string]any) (api.Charger, 
 	if cc.ChargingProfile != types.ChargingProfilePurposeTxDefaultProfile && cc.ChargingProfile != types.ChargingProfilePurposeTxProfile {
 		return nil, fmt.Errorf("invalid charging profile: %s", cc.ChargingProfile)
 	}
+	if cc.ChargingProfile == types.ChargingProfilePurposeTxProfile && cc.Connector <= 0 {
+		return nil, fmt.Errorf("TxProfile requires a positive connector: %d", cc.Connector)
+	}
 
 	stackLevelZero := cc.StackLevelZero != nil && *cc.StackLevelZero
 	profileKindRelative := cc.ProfileKindRelative

--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -337,7 +337,9 @@ func (c *OCPP) setCurrent(current float64) error {
 		if err != nil {
 			return err
 		}
-		if transactionID == 0 {
+		// StopTransaction clears the transaction id before the status notification arrives.
+		// Only an initially unknown transaction is awaited, an ended one restores the default profile.
+		if transactionID == 0 && c.transactionID == 0 {
 			status, err := c.conn.Status()
 			if err != nil {
 				return err

--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -39,6 +39,7 @@ import (
 // OCPP charger implementation
 type OCPP struct {
 	implement.Caps
+	log     *util.Logger
 	cp      *ocpp.CP
 	conn    *ocpp.Connector
 	phases  int
@@ -195,6 +196,7 @@ func NewOCPP(ctx context.Context,
 
 	c := &OCPP{
 		Caps:                implement.New(),
+		log:                 log,
 		cp:                  cp,
 		conn:                conn,
 		stackLevelZero:      stackLevelZero,
@@ -231,8 +233,9 @@ func (c *OCPP) Status() (api.ChargeStatus, error) {
 		}
 		// Transaction profiles expire even when the requested current stays unchanged.
 		if transactionID != c.transactionID {
+			// a failed update must not fail the status, it remains eligible for retry
 			if err := c.setCurrent(c.profileCurrent); err != nil {
-				return api.StatusNone, err
+				c.log.WARN.Printf("reapply charging profile: %v", err)
 			}
 		}
 	}

--- a/charger/ocpp_phases_test.go
+++ b/charger/ocpp_phases_test.go
@@ -40,7 +40,7 @@ func TestWattsProfilePhases(t *testing.T) {
 				c.lp = lp
 			}
 
-			profile := c.createTxDefaultChargingProfile(current)
+			profile := c.createChargingProfile(current, 0)
 			limit := profile.ChargingSchedule.ChargingSchedulePeriod[0].Limit
 
 			require.Equal(t, 230.0*current*float64(tc.wantPhases), limit)

--- a/charger/ocpp_profile_test.go
+++ b/charger/ocpp_profile_test.go
@@ -71,6 +71,10 @@ func TestOCPPChargingProfileValidation(t *testing.T) {
 		_, err := NewOCPPFromConfig(t.Context(), map[string]any{"chargingprofile": value})
 		require.ErrorContains(t, err, "invalid charging profile")
 	}
+	for _, connector := range []int{-1, 0} {
+		_, err := NewOCPPFromConfig(t.Context(), map[string]any{"chargingprofile": "TxProfile", "connector": connector})
+		require.ErrorContains(t, err, "TxProfile requires a positive connector")
+	}
 }
 
 func TestOCPPChargingProfileTemplates(t *testing.T) {

--- a/charger/ocpp_profile_test.go
+++ b/charger/ocpp_profile_test.go
@@ -1,0 +1,232 @@
+package charger
+
+import (
+	"encoding/json"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/charger/ocpp"
+	"github.com/evcc-io/evcc/util/sponsor"
+	"github.com/evcc-io/evcc/util/templates"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/smartcharging"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOCPPChargingProfile(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		txProfile   bool
+		txID        int
+		relative    bool
+		zeroStack   bool
+		wantTxID    int
+		wantPurpose types.ChargingProfilePurposeType
+	}{
+		{"default idle", false, 0, false, false, 0, types.ChargingProfilePurposeTxDefaultProfile},
+		{"default active", false, 42, false, false, 0, types.ChargingProfilePurposeTxDefaultProfile},
+		{"transaction idle", true, 0, false, false, 0, types.ChargingProfilePurposeTxDefaultProfile},
+		{"transaction active", true, 42, false, false, 42, types.ChargingProfilePurposeTxProfile},
+		{"relative transaction", true, 42, true, true, 42, types.ChargingProfilePurposeTxProfile},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &OCPP{
+				cp:        &ocpp.CP{ChargingProfileId: 3, StackLevel: 5, ChargingRateUnit: types.ChargingRateUnitAmperes},
+				txProfile: tc.txProfile, profileKindRelative: tc.relative, stackLevelZero: tc.zeroStack,
+			}
+			profile := c.createChargingProfile(7.2, tc.txID)
+			assert.Equal(t, tc.wantPurpose, profile.ChargingProfilePurpose)
+			assert.Equal(t, tc.wantTxID, profile.TransactionId)
+			assert.Equal(t, 3, profile.ChargingProfileId)
+			assert.Equal(t, 7.2, profile.ChargingSchedule.ChargingSchedulePeriod[0].Limit)
+			if tc.relative {
+				assert.Equal(t, types.ChargingProfileKindRelative, profile.ChargingProfileKind)
+				assert.Nil(t, profile.ChargingSchedule.StartSchedule)
+			} else {
+				assert.Equal(t, types.ChargingProfileKindAbsolute, profile.ChargingProfileKind)
+				require.NotNil(t, profile.ChargingSchedule.StartSchedule)
+				assert.True(t, profile.ChargingSchedule.StartSchedule.Before(time.Now()))
+			}
+			if tc.zeroStack {
+				assert.Zero(t, profile.StackLevel)
+			} else {
+				assert.Equal(t, 5, profile.StackLevel)
+			}
+			data, err := json.Marshal(profile)
+			require.NoError(t, err)
+			var fields map[string]any
+			require.NoError(t, json.Unmarshal(data, &fields))
+			_, hasTransactionID := fields["transactionId"]
+			assert.Equal(t, tc.wantTxID != 0, hasTransactionID)
+		})
+	}
+}
+
+func TestOCPPChargingProfileValidation(t *testing.T) {
+	for _, value := range []string{"", "unknown", "ChargePointMaxProfile"} {
+		_, err := NewOCPPFromConfig(t.Context(), map[string]any{"chargingprofile": value})
+		require.ErrorContains(t, err, "invalid charging profile")
+	}
+}
+
+func TestOCPPChargingProfileTemplates(t *testing.T) {
+	for _, name := range []string{"ocpp", "ocpp-autoaid"} {
+		for _, value := range []string{"", "TxDefaultProfile", "TxProfile"} {
+			t.Run(name+"/"+value, func(t *testing.T) {
+				tmpl, err := templates.ByName(templates.Charger, name)
+				require.NoError(t, err)
+				params := map[string]any{}
+				if value != "" {
+					params["chargingprofile"] = value
+				}
+				rendered, _, err := tmpl.RenderResult(templates.Charger, templates.RenderModeInstance, params)
+				require.NoError(t, err)
+				if value == "TxProfile" {
+					assert.Contains(t, string(rendered), "chargingprofile: TxProfile")
+				} else {
+					assert.NotContains(t, string(rendered), "chargingprofile:")
+				}
+			})
+		}
+	}
+}
+
+type ocppProfileHandler struct {
+	ChargePointHandler
+	profiles chan *smartcharging.SetChargingProfileRequest
+	reject   atomic.Bool
+}
+
+func (h *ocppProfileHandler) OnSetChargingProfile(req *smartcharging.SetChargingProfileRequest) (*smartcharging.SetChargingProfileConfirmation, error) {
+	h.profiles <- req
+	status := smartcharging.ChargingProfileStatusAccepted
+	if h.reject.Swap(false) {
+		status = smartcharging.ChargingProfileStatusRejected
+	}
+	return smartcharging.NewSetChargingProfileConfirmation(status), nil
+}
+
+func (suite *ocppTestSuite) TestTransactionProfiles() {
+	t := suite.T()
+	old := sponsor.Subject
+	sponsor.Subject = "test"
+	t.Cleanup(func() { sponsor.Subject = old })
+
+	id := suite.stationID("tx-profile")
+	cp, _, stop := suite.startChargePoint(id, 1)
+	h := &ocppProfileHandler{profiles: make(chan *smartcharging.SetChargingProfileRequest, 16)}
+	cp.SetSmartChargingHandler(h)
+	require.NoError(t, cp.Start(ocppTestUrl))
+	charger, err := NewOCPPFromConfig(t.Context(), map[string]any{
+		"stationid": id, "chargingprofile": "TxProfile", "connecttimeout": ocppTestConnectTimeout.String(),
+	})
+	require.NoError(t, err)
+	c := charger.(*OCPP)
+
+	expectProfile := func(purpose types.ChargingProfilePurposeType, txID int, current float64) {
+		t.Helper()
+		select {
+		case req := <-h.profiles:
+			assert.Equal(t, 1, req.ConnectorId)
+			assert.Equal(t, purpose, req.ChargingProfile.ChargingProfilePurpose)
+			assert.Equal(t, txID, req.ChargingProfile.TransactionId)
+			assert.Equal(t, current, req.ChargingProfile.ChargingSchedule.ChargingSchedulePeriod[0].Limit)
+		case <-time.After(time.Second):
+			t.Fatal("missing charging profile")
+		}
+	}
+
+	for _, status := range []core.ChargePointStatus{core.ChargePointStatusCharging, core.ChargePointStatusSuspendedEV, core.ChargePointStatusSuspendedEVSE} {
+		_, err = cp.StatusNotification(1, core.NoError, status)
+		require.NoError(t, err)
+		require.ErrorIs(t, c.MaxCurrentMillis(7.25), api.ErrNotAvailable)
+		require.Empty(t, h.profiles)
+	}
+	recoveredID := 77
+	_, err = cp.MeterValues(1, []types.MeterValue{{
+		Timestamp:    types.NewDateTime(time.Now()),
+		SampledValue: []types.SampledValue{{Measurand: types.MeasurandCurrentImport, Value: "0"}},
+	}}, func(req *core.MeterValuesRequest) { req.TransactionId = &recoveredID })
+	require.NoError(t, err)
+	_, err = c.Status()
+	require.NoError(t, err)
+	expectProfile(types.ChargingProfilePurposeTxProfile, recoveredID, 0)
+	_, err = cp.StopTransaction(0, types.NewDateTime(time.Now()), recoveredID)
+	require.NoError(t, err)
+	_, err = cp.StatusNotification(1, core.NoError, core.ChargePointStatusPreparing)
+	require.NoError(t, err)
+	_, err = c.Status()
+	require.NoError(t, err)
+	expectProfile(types.ChargingProfilePurposeTxDefaultProfile, 0, 0)
+	require.NoError(t, c.MaxCurrentMillis(7.25))
+	expectProfile(types.ChargingProfilePurposeTxDefaultProfile, 0, 7.2)
+
+	start, err := cp.StartTransaction(1, "tag", 0, types.NewDateTime(time.Now()))
+	require.NoError(t, err)
+	_, err = c.Status()
+	require.NoError(t, err)
+	expectProfile(types.ChargingProfilePurposeTxProfile, start.TransactionId, 7.2)
+	_, err = c.Status()
+	require.NoError(t, err)
+	require.Empty(t, h.profiles)
+
+	require.NoError(t, c.Enable(false))
+	expectProfile(types.ChargingProfilePurposeTxProfile, start.TransactionId, 0)
+	_, err = cp.StopTransaction(0, types.NewDateTime(time.Now()), start.TransactionId)
+	require.NoError(t, err)
+	_, err = cp.StatusNotification(1, core.NoError, core.ChargePointStatusFinishing)
+	require.NoError(t, err)
+	_, err = c.Status()
+	require.NoError(t, err)
+	expectProfile(types.ChargingProfilePurposeTxDefaultProfile, 0, 0)
+
+	start, err = cp.StartTransaction(1, "tag", 0, types.NewDateTime(time.Now()))
+	require.NoError(t, err)
+	h.reject.Store(true)
+	_, err = c.Status()
+	require.ErrorContains(t, err, "Rejected")
+	expectProfile(types.ChargingProfilePurposeTxProfile, start.TransactionId, 0)
+	_, err = c.Status()
+	require.NoError(t, err)
+	expectProfile(types.ChargingProfilePurposeTxProfile, start.TransactionId, 0)
+	require.NoError(t, c.Enable(true))
+	expectProfile(types.ChargingProfilePurposeTxProfile, start.TransactionId, 7.2)
+
+	stop()
+	require.Eventually(t, func() bool { return !c.cp.Connected() }, time.Second, 10*time.Millisecond)
+	require.ErrorIs(t, c.MaxCurrentMillis(10), api.ErrTimeout)
+}
+
+func (suite *ocppTestSuite) TestDefaultProfiles() {
+	t := suite.T()
+	old := sponsor.Subject
+	sponsor.Subject = "test"
+	t.Cleanup(func() { sponsor.Subject = old })
+	for _, value := range []string{"", "TxDefaultProfile"} {
+		id := suite.stationID("default-profile-" + value)
+		cp, _, _ := suite.startChargePoint(id, 1)
+		h := &ocppProfileHandler{profiles: make(chan *smartcharging.SetChargingProfileRequest, 16)}
+		cp.SetSmartChargingHandler(h)
+		require.NoError(t, cp.Start(ocppTestUrl))
+		config := map[string]any{"stationid": id, "connecttimeout": ocppTestConnectTimeout.String()}
+		if value != "" {
+			config["chargingprofile"] = value
+		}
+		charger, err := NewOCPPFromConfig(t.Context(), config)
+		require.NoError(t, err)
+		_, err = cp.StartTransaction(1, "tag", 0, types.NewDateTime(time.Now()))
+		require.NoError(t, err)
+		_, err = charger.Status()
+		require.NoError(t, err)
+		require.Empty(t, h.profiles)
+		require.NoError(t, charger.MaxCurrent(8))
+		require.Len(t, h.profiles, 1)
+		profile := (<-h.profiles).ChargingProfile
+		assert.Equal(t, types.ChargingProfilePurposeTxDefaultProfile, profile.ChargingProfilePurpose)
+		assert.Zero(t, profile.TransactionId)
+	}
+}

--- a/charger/ocpp_profile_test.go
+++ b/charger/ocpp_profile_test.go
@@ -191,8 +191,9 @@ func (suite *ocppTestSuite) TestTransactionProfiles() {
 	start, err = cp.StartTransaction(1, "tag", 0, types.NewDateTime(time.Now()))
 	require.NoError(t, err)
 	h.reject.Store(true)
+	// a rejected update is logged and retried, it must not fail the status
 	_, err = c.Status()
-	require.ErrorContains(t, err, "Rejected")
+	require.NoError(t, err)
 	expectProfile(types.ChargingProfilePurposeTxProfile, start.TransactionId, 0)
 	_, err = c.Status()
 	require.NoError(t, err)

--- a/charger/ocpp_profile_test.go
+++ b/charger/ocpp_profile_test.go
@@ -200,6 +200,15 @@ func (suite *ocppTestSuite) TestTransactionProfiles() {
 	require.NoError(t, c.Enable(true))
 	expectProfile(types.ChargingProfilePurposeTxProfile, start.TransactionId, 7.2)
 
+	// a transaction ending before its status notification must not block the default profile
+	_, err = cp.StatusNotification(1, core.NoError, core.ChargePointStatusCharging)
+	require.NoError(t, err)
+	_, err = cp.StopTransaction(0, types.NewDateTime(time.Now()), start.TransactionId)
+	require.NoError(t, err)
+	_, err = c.Status()
+	require.NoError(t, err)
+	expectProfile(types.ChargingProfilePurposeTxDefaultProfile, 0, 7.2)
+
 	stop()
 	require.Eventually(t, func() bool { return !c.cp.Connected() }, time.Second, 10*time.Millisecond)
 	require.ErrorIs(t, c.MaxCurrentMillis(10), api.ErrTimeout)

--- a/templates/definition/charger/ocpp.tpl
+++ b/templates/definition/charger/ocpp.tpl
@@ -6,6 +6,9 @@ stationid: {{ .stationid }}
 {{- if ne .connector "1" }}
 connector: {{ .connector }}
 {{- end }}
+{{- if and .chargingprofile (ne .chargingprofile "TxDefaultProfile") }}
+chargingprofile: {{ .chargingprofile }}
+{{- end }}
 {{- if .idtag }}
 idtag: {{ .idtag }}
 {{- end }}

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -733,6 +733,21 @@ presets:
   ocpp:
     - name: stationid
     - name: connector
+    - name: chargingprofile
+      advanced: true
+      type: choice
+      choice: ["TxDefaultProfile", "TxProfile"]
+      default: TxDefaultProfile
+      description:
+        de: Ladeprofiltyp
+        en: Charging profile type
+      help:
+        de: |
+          TxProfile nur verwenden, wenn die Wallbox Änderungen an TxDefaultProfile während einer laufenden Transaktion ignoriert. Ohne Transaktion wird weiterhin TxDefaultProfile verwendet; eine laufende Transaktion muss ihre ID melden.
+          TxProfile endet mit der Transaktion. Das Standardprofil wird beim nächsten Regelzyklus wiederhergestellt. Ist evcc dabei offline, kann die Wallbox bis zur Wiederverbindung ohne dieses Limit laden.
+        en: |
+          Use TxProfile only if the charger ignores TxDefaultProfile changes during an active transaction. Without a transaction, TxDefaultProfile is still used; an active transaction must report its ID.
+          TxProfile expires with its transaction. The default profile is restored on the next control cycle. If evcc is offline then, the charger may charge without this limit until it reconnects.
     - name: remotestart
       advanced: true
       type: bool


### PR DESCRIPTION
Refs https://github.com/evcc-io/evcc/discussions/2699#discussioncomment-18245429

Allow selecting transaction-specific charging profiles for chargers that accept but ignore `TxDefaultProfile` updates during an active session, as reported for Autoaid.

- Add advanced `chargingprofile` selection to OCPP templates: `TxDefaultProfile` (unchanged default) or `TxProfile`, which requires a positive connector.
- Send `TxProfile` with the active transaction ID. Use `TxDefaultProfile` before and after transactions. Only an initially unknown transaction is awaited for ID recovery after reconnect, an ended transaction restores the default profile immediately.
- Reapply the last accepted limit, including zero while disabled, when the transaction changes. A failed or rejected update is logged and remains eligible for retry instead of failing the status.
- Preserve charging units, schedule kind, profile ID, and stack-level settings. No automatic fallback based on an `Accepted` response.

`TxProfile` expires with its transaction and replaces the default profile when using the same profile ID. Restoring the default requires another control cycle; if evcc is offline when the transaction ends, the charger may operate without that limit. Confirmed working on the affected Autoaid hardware in https://github.com/evcc-io/evcc/discussions/2699#discussioncomment-18387417.

Generated with [OpenCode](https://opencode.ai)
