### PR TITLE
Optimizer: resolve suggestions against wall-clock time

### DIFF
--- a/core/optimizer_schedule_test.go
+++ b/core/optimizer_schedule_test.go
@@ -95,7 +95,7 @@ func TestApplyOptimizerResultSchedule(t *testing.T) {
 			site := &Site{valueChan: values}
 			site.applyOptimizerResult(req, details, res, schedule, tc.at)
 
-			s, ok := site.suggestions[batteryKey("home")]
+			s, ok := site.suggestionPlan.suggestions(tc.at)[batteryKey("home")]
 			require.True(t, ok)
 			assert.Equal(t, api.BatteryCharge.String(), s.Action)
 			assert.InDelta(t, tc.power, s.Charge, 1e-3)

--- a/core/site.go
+++ b/core/site.go
@@ -112,13 +112,13 @@ type Site struct {
 	// cached measurement state, guarded by RWMutex
 	siteState
 
-	batteryMaxDischargePower *float64                    // Max discharge power of all battery meters
-	batteryMode              api.BatteryMode             // Battery mode (runtime only, not persisted)
-	batteryModeExternal      api.BatteryMode             // Battery mode (external, runtime only, not persisted)
-	batteryModeExternalTimer time.Time                   // Battery mode timer for external control
-	batteryModeApplied       map[string]api.BatteryMode  // Battery mode last applied per battery meter
-	suggestions              map[string]types.Suggestion // Optimizer suggestions by device key
-	suggestionActions        map[string]string           // last notified actionable optimizer action by device key
+	batteryMaxDischargePower *float64                   // Max discharge power of all battery meters
+	batteryMode              api.BatteryMode            // Battery mode (runtime only, not persisted)
+	batteryModeExternal      api.BatteryMode            // Battery mode (external, runtime only, not persisted)
+	batteryModeExternalTimer time.Time                  // Battery mode timer for external control
+	batteryModeApplied       map[string]api.BatteryMode // Battery mode last applied per battery meter
+	suggestionPlan           *suggestionPlan            // whole-horizon optimizer suggestions, looked up per slot on read
+	suggestionActions        map[string]string          // last notified actionable optimizer action by device key
 
 	optimizerMu      sync.Mutex // guards optimizer runs
 	optimizerUpdated time.Time  // last optimizer run, guarded by optimizerMu

--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -216,12 +216,12 @@ func loadpointCurrentAction(lp *Loadpoint) string {
 	return actionStop
 }
 
-// setSuggestions replaces the suggestions applied on each publish
-func (site *Site) setSuggestions(suggestions map[string]types.Suggestion) {
+// setSuggestionPlan replaces the suggestion plan applied on each publish
+func (site *Site) setSuggestionPlan(plan *suggestionPlan) {
 	site.Lock()
 	defer site.Unlock()
 
-	site.suggestions = suggestions
+	site.suggestionPlan = plan
 }
 
 // setBatteryForecast replaces the battery forecast of the cached state
@@ -232,14 +232,16 @@ func (site *Site) setBatteryForecast(forecast *types.BatteryForecast) {
 	site.battery.Forecast = forecast
 }
 
-// suggestion returns the optimizer suggestion for the given device key.
-// The actionable flag is evaluated on read against the device's current
-// action since that changes between optimizer runs.
+// suggestion returns the optimizer suggestion for the given device key, for
+// the slot covering wall-clock now. The actionable flag is evaluated on read
+// against the device's current action since that changes between optimizer
+// runs.
 func (site *Site) suggestion(key, currentAction string) *types.Suggestion {
 	site.RLock()
-	s, ok := site.suggestions[key]
+	plan := site.suggestionPlan
 	site.RUnlock()
 
+	s, ok := plan.suggestions(time.Now())[key]
 	if !ok {
 		return nil
 	}
@@ -267,7 +269,7 @@ func (site *Site) publishSuggestions() {
 // clearSuggestions removes all suggestions and the battery forecast when the
 // optimizer result is stale
 func (site *Site) clearSuggestions() {
-	site.setSuggestions(nil)
+	site.setSuggestionPlan(nil)
 	site.setBatteryForecast(nil)
 
 	site.publishBattery()
@@ -333,6 +335,57 @@ func (site *Site) diffSuggestions(pending map[string]pendingSuggestion) []messen
 type requestDetails struct {
 	Timestamps     []time.Time     `json:"timestamp"`
 	BatteryDetails []batteryDetail `json:"batteryDetails"`
+}
+
+// suggestionPlan resolves whichever slot covers now on each read (see
+// optimizerSchedule - a solve started shortly before a slot boundary can
+// return after it, so slot 0 isn't always the active slot), instead of
+// precomputing every slot up front: only the slot a read actually lands on
+// is ever needed.
+type suggestionPlan struct {
+	schedule optimizerSchedule
+	resolve  func(slot int) map[string]types.Suggestion
+}
+
+// suggestions returns every device's suggestion for the slot covering now,
+// keyed by device key, or nil if no slot does.
+func (p *suggestionPlan) suggestions(now time.Time) map[string]types.Suggestion {
+	if p == nil {
+		return nil
+	}
+	slot := p.schedule.activeSlot(now)
+	if slot < 0 {
+		return nil
+	}
+	return p.resolve(slot)
+}
+
+// buildSuggestionPlan resolves a run's suggestions for whichever slot is
+// asked for, from the request/response of a single optimizer call.
+func buildSuggestionPlan(details []batteryDetail, res optimizer.OptimizationResult, schedule optimizerSchedule) *suggestionPlan {
+	return &suggestionPlan{
+		schedule: schedule,
+		resolve: func(slot int) map[string]types.Suggestion {
+			slotHours := schedule.duration(slot).Hours()
+			gridImporting := slot < len(res.GridImport) && res.GridImport[slot] > 0
+			gridExporting := slot < len(res.GridExport) && res.GridExport[slot] > 0
+
+			suggestions := make(map[string]types.Suggestion, len(details))
+			for j, detail := range details {
+				// uncontrollable devices can't act on a suggestion
+				key := detail.key()
+				if key == "" || !detail.controllable {
+					continue
+				}
+
+				suggestion := currentSlotSuggestion(detail, res.Batteries[j], slot, gridImporting, gridExporting, slotHours)
+				if suggestion.Action != "" {
+					suggestions[key] = suggestion
+				}
+			}
+			return suggestions
+		},
+	}
 }
 
 // optimizerBattery pairs a battery request entry with its device detail
@@ -647,13 +700,7 @@ func (site *Site) optimizerUpdate(battery []types.Measurement) error {
 // applyOptimizerResult maps the optimizer response onto suggestions, battery
 // forecast and notifications
 func (site *Site) applyOptimizerResult(req optimizer.OptimizationInput, details requestDetails, res optimizer.OptimizationResult, schedule optimizerSchedule, now time.Time) {
-	slot := schedule.activeSlot(now)
-	slotHours := schedule.duration(slot).Hours()
-	gridImporting := slot >= 0 && slot < len(res.GridImport) && res.GridImport[slot] > 0
-	gridExporting := slot >= 0 && slot < len(res.GridExport) && res.GridExport[slot] > 0
-
 	var batteries []batteryResult
-	suggestions := make(map[string]types.Suggestion, len(req.Batteries))
 
 	for i, batReq := range req.Batteries {
 		batRes := res.Batteries[i]
@@ -668,21 +715,11 @@ func (site *Site) applyOptimizerResult(req optimizer.OptimizationInput, details 
 				return soc <= batReq.SMin
 			}),
 		})
-
-		suggestion := currentSlotSuggestion(detail, batRes, slot, gridImporting, gridExporting, slotHours)
-		if suggestion.Action == "" {
-			continue
-		}
-
-		// uncontrollable devices can't act on a suggestion
-		if key := detail.key(); key != "" && detail.controllable {
-			suggestions[key] = suggestion
-		}
 	}
 
 	site.publish("evopt-batteries", batteries)
 
-	site.setSuggestions(suggestions)
+	site.setSuggestionPlan(buildSuggestionPlan(details.BatteryDetails, res, schedule))
 	site.setBatteryForecast(site.addBatteryForecastTotals(req.Batteries, res.Batteries, schedule, now))
 
 	site.publishBattery()

--- a/core/site_optimizer_test.go
+++ b/core/site_optimizer_test.go
@@ -766,3 +766,41 @@ func TestBuildSuggestionPlanPerSlot(t *testing.T) {
 	assert.Equal(t, api.BatteryHold.String(), plan.resolve(1)["battery:home"].Action)
 	assert.Equal(t, api.BatteryDischarge.String(), plan.resolve(2)["battery:home"].Action)
 }
+
+// TestSuggestionPlanResolvesOrdinaryDrift covers the ordinary case, not an
+// edge case: optimizerUpdateAsync only re-solves tariff.SlotDuration after
+// the *previous* solve's own completion (core/site_optimizer.go), not
+// aligned to the slot grid. A solve completing t minutes into its slot
+// leaves site.suggestions describing that slot for exactly t minutes after
+// it has already ended - every run, proportional to how late in its slot
+// the previous solve happened to land, not just in a rare short-slot case.
+func TestSuggestionPlanResolvesOrdinaryDrift(t *testing.T) {
+	// solve completes 8 minutes into a 12:00-12:15 slot - unremarkable timing,
+	// no unusually short or delayed solve involved
+	applied := time.Date(2025, 1, 1, 12, 8, 0, 0, time.UTC)
+	dt := []int{7 * 60, 900, 900} // 7min left in the current slot, then full 15min slots
+	timestamps := asTimestamps(dt, applied)
+	schedule := optimizerSchedule{timestamps: timestamps, dt: dt}
+
+	slot := schedule.activeSlot(applied)
+	assert.Equal(t, 0, slot, "slot 0 is genuinely active when the result is applied")
+
+	plan := buildSuggestionPlan(
+		[]batteryDetail{{Type: batteryTypeBattery, Name: "home", controllable: true}},
+		optimizer.OptimizationResult{
+			GridImport: []float32{0, 500, 0},
+			Batteries: []optimizer.BatteryResult{{
+				ChargingPower:    []float32{0, 0, 0},
+				DischargingPower: []float32{0, 0, 0},
+			}},
+		},
+		schedule,
+	)
+
+	// next possible solve: not until 15min after 12:08, i.e. 12:23 - 8 minutes
+	// after the 12:00 slot already ended at 12:15. A read anywhere in that
+	// 8-minute gap must resolve to slot 1, not the expired slot 0.
+	midGap := time.Date(2025, 1, 1, 12, 20, 0, 0, time.UTC)
+	assert.Equal(t, api.BatteryHold.String(), plan.suggestions(midGap)["battery:home"].Action,
+		"read mid-gap resolves to slot 1 (import, idle -> hold), not the expired slot 0 (no import -> normal)")
+}

--- a/core/site_optimizer_test.go
+++ b/core/site_optimizer_test.go
@@ -558,6 +558,19 @@ func TestCurrentSlotSuggestion(t *testing.T) {
 	}
 	s := currentSlotSuggestion(batteryDetail{Type: batteryTypeBattery}, res, 1, true, false, 1)
 	assert.Equal(t, api.BatteryHold.String(), s.Action)
+
+	// a result whose active slot is not 0 (a delayed run, see optimizerSchedule)
+	// reads that slot's corner values, not the expired slot 0's
+	res2 := optimizer.BatteryResult{
+		ChargingPower:    []float32{3000, 0},
+		DischargingPower: []float32{0, 0},
+	}
+	s2 := currentSlotSuggestion(batteryDetail{Type: batteryTypeBattery}, res2, 1, false, false, 1)
+	assert.Equal(t, "normal", s2.Action)
+	assert.InDelta(t, 0, s2.Charge, 1e-3)
+
+	// an out-of-range slot yields an empty suggestion instead of panicking
+	assert.Empty(t, currentSlotSuggestion(batteryDetail{Type: batteryTypeBattery}, res2, 2, false, false, 1))
 }
 
 // TestSuggestionActionable ensures the actionable flag follows the current state
@@ -569,10 +582,10 @@ func TestSuggestionActionable(t *testing.T) {
 		batteryMode: api.BatteryNormal,
 		loadpoints:  []*Loadpoint{lp},
 	}
-	site.setSuggestions(map[string]types.Suggestion{
+	site.setSuggestionPlan(singleSlotSuggestionPlan(map[string]types.Suggestion{
 		batteryKey("bat"): {Action: api.BatteryCharge.String()},
 		loadpointKey(0):   {Action: actionCharge},
-	})
+	}))
 
 	batterySuggestion := func(name string) *types.Suggestion {
 		return site.suggestion(batteryKey(name), site.GetBatteryMode().String())
@@ -660,4 +673,96 @@ func TestDiffSuggestions(t *testing.T) {
 	// vanished device is pruned and re-notifies on return
 	assert.Empty(t, site.diffSuggestions(map[string]pendingSuggestion{}))
 	assert.Len(t, site.diffSuggestions(pending(stop)), 1)
+}
+
+// singleSlotSuggestionPlan wraps a suggestion map in a plan valid for an hour
+func singleSlotSuggestionPlan(suggestions map[string]types.Suggestion) *suggestionPlan {
+	now := time.Now()
+	return &suggestionPlan{
+		schedule: optimizerSchedule{timestamps: []time.Time{now}, dt: []int{3600}},
+		resolve:  func(int) map[string]types.Suggestion { return suggestions },
+	}
+}
+
+// testSchedule builds a 3-slot schedule of 15min each, starting at start.
+func testSchedule(start time.Time) optimizerSchedule {
+	return optimizerSchedule{
+		timestamps: []time.Time{start, start.Add(15 * time.Minute), start.Add(30 * time.Minute)},
+		dt:         []int{900, 900, 900},
+	}
+}
+
+func TestSuggestionPlanTracksWallClockAcrossReads(t *testing.T) {
+	start := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	schedule := testSchedule(start)
+
+	slots := []map[string]types.Suggestion{
+		{"battery:home": {Action: "hold"}},
+		{"battery:home": {Action: "normal"}},
+		{"battery:home": {Action: "charge"}},
+	}
+	plan := &suggestionPlan{
+		schedule: schedule,
+		resolve:  func(slot int) map[string]types.Suggestion { return slots[slot] },
+	}
+
+	assert.Equal(t, "hold", plan.suggestions(start.Add(5 * time.Minute))["battery:home"].Action)
+	assert.Equal(t, "normal", plan.suggestions(start.Add(20 * time.Minute))["battery:home"].Action)
+	assert.Equal(t, "charge", plan.suggestions(start.Add(40 * time.Minute))["battery:home"].Action)
+
+	// past the retained horizon
+	assert.Nil(t, plan.suggestions(start.Add(2*time.Hour)))
+
+	var nilPlan *suggestionPlan
+	assert.Nil(t, nilPlan.suggestions(start))
+}
+
+func TestSuggestionReadsAcrossSlotBoundary(t *testing.T) {
+	site := &Site{}
+
+	past := time.Now().Add(-20 * time.Minute)
+	schedule := optimizerSchedule{
+		timestamps: []time.Time{past, past.Add(15 * time.Minute)},
+		dt:         []int{900, 900},
+	}
+	slots := []map[string]types.Suggestion{
+		{batteryKey("bat"): {Action: api.BatteryHold.String()}},
+		{batteryKey("bat"): {Action: api.BatteryNormal.String()}},
+	}
+	site.setSuggestionPlan(&suggestionPlan{
+		schedule: schedule,
+		resolve:  func(slot int) map[string]types.Suggestion { return slots[slot] },
+	})
+
+	s := site.suggestion(batteryKey("bat"), api.BatteryNormal.String())
+	require.NotNil(t, s)
+	assert.Equal(t, api.BatteryNormal.String(), s.Action, "must read slot 1 (now's slot), not the expired slot 0")
+
+	// entirely expired plan (both slots ended in the past): no suggestion
+	site.setSuggestionPlan(&suggestionPlan{
+		schedule: optimizerSchedule{timestamps: []time.Time{past}, dt: []int{60}},
+		resolve: func(int) map[string]types.Suggestion {
+			return map[string]types.Suggestion{batteryKey("bat"): {Action: api.BatteryHold.String()}}
+		},
+	})
+	assert.Nil(t, site.suggestion(batteryKey("bat"), api.BatteryNormal.String()))
+}
+
+func TestBuildSuggestionPlanPerSlot(t *testing.T) {
+	start := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	schedule := testSchedule(start)
+
+	res := optimizer.OptimizationResult{
+		// slot 0: grid-charging, slot 1: idle while importing, slot 2: grid-discharging
+		GridImport: []float32{2000, 500, 0},
+		GridExport: []float32{0, 0, 2000},
+		Batteries:  []optimizer.BatteryResult{{ChargingPower: []float32{3000, 0, 0}, DischargingPower: []float32{0, 0, 2000}}},
+	}
+	details := []batteryDetail{{Type: batteryTypeBattery, Name: "home", controllable: true}}
+
+	plan := buildSuggestionPlan(details, res, schedule)
+
+	assert.Equal(t, api.BatteryCharge.String(), plan.resolve(0)["battery:home"].Action)
+	assert.Equal(t, api.BatteryHold.String(), plan.resolve(1)["battery:home"].Action)
+	assert.Equal(t, api.BatteryDischarge.String(), plan.resolve(2)["battery:home"].Action)
 }


### PR DESCRIPTION
refs #33509, #32881

A suggestion can describe an already-expired slot for up to 15 minutes after it stopped applying. Event-driven it never matches the slot boundary.

Fix: look up the slot that actually covers the current time on every read (suggestionPlan), instead of only once when the solve result first arrives. Only the one slot a given read needs gets computed, not the whole horizon.

Scope: complements the now-merged #33501, doesn't overlap it. That PR fixed the once-per-solve slot choice for battery Full/Empty and the battery forecast - this one fixes the separate problem of a correct choice going stale between solves. Neither depends on the other; both happen to add the same explicit slot parameter to currentSlotSuggestion because both need it.

Targets master directly, no dependency on #32881 (automatic mode): the staleness already affects today's advisory-only suggestions, before automatic mode would ever apply one to hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)