### PR TITLE
Remote Access UI: don't show toast for proxy errors

### DIFF
--- a/assets/js/api.ts
+++ b/assets/js/api.ts
@@ -35,6 +35,11 @@ const errorInterceptor = (error: any) => {
     return Promise.reject(error);
   }
 
+  // proxy/tunnel errors, backend unreachable, no toast
+  if ([502, 503, 504].includes(error.response?.status)) {
+    return Promise.reject(error);
+  }
+
   // handle unauthorized errors
   if (error.response?.status === 401) {
     openLoginModal();

--- a/assets/js/restart.ts
+++ b/assets/js/restart.ts
@@ -7,11 +7,15 @@ const restart = reactive({
 });
 
 export async function performRestart() {
+  restart.restarting = true;
   try {
     await api.post("/system/shutdown");
-    restart.restarting = true;
-  } catch (e) {
-    alert(`Unable to restart server. ${e}`);
+  } catch (e: any) {
+    // connection may drop before response
+    if (e.response?.status < 500) {
+      restart.restarting = false;
+      alert(`Unable to restart server. ${e}`);
+    }
   }
 }
 


### PR DESCRIPTION
Restarting via a tunnel URL showed a "Request failed with status code 502" toast. The reverse proxy answers 502/503/504 whenever the backend is briefly unreachable (restart, reconnect), so these are not actionable for the user.

- Global error interceptor skips the toast for 502, 503 and 504
- Restart sets the restarting flag before the request and only alerts on real backend errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)