### PR TITLE
fox-ess-h3-smart: hold via On-Grid SoC reserve instead of Feed-in First

### DIFF
--- a/templates/definition/meter/fox-ess-h3-smart.yaml
+++ b/templates/definition/meter/fox-ess-h3-smart.yaml
@@ -186,29 +186,12 @@ render: |
           source: sequence
           set:
           - source: const
-            value: 1 # Self Use, fallback if the remote control watchdog expires.
-            # Feed-in First (as used previously) charges the battery from PV before AC
-            # loads, which starves the EV of solar during fast charging. Blocking
-            # discharge via the On-Grid SoC reserve below keeps normal Self Use load
-            # priority while still preventing the battery from discharging.
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 12 }}
-              register:
-                address: 49203 # Work Mode
-                type: writesingle
-                encoding: uint16
-          - source: const
-            value: 60 # Remote timeout 60 seconds
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 12 }}
-              register:
-                address: 46002 # Remote Timeout Set
-                type: writesingle
-                encoding: uint16
-          - source: const
-            value: 1 # Enabled
+            value: 0 # Disabled: keeping remote control enabled with a 0W active power
+            # target (tried previously) makes the inverter curtail PV production
+            # entirely instead of just holding the battery, confirmed on real
+            # hardware. Stay on plain Self Use and rely solely on the On-Grid SoC
+            # reserve below to block discharge; Work Mode is not locked against
+            # external changes while holding, which is the accepted trade-off.
             set:
               source: modbus
               {{- include "modbus" . | indent 12 }}
@@ -217,14 +200,14 @@ render: |
                 type: writesingle
                 encoding: uint16
           - source: const
-            value: 0 # W
+            value: 1 # Self Use
             set:
               source: modbus
               {{- include "modbus" . | indent 12 }}
               register:
-                address: 46003 # Remote Active Power, int32 across 46003 (high word) and 46004 (low word)
-                type: writemultiple
-                encoding: int32
+                address: 49203 # Work Mode
+                type: writesingle
+                encoding: uint16
           - source: const
             value: 100 # blocks discharge regardless of current SoC
             set:

--- a/templates/definition/meter/fox-ess-h3-smart.yaml
+++ b/templates/definition/meter/fox-ess-h3-smart.yaml
@@ -172,30 +172,25 @@ render: |
                 address: 46610 # Maximum SoC
                 type: writesingle
                 encoding: uint16
+          - source: const
+            value: {{ .minsoc }}
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 46611 # Minimum SoC On-Grid
+                type: writesingle
+                encoding: uint16
       - case: 2 # hold - stop battery discharge
         set:
           source: sequence
           set:
           - source: const
-            value: 2 # Feed-in First, fallback if the remote control watchdog expires
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 12 }}
-              register:
-                address: 49203 # Work Mode
-                type: writesingle
-                encoding: uint16
-          - source: const
-            value: 60 # Remote timeout 60 seconds
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 12 }}
-              register:
-                address: 46002 # Remote Timeout Set
-                type: writesingle
-                encoding: uint16
-          - source: const
-            value: 1 # Enabled
+            value: 0 # Disabled: stay on Self Use, PV still serves AC loads (incl. EV) first.
+            # Feed-in First (as used previously) charges the battery from PV before AC
+            # loads, which starves the EV of solar during fast charging. Blocking
+            # discharge via the On-Grid SoC reserve below keeps normal Self Use load
+            # priority while still preventing the battery from discharging.
             set:
               source: modbus
               {{- include "modbus" . | indent 12 }}
@@ -204,14 +199,23 @@ render: |
                 type: writesingle
                 encoding: uint16
           - source: const
-            value: 0 # W
+            value: 1 # Self Use
             set:
               source: modbus
               {{- include "modbus" . | indent 12 }}
               register:
-                address: 46003 # Remote Active Power, int32 across 46003 (high word) and 46004 (low word)
-                type: writemultiple
-                encoding: int32
+                address: 49203 # Work Mode
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 100 # blocks discharge regardless of current SoC
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 46611 # Minimum SoC On-Grid
+                type: writesingle
+                encoding: uint16
       - case: 3 # charge - force battery charge
         set:
           source: sequence

--- a/templates/definition/meter/fox-ess-h3-smart.yaml
+++ b/templates/definition/meter/fox-ess-h3-smart.yaml
@@ -186,7 +186,7 @@ render: |
           source: sequence
           set:
           - source: const
-            value: 0 # Disabled: stay on Self Use, PV still serves AC loads (incl. EV) first.
+            value: 1 # Self Use, fallback if the remote control watchdog expires.
             # Feed-in First (as used previously) charges the battery from PV before AC
             # loads, which starves the EV of solar during fast charging. Blocking
             # discharge via the On-Grid SoC reserve below keeps normal Self Use load
@@ -195,18 +195,36 @@ render: |
               source: modbus
               {{- include "modbus" . | indent 12 }}
               register:
-                address: 46001 # Remote Control
+                address: 49203 # Work Mode
                 type: writesingle
                 encoding: uint16
           - source: const
-            value: 1 # Self Use
+            value: 60 # Remote timeout 60 seconds
             set:
               source: modbus
               {{- include "modbus" . | indent 12 }}
               register:
-                address: 49203 # Work Mode
+                address: 46002 # Remote Timeout Set
                 type: writesingle
                 encoding: uint16
+          - source: const
+            value: 1 # Enabled
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 46001 # Remote Control
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 0 # W
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 46003 # Remote Active Power, int32 across 46003 (high word) and 46004 (low word)
+                type: writemultiple
+                encoding: int32
           - source: const
             value: 100 # blocks discharge regardless of current SoC
             set:


### PR DESCRIPTION
Fixes #33536

When using Fast mode or Solar with the planner, and house battery discharing is disabled, we end up importing all the power for the charger, while using solar to charge the house battery.

This is due to the hold mode being fixed, which reveals that Feed-In seems to be the wrong mode.

This changes it, so it stays in Self-Use mode, which makes it use the solar for the charger, with grid import topping up to the maximum.