### PR TITLE
chore: fail early when vp is not Vite+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,14 @@ clean::
 install::
 	go install tool
 
-install-ui::
+# verify vp is Vite+ before running ui tasks
+check-vp::
+	@vp --version 2>/dev/null | grep -q '^vp v' || { echo "vp is not Vite+, see https://viteplus.dev/guide/#install-vp" >&2; exit 1; }
+
+install-ui:: check-vp
 	vp install
 
-ui::
+ui:: check-vp
 	vp run build
 
 assets::


### PR DESCRIPTION
fixes #33532

Another \`vp\` binary on PATH silently skipped \`vp install\` and \`vp run build\`, leaving no \`dist\` for the Go embed. The Makefile now verifies \`vp --version\` before running ui tasks.

- \`check-vp\` target, prerequisite of \`install-ui\` and \`ui\`
- clear error with install link instead of a confusing embed failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)