### PR TITLE
GhostEEBus: isolate phase-switch test HTTP transport

### DIFF
--- a/charger/ghosteebus_test.go
+++ b/charger/ghosteebus_test.go
@@ -186,14 +186,16 @@ func TestGhostEEBus_PhaseSwitch(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			wb := newTestGhostEEBusREST(t)
 
-			httpmock.ActivateNonDefault(wb.Client)
-			defer httpmock.DeactivateAndReset()
+			transport := httpmock.NewMockTransport()
+			wb.Client.Transport = transport
 
 			// mock PUT (phase switch command)
 			var capturedBody ghostone.RelaisSwitchStateWrite
-			httpmock.RegisterResponder(http.MethodPut, ghostEEBusRelaisStateURL,
+			transport.RegisterResponder(http.MethodPut, ghostEEBusRelaisStateURL,
 				func(req *http.Request) (*http.Response, error) {
 					if err := json.NewDecoder(req.Body).Decode(&capturedBody); err != nil {
 						return httpmock.NewStringResponse(400, ""), nil
@@ -204,14 +206,14 @@ func TestGhostEEBus_PhaseSwitch(t *testing.T) {
 
 			// mock GET (read-after-write verification)
 			body, _ := json.Marshal(tc.readBack)
-			httpmock.RegisterResponder(http.MethodGet, ghostEEBusRelaisStateURL,
+			transport.RegisterResponder(http.MethodGet, ghostEEBusRelaisStateURL,
 				httpmock.NewBytesResponder(200, body),
 			)
 
 			err := wb.phases1p3p(tc.phases)
 
 			assert.Equal(t, tc.wantValue, capturedBody.Value)
-			assert.Equal(t, 2, httpmock.GetTotalCallCount(), "expected PUT + GET")
+			assert.Equal(t, 2, transport.GetTotalCallCount(), "expected PUT + GET")
 
 			if tc.wantErr {
 				require.Error(t, err)

--- a/charger/ghosteebus_test.go
+++ b/charger/ghosteebus_test.go
@@ -143,6 +143,8 @@ func TestGhostEEBus_PhaseSwitchISO15118(t *testing.T) {
 }
 
 func TestGhostEEBus_PhaseSwitch(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		phases    int


### PR DESCRIPTION
Refs #33525, where this independent test failure was observed during validation.

The phase-switch test used httpmock’s shared transport and global request counter, allowing unrelated requests to break its expected PUT + GET count. Give each case its own transport rather than weakening the assertion.

- Keep responders and request counts local to each case.
- Run cases in parallel to exercise isolation between conflicting responses.
- No charger behavior changes.

🤖 Generated with [OpenCode](https://opencode.ai)