### PR TITLE
Sigenergy: add per-string meter

### DIFF
--- a/templates/definition/meter/sigenergy.yaml
+++ b/templates/definition/meter/sigenergy.yaml
@@ -14,6 +14,14 @@ requirements:
   description:
     de: Modbus TCP muss in der Konfigurations-App mit Installateursrechten aktiviert werden. Diese Option ist in der mySigen App für Kunden nicht verfügbar.
     en: Modbus TCP must be enabled in the configuration app with installer rights. This option is not available in the mySigen app for customers.
+caveats:
+  - description:
+      de: |
+        Einzelne MPPT-Zähler messen auf der DC-Seite (vor dem Wechselrichter), der Gesamt-Zähler auf der AC-Seite (hinter dem Wechselrichter).
+        Aufgrund von Umwandlungsverlusten des Wechselrichters können die Werte beider Seiten voneinander abweichen.
+      en: |
+        Individual MPPT meters measure on the DC side (before the inverter), the total meter on the AC side (behind the inverter).
+        Due to inverter conversion losses the values of both sides can differ.
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
@@ -23,21 +31,22 @@ params:
   - name: id
     default: 1
   - name: maxacpower
-  - name: string
+  - name: mppt
     type: choice
-    choice: ["0", "1", "2", "3", "4"]
+    choice: ["all", "mppt1", "mppt2", "mppt3", "mppt4"]
+    default: all
     usages: ["pv"]
     advanced: true
     description:
-      de: PV String
-      en: PV String
+      de: PV MPPT
+      en: PV MPPT
     help:
       de: |
-        Nicht gesetzt oder 0 = Gesamtleistung aller Strings, 1-4 = ein einzelner String.
-        String-Zähler messen DC-Leistung (Spannung × Strom) und dienen nur der Überwachung. Als PV-Zähler der Site den Gesamtleistungs-Zähler (0) verwenden.
+        Nicht gesetzt oder all = Gesamtleistung auf der AC-Seite (hinter dem Wechselrichter), mppt1-4 = ein einzelner MPPT auf der DC-Seite (vor dem Wechselrichter).
+        MPPT-Zähler messen die DC-Leistung (Spannung × Strom) auf der DC-Seite. Für einzelne MPPTs gibt es keinen Energiezähler.
       en: |
-        Unset or 0 = total power of all strings, 1-4 = one individual string.
-        String meters measure DC power (voltage × current) and are for monitoring only. Keep the total-power meter (0) as the site's PV meter.
+        Unset or all = total power on the AC side (behind the inverter), mppt1-4 = one individual MPPT on the DC side (before the inverter).
+        MPPT meters measure DC power (voltage × current) on the DC side. There is no accumulated energy register for individual MPPTs.
   - preset: battery-params
 render: |
   type: custom
@@ -86,7 +95,7 @@ render: |
       scale: 0.01
   {{- end }}
   {{- if eq .usage "pv" }}
-  {{- if and .string (ne .string "0") }}
+  {{- if and .mppt (ne .mppt "all") }}
   power:
     source: calc
     mul:
@@ -94,7 +103,7 @@ render: |
         uri: {{ joinHostPort .host .port }}
         id: {{ .id }}
         register:
-          address: {{ add 31027 (mul 2 (sub (int .string) 1)) }} # PV{{ .string }} voltage
+          address: {{ add 31027 (mul 2 (sub (int (trimPrefix "mppt" .mppt)) 1)) }} # {{ .mppt }} voltage
           type: holding
           decode: int16
         scale: 0.1
@@ -102,7 +111,7 @@ render: |
         uri: {{ joinHostPort .host .port }}
         id: {{ .id }}
         register:
-          address: {{ add 31028 (mul 2 (sub (int .string) 1)) }} # PV{{ .string }} current
+          address: {{ add 31028 (mul 2 (sub (int (trimPrefix "mppt" .mppt)) 1)) }} # {{ .mppt }} current
           type: holding
           decode: int16
         scale: 0.01

--- a/templates/definition/meter/sigenergy.yaml
+++ b/templates/definition/meter/sigenergy.yaml
@@ -23,6 +23,19 @@ params:
   - name: id
     default: 1
   - name: maxacpower
+  - name: string
+    type: choice
+    choice: ["0", "1", "2", "3", "4"]
+    usages: ["pv"]
+    advanced: true
+    description:
+      de: PV String
+      en: PV String
+    help:
+      de: |
+        Nicht gesetzt oder 0 = Gesamtleistung aller Strings, 1-4 = ein einzelner String.
+      en: |
+        Unset or 0 = total power of all strings, 1-4 = one individual string.
   - preset: battery-params
 render: |
   type: custom
@@ -71,6 +84,27 @@ render: |
       scale: 0.01
   {{- end }}
   {{- if eq .usage "pv" }}
+  {{- if and .string (ne .string "0") }}
+  power:
+    source: calc
+    mul:
+      - source: modbus
+        uri: {{ joinHostPort .host .port }}
+        id: {{ .id }}
+        register:
+          address: {{ add 31027 (mul 2 (sub (int .string) 1)) }} # PV{{ .string }} voltage
+          type: holding
+          decode: int16
+        scale: 0.1
+      - source: modbus
+        uri: {{ joinHostPort .host .port }}
+        id: {{ .id }}
+        register:
+          address: {{ add 31028 (mul 2 (sub (int .string) 1)) }} # PV{{ .string }} current
+          type: holding
+          decode: int16
+        scale: 0.01
+  {{- else }}
   power:
     source: modbus
     uri: {{ joinHostPort .host .port }}
@@ -80,6 +114,7 @@ render: |
       address: 31035 # PV power (per inverter)
       decode: int32
   maxacpower: {{ .maxacpower }} # W
+  {{- end }}
   {{- end }}
   {{- if eq .usage "battery" }}
   power:

--- a/templates/definition/meter/sigenergy.yaml
+++ b/templates/definition/meter/sigenergy.yaml
@@ -34,8 +34,10 @@ params:
     help:
       de: |
         Nicht gesetzt oder 0 = Gesamtleistung aller Strings, 1-4 = ein einzelner String.
+        String-Zähler messen DC-Leistung (Spannung × Strom) und dienen nur der Überwachung. Als PV-Zähler der Site den Gesamtleistungs-Zähler (0) verwenden.
       en: |
         Unset or 0 = total power of all strings, 1-4 = one individual string.
+        String meters measure DC power (voltage × current) and are for monitoring only. Keep the total-power meter (0) as the site's PV meter.
   - preset: battery-params
 render: |
   type: custom

--- a/templates/definition/meter/sigenergy.yaml
+++ b/templates/definition/meter/sigenergy.yaml
@@ -98,23 +98,27 @@ render: |
   {{- if and .mppt (ne .mppt "all") }}
   power:
     source: calc
-    mul:
-      - source: modbus
-        uri: {{ joinHostPort .host .port }}
-        id: {{ .id }}
-        register:
-          address: {{ add 31027 (mul 2 (sub (int (trimPrefix "mppt" .mppt)) 1)) }} # {{ .mppt }} voltage
-          type: holding
-          decode: int16
-        scale: 0.1
-      - source: modbus
-        uri: {{ joinHostPort .host .port }}
-        id: {{ .id }}
-        register:
-          address: {{ add 31028 (mul 2 (sub (int (trimPrefix "mppt" .mppt)) 1)) }} # {{ .mppt }} current
-          type: holding
-          decode: int16
-        scale: 0.01
+    max:
+      - source: calc
+        mul:
+          - source: modbus
+            uri: {{ joinHostPort .host .port }}
+            id: {{ .id }}
+            register:
+              address: {{ add 31027 (mul 2 (sub (int (trimPrefix "mppt" .mppt)) 1)) }} # {{ .mppt }} voltage
+              type: holding
+              decode: int16
+            scale: 0.1
+          - source: modbus
+            uri: {{ joinHostPort .host .port }}
+            id: {{ .id }}
+            register:
+              address: {{ add 31028 (mul 2 (sub (int (trimPrefix "mppt" .mppt)) 1)) }} # {{ .mppt }} current
+              type: holding
+              decode: int16
+            scale: 0.01
+      - source: const
+        value: 0
   {{- else }}
   power:
     source: modbus


### PR DESCRIPTION
Supersedes and reopens #33114 (auto-closed as stale while in draft). Updated to latest master and now includes the clamp that avoids negative MPPT readings at low production (discussed in the original PR).

Based on no objection on #32715, this adds per-MPPT selection for the Sigenergy template.

## Why?
If you have two different roofs (e.g. east / west) connected to the same Sigenergy inverter, the current modbus template only catches the total power produced by both sides.

## Solution
The template is extended to use the additional modbus registers.
An existing config ignores the new option; it only becomes active when the meter is reconfigured to use it.

## Gotcha
The per-MPPT registers measure DC power (voltage × current) on the DC side, so they deviate from the AC-side total by inverter conversion losses. The clamp ensures power does not go negative at near-zero production. Intended as an additional meter for statistics, not as the PV overall power meter.

Changes vs the previously reviewed commits:
- Rebased onto current evcc master
- `power` is now clamped to a minimum of 0 (avoids negative readings when production is near zero)