### PR TITLE
Heating: add Intergas thermostat boost via Home Assistant

### DIFF
--- a/charger/homeassistant_thermostat.go
+++ b/charger/homeassistant_thermostat.go
@@ -1,0 +1,345 @@
+package charger
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/api/implement"
+	"github.com/evcc-io/evcc/db"
+	"github.com/evcc-io/evcc/db/settings"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/homeassistant"
+)
+
+// ponytail: serialize thermostat commands globally; use keyed locks if concurrent devices need independent I/O.
+var thermostatMu sync.Mutex
+
+type thermostatBoost struct {
+	Baseline  float64 `json:"baseline"`
+	Target    float64 `json:"target"`
+	Confirmed bool    `json:"confirmed"`
+	Hold      bool    `json:"hold"`
+	Restoring bool    `json:"restoring"`
+}
+
+// HomeAssistantThermostat temporarily raises a single heating target.
+type HomeAssistantThermostat struct {
+	*embed
+	implement.Caps
+	conn   *homeassistant.Connection
+	entity string
+	boost  float64
+}
+
+func init() {
+	registry.Add("homeassistant-thermostat", NewHomeAssistantThermostatFromConfig)
+}
+
+// NewHomeAssistantThermostatFromConfig creates a thermostat boost controller.
+func NewHomeAssistantThermostatFromConfig(other map[string]any) (api.Charger, error) {
+	var cc struct {
+		embed                `mapstructure:",squash"`
+		homeassistant.Config `mapstructure:",squash"`
+		Entity               string
+		Boost                float64
+		Power                string
+	}
+	cc.Icon_ = "heatpump"
+	cc.Features_ = []api.Feature{api.Continuous, api.Heating, api.IntegratedDevice, api.SwitchDevice}
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+	if domain, name, ok := strings.Cut(cc.Entity, "."); !ok || domain != "climate" || name == "" || strings.ContainsAny(name, "/?# ") {
+		return nil, errors.New("entity must be a climate entity")
+	}
+	if !thermostatFinite(cc.Boost) || cc.Boost <= 0 {
+		return nil, errors.New("boost must be a positive temperature increase")
+	}
+	conn, err := cc.Config.NewConnection(util.NewLogger("ha-thermostat"))
+	if err != nil {
+		return nil, err
+	}
+	c := &HomeAssistantThermostat{
+		embed: &cc.embed, Caps: implement.New(), conn: conn, entity: cc.Entity, boost: cc.Boost,
+	}
+	if cc.Power != "" {
+		implement.Has(c, implement.Meter(func() (float64, error) {
+			state, err := conn.GetState(cc.Power)
+			if err != nil {
+				return 0, err
+			}
+			unit := state.Attributes.UnitOfMeasurement
+			if unit != "W" && unit != "kW" {
+				return 0, errors.New("thermostat power sensor must use W or kW")
+			}
+			power, err := strconv.ParseFloat(state.State, 64)
+			if unit == "kW" {
+				power *= 1e3
+			}
+			if err == nil && (!thermostatFinite(power) || power < 0) {
+				err = errors.New("invalid thermostat power")
+			}
+			return power, err
+		}))
+	}
+	return c, nil
+}
+
+func thermostatFinite(v float64) bool {
+	return !math.IsNaN(v) && !math.IsInf(v, 0)
+}
+
+func thermostatEqual(a, b float64) bool {
+	return math.Abs(a-b) < 1e-6
+}
+
+func (c *HomeAssistantThermostat) key() string {
+	return fmt.Sprintf("thermostat:%x", sha256.Sum256([]byte(c.conn.URI()+"\x00"+c.entity)))
+}
+
+func (c *HomeAssistantThermostat) read() (homeassistant.ClimateStateResponse, error) {
+	var config struct {
+		UnitSystem struct {
+			Temperature string `json:"temperature"`
+		} `json:"unit_system"`
+	}
+	if err := c.conn.GetJSON(c.conn.URI()+"/api/config", &config); err != nil {
+		return homeassistant.ClimateStateResponse{}, err
+	}
+	if config.UnitSystem.Temperature != "°C" {
+		return homeassistant.ClimateStateResponse{}, errors.New("thermostat requires Home Assistant Celsius units")
+	}
+	s, err := c.conn.GetClimateState(c.entity)
+	if err != nil {
+		return s, err
+	}
+	a := s.Attributes
+	if a.UnitOfMeasurement != "" && a.UnitOfMeasurement != "°C" {
+		return s, errors.New("thermostat requires Celsius temperature attributes")
+	}
+	if s.State != "heat" && s.State != "off" {
+		return s, fmt.Errorf("unsupported thermostat mode: %s", s.State)
+	}
+	if a.SupportedFeatures&1 == 0 || a.Temperature == nil || a.MinTemp == nil || a.MaxTemp == nil {
+		return s, errors.New("thermostat requires a single writable temperature and limits")
+	}
+	if !thermostatFinite(*a.MinTemp) || !thermostatFinite(*a.MaxTemp) || *a.MinTemp >= *a.MaxTemp {
+		return s, errors.New("invalid thermostat temperature limits")
+	}
+	return s, thermostatTarget(s, *a.Temperature)
+}
+
+func thermostatTarget(s homeassistant.ClimateStateResponse, target float64) error {
+	a := s.Attributes
+	if !thermostatFinite(target) || target < *a.MinTemp || target > *a.MaxTemp {
+		return errors.New("thermostat target outside temperature limits")
+	}
+	if step := a.TargetTempStep; step != nil {
+		if !thermostatFinite(*step) || *step <= 0 || !thermostatEqual((target-*a.MinTemp) / *step, math.Round((target-*a.MinTemp) / *step)) {
+			return errors.New("thermostat target does not match temperature step")
+		}
+	}
+	return nil
+}
+
+func (c *HomeAssistantThermostat) saved() (*thermostatBoost, error) {
+	var saved thermostatBoost
+	if err := settings.Json(c.key(), &saved); errors.Is(err, settings.ErrNotFound) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	if !thermostatFinite(saved.Baseline) || !thermostatFinite(saved.Target) || saved.Target <= saved.Baseline {
+		return nil, errors.New("invalid saved thermostat boost")
+	}
+	return &saved, nil
+}
+
+func (c *HomeAssistantThermostat) save(saved *thermostatBoost) error {
+	if db.Instance == nil {
+		return errors.New("thermostat boost requires a persistent database")
+	}
+	var databases []struct{ Name, File string }
+	if err := db.Instance.Raw("PRAGMA database_list").Scan(&databases).Error; err != nil {
+		return err
+	}
+	if !slices.ContainsFunc(databases, func(d struct{ Name, File string }) bool { return d.Name == "main" && d.File != "" }) {
+		return errors.New("thermostat boost requires a persistent database")
+	}
+	key := c.key()
+	previous, err := settings.String(key)
+	if err != nil && !errors.Is(err, settings.ErrNotFound) {
+		return err
+	}
+	if err := settings.SetJson(key, saved); err != nil {
+		return err
+	}
+	if err := settings.Persist(); err != nil {
+		settings.SetString(key, previous)
+		return fmt.Errorf("persist thermostat boost: %w", err)
+	}
+	return nil
+}
+
+// observe records acknowledgements without sending thermostat commands.
+func (c *HomeAssistantThermostat) observe(s homeassistant.ClimateStateResponse) (*thermostatBoost, error) {
+	saved, err := c.saved()
+	if err != nil || saved == nil || saved.Restoring {
+		return saved, err
+	}
+	before := *saved
+	target := *s.Attributes.Temperature
+	if thermostatEqual(target, saved.Target) {
+		saved.Confirmed = true
+	}
+	switch {
+	case saved.Hold:
+	case s.State != "heat":
+		saved.Hold = true
+	case thermostatEqual(target, saved.Target):
+	case saved.Confirmed || !thermostatEqual(target, saved.Baseline):
+		saved.Hold = true
+	}
+	if *saved != before {
+		err = c.save(saved)
+	}
+	return saved, err
+}
+
+var _ api.Charger = (*HomeAssistantThermostat)(nil)
+
+// Status implements api.ChargeState; compressor activity is measured separately.
+func (c *HomeAssistantThermostat) Status() (api.ChargeStatus, error) {
+	thermostatMu.Lock()
+	defer thermostatMu.Unlock()
+	s, err := c.read()
+	if err != nil {
+		return api.StatusNone, err
+	}
+	saved, err := c.observe(s)
+	if err != nil {
+		return api.StatusNone, err
+	}
+	if saved != nil && saved.Confirmed && !saved.Hold && !saved.Restoring {
+		return api.StatusC, nil
+	}
+	return api.StatusB, nil
+}
+
+// Enabled includes pending restoration and manual hold until the next Normal request.
+func (c *HomeAssistantThermostat) Enabled() (bool, error) {
+	thermostatMu.Lock()
+	defer thermostatMu.Unlock()
+	s, err := c.read()
+	if err != nil {
+		return false, err
+	}
+	saved, err := c.observe(s)
+	return saved != nil, err
+}
+
+// Enable applies one bounded increase or restores the captured target.
+func (c *HomeAssistantThermostat) Enable(enable bool) error {
+	thermostatMu.Lock()
+	defer thermostatMu.Unlock()
+	s, err := c.read()
+	if err != nil {
+		return err
+	}
+	saved, err := c.observe(s)
+	if err != nil {
+		return err
+	}
+	if enable {
+		if saved != nil {
+			if saved.Restoring {
+				return errors.New("thermostat restoration pending; select Off to finish")
+			}
+			return nil
+		}
+		if s.State != "heat" {
+			return errors.New("thermostat must already be in heat mode")
+		}
+		baseline := *s.Attributes.Temperature
+		target := baseline + c.boost
+		if target <= baseline || thermostatEqual(target, baseline) {
+			return errors.New("boost is below thermostat comparison precision")
+		}
+		if err := thermostatTarget(s, target); err != nil {
+			return err
+		}
+		saved = &thermostatBoost{Baseline: baseline, Target: target}
+		if err := c.save(saved); err != nil {
+			return err
+		}
+		return c.setTemperature(target)
+	}
+	if saved == nil {
+		return nil
+	}
+	target := *s.Attributes.Temperature
+	if !saved.Confirmed {
+		return errors.New("thermostat boost not yet observed; restoration remains pending")
+	}
+	if saved.Restoring {
+		if thermostatEqual(target, saved.Baseline) {
+			return settings.Delete(c.key())
+		}
+		if !thermostatEqual(target, saved.Target) || s.State != "heat" {
+			return errors.New("thermostat restoration unconfirmed; preserving the observed target")
+		}
+	} else if saved.Hold {
+		if thermostatEqual(target, saved.Target) {
+			return errors.New("boost observed after manual change; restore the thermostat manually")
+		}
+		return settings.Delete(c.key())
+	}
+	if err := thermostatTarget(s, saved.Baseline); err != nil {
+		return err
+	}
+	saved.Restoring = true
+	if err := c.save(saved); err != nil {
+		return err
+	}
+	if err := c.setTemperature(saved.Baseline); err != nil {
+		return err
+	}
+	s, err = c.read()
+	if err != nil {
+		return err
+	}
+	if !thermostatEqual(*s.Attributes.Temperature, saved.Baseline) {
+		return errors.New("thermostat restoration not yet observed")
+	}
+	return settings.Delete(c.key())
+}
+
+func (c *HomeAssistantThermostat) setTemperature(target float64) error {
+	return c.conn.CallService("climate", "set_temperature", map[string]any{
+		"entity_id": c.entity, "temperature": target,
+	})
+}
+
+// MaxCurrent implements api.Charger; this device cannot control electrical current.
+func (c *HomeAssistantThermostat) MaxCurrent(int64) error { return nil }
+
+var _ api.Battery = (*HomeAssistantThermostat)(nil)
+
+// Soc implements api.Battery as the measured room temperature in Celsius.
+func (c *HomeAssistantThermostat) Soc() (float64, error) {
+	s, err := c.read()
+	if err != nil {
+		return 0, err
+	}
+	if s.Attributes.CurrentTemperature == nil || !thermostatFinite(*s.Attributes.CurrentTemperature) {
+		return 0, api.ErrNotAvailable
+	}
+	return *s.Attributes.CurrentTemperature, nil
+}

--- a/charger/homeassistant_thermostat_test.go
+++ b/charger/homeassistant_thermostat_test.go
@@ -1,0 +1,505 @@
+package charger
+
+import (
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/db"
+	"github.com/evcc-io/evcc/db/settings"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type thermostatTestHA struct {
+	mu           sync.Mutex
+	server       *httptest.Server
+	unit         string
+	state        string
+	attributes   map[string]any
+	power        string
+	powerUnit    string
+	apply        bool
+	dropResponse bool
+	writes       []float64
+}
+
+func newThermostatTestHA(t *testing.T) *thermostatTestHA {
+	t.Helper()
+	h := &thermostatTestHA{
+		unit: "°C", state: "heat", apply: true, power: "700", powerUnit: "W",
+		attributes: map[string]any{
+			"temperature": 20.0, "current_temperature": 19.8,
+			"min_temp": 5.0, "max_temp": 30.0,
+			"supported_features": 1, "hvac_modes": []string{"heat"}, "hvac_action": "heating",
+		},
+	}
+	h.server = httptest.NewTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		var response any
+		switch r.Method + " " + r.URL.Path {
+		case "GET /api/config":
+			response = map[string]any{"unit_system": map[string]string{"temperature": h.unit}}
+		case "GET /api/states/climate.room":
+			response = map[string]any{"entity_id": "climate.room", "state": h.state, "attributes": h.attributes}
+		case "GET /api/states/sensor.power":
+			response = map[string]any{"entity_id": "sensor.power", "state": h.power,
+				"attributes": map[string]string{"unit_of_measurement": h.powerUnit}}
+		case "POST /api/services/climate/set_temperature":
+			var body map[string]any
+			if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&body)) {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			assert.Len(t, body, 2)
+			assert.Equal(t, "climate.room", body["entity_id"])
+			target, ok := body["temperature"].(float64)
+			if !assert.True(t, ok) {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			h.writes = append(h.writes, target)
+			if h.apply {
+				h.attributes["temperature"] = target
+			}
+			if h.dropResponse {
+				conn, _, err := w.(http.Hijacker).Hijack()
+				if assert.NoError(t, err) {
+					assert.NoError(t, conn.Close())
+				}
+				return
+			}
+			response = []any{}
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		assert.NoError(t, json.NewEncoder(w).Encode(response))
+	}))
+	h.server.Start()
+	return h
+}
+
+func (h *thermostatTestHA) change(f func()) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	f()
+}
+
+func (h *thermostatTestHA) commands() []float64 {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return slices.Clone(h.writes)
+}
+
+func (h *thermostatTestHA) charger(t *testing.T, boost float64) *HomeAssistantThermostat {
+	t.Helper()
+	c, err := NewHomeAssistantThermostatFromConfig(map[string]any{
+		"uri": h.server.URL, "entity": "climate.room", "boost": boost, "power": "sensor.power",
+	})
+	require.NoError(t, err)
+	thermostat := c.(*HomeAssistantThermostat)
+	thermostat.conn.Client.Transport = http.DefaultTransport
+	return thermostat
+}
+
+func thermostatTestDatabase(t *testing.T) func() {
+	t.Helper()
+	previous := db.Instance
+	path := filepath.Join(t.TempDir(), "evcc.db")
+	require.NoError(t, db.NewInstance("sqlite", path))
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+		db.Instance = previous
+	})
+	return func() {
+		t.Helper()
+		require.NoError(t, db.Close())
+		require.NoError(t, db.NewInstance("sqlite", path))
+	}
+}
+
+func TestHomeAssistantThermostatBoostRestore(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		baseline float64
+		boost    float64
+	}{
+		{"half degree", 20, 0.5},
+		{"fractional baseline", 20.1, 0.2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			thermostatTestDatabase(t)
+			h := newThermostatTestHA(t)
+			h.change(func() { h.attributes["temperature"] = tc.baseline })
+			c := h.charger(t, tc.boost)
+			status, err := c.Status()
+			require.NoError(t, err)
+			assert.Equal(t, api.StatusB, status)
+			enabled, err := c.Enabled()
+			require.NoError(t, err)
+			assert.False(t, enabled)
+			assert.Empty(t, h.commands(), "construction and getters must not actuate")
+			require.NoError(t, c.Enable(true))
+			require.NoError(t, c.Enable(true))
+			status, err = c.Status()
+			require.NoError(t, err)
+			assert.Equal(t, api.StatusC, status)
+			require.NoError(t, c.Enable(false))
+			require.NoError(t, c.Enable(false))
+			assert.Equal(t, []float64{tc.baseline + tc.boost, tc.baseline}, h.commands())
+			enabled, err = c.Enabled()
+			require.NoError(t, err)
+			assert.False(t, enabled)
+			assert.False(t, settings.Exists(c.key()))
+		})
+	}
+}
+
+func TestHomeAssistantThermostatSharedTarget(t *testing.T) {
+	thermostatTestDatabase(t)
+	h := newThermostatTestHA(t)
+	first, second := h.charger(t, 0.5), h.charger(t, 1)
+	require.NoError(t, first.Enable(true))
+	require.NoError(t, second.Enable(true))
+	assert.Equal(t, []float64{20.5}, h.commands())
+	require.NoError(t, second.Enable(false))
+	assert.Equal(t, []float64{20.5, 20}, h.commands())
+}
+
+func TestHomeAssistantThermostatConcurrentBoost(t *testing.T) {
+	thermostatTestDatabase(t)
+	h := newThermostatTestHA(t)
+	first, second := h.charger(t, 0.5), h.charger(t, 1)
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Go(func() {
+			c := first
+			if i%2 != 0 {
+				c = second
+			}
+			assert.NoError(t, c.Enable(true))
+		})
+	}
+	wg.Wait()
+	require.Len(t, h.commands(), 1)
+	require.NoError(t, first.Enable(false))
+	assert.Equal(t, 20.0, h.commands()[1])
+}
+
+func TestHomeAssistantThermostatTinyBoost(t *testing.T) {
+	thermostatTestDatabase(t)
+	h := newThermostatTestHA(t)
+	for _, boost := range []float64{1e-20, 1e-8} {
+		c := h.charger(t, boost)
+		assert.Error(t, c.Enable(true))
+		assert.False(t, settings.Exists(c.key()))
+	}
+	assert.Empty(t, h.commands())
+}
+
+func TestHomeAssistantThermostatRestart(t *testing.T) {
+	restart := thermostatTestDatabase(t)
+	h := newThermostatTestHA(t)
+	c := h.charger(t, 0.5)
+	require.NoError(t, c.Enable(true))
+	restart()
+	c = h.charger(t, 0.5)
+	enabled, err := c.Enabled()
+	require.NoError(t, err)
+	assert.True(t, enabled)
+	assert.Equal(t, []float64{20.5}, h.commands())
+	require.NoError(t, c.Enable(false))
+	assert.Equal(t, []float64{20.5, 20}, h.commands())
+}
+
+func TestHomeAssistantThermostatManualHold(t *testing.T) {
+	restart := thermostatTestDatabase(t)
+	h := newThermostatTestHA(t)
+	c := h.charger(t, 0.5)
+	require.NoError(t, c.Enable(true))
+	_, err := c.Status()
+	require.NoError(t, err)
+	h.change(func() { h.attributes["temperature"] = 21.0 })
+	require.NoError(t, c.Enable(true))
+	restart()
+	c = h.charger(t, 0.5)
+	require.NoError(t, c.Enable(true))
+	status, err := c.Status()
+	require.NoError(t, err)
+	assert.Equal(t, api.StatusB, status)
+	enabled, err := c.Enabled()
+	require.NoError(t, err)
+	assert.True(t, enabled, "hold suppresses immediate re-acquisition by core")
+	require.NoError(t, c.Enable(false))
+	assert.Equal(t, []float64{20.5}, h.commands(), "Normal must respect the manual target")
+	require.NoError(t, c.Enable(true))
+	assert.Equal(t, []float64{20.5, 21.5}, h.commands())
+}
+
+func TestHomeAssistantThermostatDelayedBoost(t *testing.T) {
+	thermostatTestDatabase(t)
+	h := newThermostatTestHA(t)
+	h.change(func() { h.apply = false })
+	c := h.charger(t, 0.5)
+	require.NoError(t, c.Enable(true))
+	require.NoError(t, c.Enable(true))
+	assert.Error(t, c.Enable(false))
+	assert.True(t, settings.Exists(c.key()))
+	assert.Equal(t, []float64{20.5}, h.commands())
+	h.change(func() {
+		h.attributes["temperature"] = 20.5
+		h.apply = true
+	})
+	require.NoError(t, c.Enable(false))
+	assert.Equal(t, []float64{20.5, 20}, h.commands())
+}
+
+func TestHomeAssistantThermostatDelayedBoostManualChange(t *testing.T) {
+	restart := thermostatTestDatabase(t)
+	h := newThermostatTestHA(t)
+	h.change(func() { h.apply = false })
+	c := h.charger(t, 0.5)
+	require.NoError(t, c.Enable(true))
+	h.change(func() { h.attributes["temperature"] = 21.0 })
+	assert.Error(t, c.Enable(false), "a manual change does not acknowledge the outstanding boost")
+	assert.True(t, settings.Exists(c.key()))
+	restart()
+	c = h.charger(t, 0.5)
+	h.change(func() { h.attributes["temperature"] = 20.5 })
+	assert.Error(t, c.Enable(false), "the late boost must not overwrite the manual choice again")
+	assert.True(t, settings.Exists(c.key()))
+	assert.Equal(t, []float64{20.5}, h.commands())
+	h.change(func() { h.attributes["temperature"] = 21.0 })
+	require.NoError(t, c.Enable(false))
+	assert.False(t, settings.Exists(c.key()))
+	assert.Equal(t, []float64{20.5}, h.commands())
+}
+
+func TestHomeAssistantThermostatManualOff(t *testing.T) {
+	thermostatTestDatabase(t)
+	h := newThermostatTestHA(t)
+	c := h.charger(t, 0.5)
+	require.NoError(t, c.Enable(true))
+	h.change(func() { h.state = "off" })
+	status, err := c.Status()
+	require.NoError(t, err)
+	assert.Equal(t, api.StatusB, status)
+	enabled, err := c.Enabled()
+	require.NoError(t, err)
+	assert.True(t, enabled)
+	assert.Error(t, c.Enable(false))
+	assert.True(t, settings.Exists(c.key()))
+	assert.Equal(t, []float64{20.5}, h.commands())
+	h.change(func() { h.attributes["temperature"] = 20.0 })
+	require.NoError(t, c.Enable(false))
+	assert.False(t, settings.Exists(c.key()))
+	assert.Equal(t, []float64{20.5}, h.commands())
+}
+
+func TestHomeAssistantThermostatLostResponse(t *testing.T) {
+	for _, duringRestore := range []bool{false, true} {
+		name := "boost"
+		if duringRestore {
+			name = "restore"
+		}
+		t.Run(name, func(t *testing.T) {
+			restart := thermostatTestDatabase(t)
+			h := newThermostatTestHA(t)
+			c := h.charger(t, 0.5)
+			if duringRestore {
+				require.NoError(t, c.Enable(true))
+			}
+			h.change(func() { h.dropResponse = true })
+			assert.Error(t, c.Enable(!duringRestore))
+			assert.True(t, settings.Exists(c.key()))
+			h.change(func() { h.dropResponse = false })
+			restart()
+			c = h.charger(t, 0.5)
+			require.NoError(t, c.Enable(false))
+			assert.Equal(t, []float64{20.5, 20}, h.commands(), "do not repeat an already applied command")
+			assert.False(t, settings.Exists(c.key()))
+		})
+	}
+}
+
+func TestHomeAssistantThermostatDelayedRestore(t *testing.T) {
+	restart := thermostatTestDatabase(t)
+	h := newThermostatTestHA(t)
+	c := h.charger(t, 0.5)
+	require.NoError(t, c.Enable(true))
+	h.change(func() { h.apply = false })
+	assert.Error(t, c.Enable(false))
+	assert.Error(t, c.Enable(true), "a pending restore cannot start a new boost")
+	assert.True(t, settings.Exists(c.key()))
+	restart()
+	c = h.charger(t, 0.5)
+	h.change(func() { h.attributes["temperature"] = 20.0 })
+	require.NoError(t, c.Enable(false))
+	assert.Equal(t, []float64{20.5, 20}, h.commands())
+	assert.False(t, settings.Exists(c.key()))
+}
+
+func TestHomeAssistantThermostatRestoreManualChange(t *testing.T) {
+	thermostatTestDatabase(t)
+	h := newThermostatTestHA(t)
+	c := h.charger(t, 0.5)
+	require.NoError(t, c.Enable(true))
+	h.change(func() { h.apply = false })
+	assert.Error(t, c.Enable(false))
+	h.change(func() { h.attributes["temperature"] = 21.0 })
+	assert.Error(t, c.Enable(false), "an unrelated target does not confirm restoration")
+	assert.True(t, settings.Exists(c.key()))
+	assert.Equal(t, []float64{20.5, 20}, h.commands())
+}
+
+func TestHomeAssistantThermostatInvalidState(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		change func(*thermostatTestHA)
+	}{
+		{"fahrenheit", func(h *thermostatTestHA) { h.unit = "°F" }},
+		{"fahrenheit attribute", func(h *thermostatTestHA) { h.attributes["unit_of_measurement"] = "°F" }},
+		{"unknown", func(h *thermostatTestHA) { h.state = "unknown" }},
+		{"unavailable", func(h *thermostatTestHA) { h.state = "unavailable" }},
+		{"cooling", func(h *thermostatTestHA) { h.state = "cool" }},
+		{"off", func(h *thermostatTestHA) { h.state = "off" }},
+		{"readonly", func(h *thermostatTestHA) { h.attributes["supported_features"] = 0 }},
+		{"range only", func(h *thermostatTestHA) { h.attributes["supported_features"] = 2 }},
+		{"missing target", func(h *thermostatTestHA) { delete(h.attributes, "temperature") }},
+		{"missing minimum", func(h *thermostatTestHA) { delete(h.attributes, "min_temp") }},
+		{"missing maximum", func(h *thermostatTestHA) { delete(h.attributes, "max_temp") }},
+		{"inverted limits", func(h *thermostatTestHA) { h.attributes["min_temp"] = 31.0 }},
+		{"target out of range", func(h *thermostatTestHA) { h.attributes["temperature"] = 31.0 }},
+		{"boost out of range", func(h *thermostatTestHA) { h.attributes["temperature"] = 30.0 }},
+		{"invalid step", func(h *thermostatTestHA) { h.attributes["target_temp_step"] = 0.0 }},
+		{"step mismatch", func(h *thermostatTestHA) { h.attributes["target_temp_step"] = 1.0 }},
+		{"non numeric target", func(h *thermostatTestHA) { h.attributes["temperature"] = "NaN" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			thermostatTestDatabase(t)
+			h := newThermostatTestHA(t)
+			h.change(func() { tc.change(h) })
+			c := h.charger(t, 0.5)
+			assert.Error(t, c.Enable(true))
+			assert.Empty(t, h.commands())
+			assert.False(t, settings.Exists(c.key()))
+		})
+	}
+}
+
+func TestHomeAssistantThermostatInvalidConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		key   string
+		value any
+	}{
+		{"zero boost", "boost", 0.0},
+		{"negative boost", "boost", -0.5},
+		{"NaN boost", "boost", math.NaN()},
+		{"infinite boost", "boost", math.Inf(1)},
+		{"wrong entity", "entity", "switch.room"},
+		{"empty entity", "entity", "climate."},
+		{"entity path", "entity", "climate.room/other"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			config := map[string]any{"uri": "http://127.0.0.1", "entity": "climate.room", "boost": 0.5}
+			config[tc.key] = tc.value
+			_, err := NewHomeAssistantThermostatFromConfig(config)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestHomeAssistantThermostatPersistenceFailure(t *testing.T) {
+	for _, missing := range []bool{true, false} {
+		name := "write failure"
+		if missing {
+			name = "no database"
+		}
+		t.Run(name, func(t *testing.T) {
+			thermostatTestDatabase(t)
+			h := newThermostatTestHA(t)
+			c := h.charger(t, 0.5)
+			instance := db.Instance
+			if missing {
+				db.Instance = nil
+				defer func() { db.Instance = instance }()
+			} else {
+				require.NoError(t, db.Instance.Exec("PRAGMA query_only = ON").Error)
+			}
+			assert.Error(t, c.Enable(true))
+			assert.Empty(t, h.commands(), "persistence must succeed before a command is sent")
+			assert.False(t, settings.Exists(c.key()))
+			if !missing {
+				require.NoError(t, db.Instance.Exec("PRAGMA query_only = OFF").Error)
+				require.NoError(t, c.Enable(true))
+				assert.Equal(t, []float64{20.5}, h.commands())
+			}
+		})
+	}
+}
+
+func TestHomeAssistantThermostatMemoryDatabase(t *testing.T) {
+	for _, dsn := range []string{":memory:", "file:thermostat-memory?mode=memory&cache=shared"} {
+		t.Run(dsn, func(t *testing.T) {
+			thermostatTestDatabase(t)
+			require.NoError(t, db.Close())
+			require.NoError(t, db.NewInstance("sqlite", dsn))
+			h := newThermostatTestHA(t)
+			c := h.charger(t, 0.5)
+			assert.Error(t, c.Enable(true))
+			assert.Empty(t, h.commands())
+			assert.False(t, settings.Exists(c.key()))
+		})
+	}
+}
+
+func TestHomeAssistantThermostatMeasurements(t *testing.T) {
+	h := newThermostatTestHA(t)
+	c := h.charger(t, 0.5)
+	temperature, err := c.Soc()
+	require.NoError(t, err)
+	assert.Equal(t, 19.8, temperature)
+	meter, ok := api.Cap[api.Meter](c)
+	require.True(t, ok)
+	for _, tc := range []struct {
+		value string
+		unit  string
+		want  float64
+		err   bool
+	}{
+		{"700", "W", 700, false},
+		{"0.7", "kW", 700, false},
+		{"700", "kWh", 0, true},
+		{"700", "", 0, true},
+		{"unknown", "W", 0, true},
+		{"NaN", "W", 0, true},
+		{"+Inf", "W", 0, true},
+		{"-10", "W", 0, true},
+	} {
+		t.Run(tc.value+tc.unit, func(t *testing.T) {
+			h.change(func() { h.power, h.powerUnit = tc.value, tc.unit })
+			power, err := meter.CurrentPower()
+			if tc.err {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.want, power)
+			}
+		})
+	}
+	h.change(func() { delete(h.attributes, "current_temperature") })
+	_, err = c.Soc()
+	assert.Error(t, err)
+	assert.Empty(t, h.commands())
+}

--- a/templates/definition/charger/intergas-homeassistant.yaml
+++ b/templates/definition/charger/intergas-homeassistant.yaml
@@ -1,0 +1,72 @@
+template: intergas-homeassistant
+products:
+  - brand: Intergas
+    description:
+      generic: Comfort Touch / Xtend (Home Assistant)
+group: heating
+requirements:
+  description:
+    en: |
+      Requires the Home Assistant InComfort integration, Celsius units and a persistent evcc database. Gateway V3 is not supported by InComfort. The thermostat must already be in heat mode.
+
+      Boost raises the current room target once by the configured amount. Off returns to normal heating by restoring the captured target; it does not turn the heating off. Manual or scheduled target changes suspend boost until the next Off transition. Only one controller should write the thermostat. Same-value changes and commands racing a manual change cannot always be distinguished.
+
+      Select Off and confirm restoration at the thermostat before stopping, removing or reconfiguring the controller. Home Assistant may acknowledge a target before the device applies it. Restoration requires connectivity. Unconfirmed commands retain their saved target across restarts and may require manual recovery; they do not have a device-side expiry.
+
+      Larger setpoint increases can engage the hybrid boiler. P217 and P186 are distinct installer settings; staying below a threshold does not guarantee gas-free heating. This integration does not change installer parameters, inhibit the boiler or control compressor power. The documented gateway test verified 20.0 → 20.5 → 20.0°C target propagation, not heating savings. Verify the chosen targets on your installation before enabling automatic control. InComfort client 0.7.1 can truncate some tenth-degree targets; check exact restoration as well as the boost target.
+    de: |
+      Benötigt die Home-Assistant-Integration InComfort, Celsius-Einheiten und eine dauerhafte evcc-Datenbank. Gateway V3 wird von InComfort nicht unterstützt. Der Thermostat muss bereits im Heizmodus sein.
+
+      Boost erhöht den aktuellen Raumsollwert einmal um den konfigurierten Betrag. Aus stellt den gespeicherten Sollwert wieder her und bedeutet normalen Heizbetrieb, nicht Abschalten der Heizung. Manuelle oder zeitgesteuerte Sollwertänderungen unterbrechen Boost bis zum nächsten Wechsel auf Aus. Nur eine Steuerung darf den Thermostat beschreiben. Gleichwertige Änderungen und zeitgleiche manuelle Eingriffe sind nicht immer unterscheidbar.
+
+      Vor dem Stoppen, Entfernen oder Umkonfigurieren Aus wählen und die Wiederherstellung am Thermostat prüfen. Home Assistant kann einen Sollwert bestätigen, bevor das Gerät ihn übernimmt. Dafür ist eine Verbindung erforderlich. Unbestätigte Befehle behalten ihren gespeicherten Sollwert auch nach Neustarts und können manuelle Wiederherstellung erfordern; sie haben keine geräteseitige Ablaufzeit.
+
+      Größere Sollwerterhöhungen können den Heizkessel zuschalten. P217 und P186 sind unterschiedliche Installateureinstellungen; das Unterschreiten eines Grenzwerts garantiert keinen gasfreien Betrieb. Diese Integration ändert keine Installateurparameter, sperrt den Heizkessel nicht und regelt keine Verdichterleistung. Der dokumentierte Gateway-Test bestätigte 20,0 → 20,5 → 20,0°C Sollwertübertragung, keine Heizkostenersparnis. Die gewählten Sollwerte vor automatischem Betrieb an der eigenen Anlage prüfen. InComfort-Client 0.7.1 kann einige Zehntelgradwerte abrunden; auch die exakte Wiederherstellung prüfen.
+auth:
+  type: homeassistant
+  params: [uri, insecure]
+params:
+  - name: uri
+    example: http://homeassistant.local:8123
+    description:
+      en: Home Assistant URI
+      de: Home Assistant URI
+    service: homeassistant/instances
+    required: true
+  - name: insecure
+  - name: entity
+    description:
+      en: Thermostat entity
+      de: Thermostat-Entität
+    service: homeassistant/entities?uri={uri}&insecure={insecure}&domain=climate
+    example: climate.living_room
+    required: true
+  - name: boost
+    type: float
+    unit: °C
+    description:
+      en: Temperature increase
+      de: Sollwerterhöhung
+    help:
+      en: Total increase from the starting target, not an increment per update. Choose and verify a suitable value for your heating system.
+      de: Gesamte Erhöhung gegenüber dem Ausgangssollwert, kein Zuschlag je Aktualisierung. Einen zur Heizung passenden Wert wählen und prüfen.
+    example: 0.5
+    required: true
+  - name: power
+    description:
+      en: Electrical power sensor
+      de: Sensor für elektrische Leistung
+    help:
+      en: Measured heat-pump electrical input in W or kW, not thermal output or boiler activity.
+      de: Gemessene elektrische Aufnahme der Wärmepumpe in W oder kW, nicht Wärmeleistung oder Kesselaktivität.
+    service: homeassistant/entities?uri={uri}&insecure={insecure}&domain=sensor
+    example: sensor.heat_pump_electrical_power
+render: |
+  type: homeassistant-thermostat
+  uri: {{ .uri }}
+  insecure: {{ .insecure }}
+  entity: {{ .entity }}
+  boost: {{ .boost }}
+  {{- if .power }}
+  power: {{ .power }}
+  {{- end }}

--- a/util/homeassistant/climate.go
+++ b/util/homeassistant/climate.go
@@ -1,0 +1,21 @@
+package homeassistant
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/evcc-io/evcc/api"
+)
+
+// GetClimateState retrieves the state and temperature attributes of a climate entity.
+func (c *Connection) GetClimateState(entity string) (ClimateStateResponse, error) {
+	var res ClimateStateResponse
+	uri := fmt.Sprintf("%s/api/states/%s", c.instance.URI(), url.PathEscape(entity))
+	if err := c.GetJSON(uri, &res); err != nil {
+		return res, err
+	}
+	if res.State == "unknown" || res.State == "unavailable" {
+		return res, api.ErrNotAvailable
+	}
+	return res, nil
+}

--- a/util/homeassistant/climate_test.go
+++ b/util/homeassistant/climate_test.go
@@ -1,0 +1,152 @@
+package homeassistant
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClimateAttributes(t *testing.T) {
+	var state ClimateStateResponse
+	err := json.Unmarshal([]byte(`{
+		"entity_id": "climate.thermostat",
+		"state": "heat",
+		"attributes": {
+			"temperature": 20.5,
+			"current_temperature": 22.87,
+			"min_temp": 5.0,
+			"max_temp": 30.0,
+			"target_temp_step": 0.1,
+			"hvac_modes": ["heat"],
+			"supported_features": 1
+		}
+	}`), &state)
+	require.NoError(t, err)
+	assert.Equal(t, "climate.thermostat", state.EntityId)
+	assert.Equal(t, "heat", state.State)
+	assert.Empty(t, state.Attributes.UnitOfMeasurement)
+	assert.Equal(t, []string{"heat"}, state.Attributes.HVACModes)
+	assert.Equal(t, 1, state.Attributes.SupportedFeatures)
+
+	for _, tc := range []struct {
+		got  *float64
+		want float64
+	}{
+		{state.Attributes.Temperature, 20.5},
+		{state.Attributes.CurrentTemperature, 22.87},
+		{state.Attributes.MinTemp, 5},
+		{state.Attributes.MaxTemp, 30},
+		{state.Attributes.TargetTempStep, 0.1},
+	} {
+		require.NotNil(t, tc.got)
+		assert.Equal(t, tc.want, *tc.got)
+	}
+}
+
+func TestClimateAttributesMissingAndZero(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		attributes string
+		missing    bool
+	}{
+		{"missing", `{}`, true},
+		{"null", `{"temperature":null,"current_temperature":null,"min_temp":null,"max_temp":null,"target_temp_step":null,"hvac_modes":null,"supported_features":null}`, true},
+		{"zero", `{"temperature":0,"current_temperature":0,"min_temp":0,"max_temp":0,"target_temp_step":0,"supported_features":0}`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var state ClimateStateResponse
+			require.NoError(t, json.Unmarshal([]byte(`{"attributes":`+tc.attributes+`}`), &state))
+			assert.Nil(t, state.Attributes.HVACModes)
+			assert.Zero(t, state.Attributes.SupportedFeatures)
+			for _, got := range []*float64{
+				state.Attributes.Temperature,
+				state.Attributes.CurrentTemperature,
+				state.Attributes.MinTemp,
+				state.Attributes.MaxTemp,
+				state.Attributes.TargetTempStep,
+			} {
+				if tc.missing {
+					assert.Nil(t, got)
+				} else {
+					require.NotNil(t, got)
+					assert.Zero(t, *got)
+				}
+			}
+		})
+	}
+}
+
+func TestClimateAttributesInvalid(t *testing.T) {
+	for _, attributes := range []string{
+		`"temperature":"20.5"`,
+		`"current_temperature":"unknown"`,
+		`"min_temp":false`,
+		`"max_temp":{}`,
+		`"target_temp_step":[]`,
+		`"temperature":1e400`,
+		`"temperature":NaN`,
+		`"hvac_modes":[1]`,
+		`"supported_features":"1"`,
+		`"supported_features":1.5`,
+	} {
+		t.Run(attributes, func(t *testing.T) {
+			var state ClimateStateResponse
+			assert.Error(t, json.Unmarshal([]byte(`{"attributes":{`+attributes+`}}`), &state))
+		})
+	}
+}
+
+func TestStateResponseIgnoresClimateAttributes(t *testing.T) {
+	var state StateResponse
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"entity_id":"sensor.example",
+		"state":"42",
+		"attributes":{"temperature":"unknown","unit_of_measurement":"W"}
+	}`), &state))
+	assert.Equal(t, "42", state.State)
+	assert.Equal(t, "W", state.Attributes.UnitOfMeasurement)
+}
+
+func TestGetClimateState(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+		want   error
+	}{
+		{"heat", http.StatusOK, `{"state":"heat","attributes":{"temperature":20.5}}`, nil},
+		{"unknown", http.StatusOK, `{"state":"unknown"}`, api.ErrNotAvailable},
+		{"unavailable", http.StatusOK, `{"state":"unavailable"}`, api.ErrNotAvailable},
+		{"http error", http.StatusServiceUnavailable, `unavailable`, nil},
+		{"invalid temperature", http.StatusOK, `{"state":"heat","attributes":{"temperature":"unknown"}}`, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/api/states/climate.thermostat%2Fzone", r.URL.EscapedPath())
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				fmt.Fprint(w, tc.body)
+			}))
+			srv.Start()
+
+			state, err := newTestConnection(srv.URL).GetClimateState("climate.thermostat/zone")
+			if tc.want != nil {
+				assert.ErrorIs(t, err, tc.want)
+			} else if tc.name != "heat" {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, "heat", state.State)
+				require.NotNil(t, state.Attributes.Temperature)
+				assert.Equal(t, 20.5, *state.Attributes.Temperature)
+			}
+		})
+	}
+}

--- a/util/homeassistant/types.go
+++ b/util/homeassistant/types.go
@@ -20,6 +20,21 @@ type StateResponse struct {
 	} `json:"attributes"`
 }
 
+type ClimateStateResponse struct {
+	EntityId   string `json:"entity_id"`
+	State      string `json:"state"`
+	Attributes struct {
+		UnitOfMeasurement  string   `json:"unit_of_measurement"`
+		Temperature        *float64 `json:"temperature"`
+		CurrentTemperature *float64 `json:"current_temperature"`
+		MinTemp            *float64 `json:"min_temp"`
+		MaxTemp            *float64 `json:"max_temp"`
+		TargetTempStep     *float64 `json:"target_temp_step"`
+		HVACModes          []string `json:"hvac_modes"`
+		SupportedFeatures  int      `json:"supported_features"`
+	} `json:"attributes"`
+}
+
 func (state StateResponse) scale() (float64, error) {
 	if unit, ok := strings.CutSuffix(state.Attributes.UnitOfMeasurement, "W"); ok {
 		switch unit {


### PR DESCRIPTION
Related to #25906 and [discussion #28256](https://github.com/evcc-io/evcc/discussions/28256).

Adds thermostat boost-and-restore through Home Assistant, with an Intergas Comfort Touch / Xtend template. The intended behavior is to raise the starting room target once, then restore it on Normal. InComfort exposes a heat-only thermostat with a writable target, so treating it as an on/off switch does not express that contract.

- Reuses Home Assistant authentication and the settings database. evcc chooses when to boost; the configured delta defines the total increase. Native Intergas hybrid control remains responsible for heating.
- Persists the starting target before writing, prevents accumulated increases, and retains unresolved commands across restarts. Observed manual/schedule changes suspend further boost until Normal. Getters never send temperature commands.
- Validates Celsius units, target limits and reported steps; measures electrical input separately from logical boost state. Includes isolated HTTP and file-backed persistence regressions for delayed/lost replies, manual changes, restart, concurrent instances and restoration failures.

On the reference installation, an HA service test on 28 August 2026 propagated 20.0 → 20.5 → 20.0°C to the separately reported Xtend room target, approximately 28 seconds after the increase and 64 seconds after restoration. The room was warmer than both targets, so this demonstrates the existing transport only. The inspected installation uses the legacy LAN2RF gateway protocol, gateway firmware IC3-2-ICN-V1.30, and Xtend firmware V0.93-. The new evcc adapter has been exercised against simulated HA responses, not a live heating cycle. No savings or gas-avoidance claim is made. Raw household snapshots are not attached.

Compatibility is intentionally limited: [HA InComfort](https://www.home-assistant.io/integrations/incomfort/) does not support Gateway V3, and the [HA climate implementation](https://github.com/home-assistant/core/blob/2026.9.1/homeassistant/components/incomfort/climate.py) exposes no usable heating-off action. The [Xtend manual](https://www.intergas-verwarming.nl/app/uploads/2022/09/880084-Installatievoorschrift-Xtend-NL.pdf#page=71) distinguishes the P186/P217 boiler-assistance thresholds. A small boost is not a guarantee that the boiler will remain off; this PR changes no installer parameters.

Restoration requires connectivity. Select Off and confirm the saved target at the thermostat before stopping/removing/reconfiguring the controller; HA can acknowledge a target before the device applies it. There is no device-side expiry, and a command that never acknowledges may need manual recovery. Numeric comparison cannot perfectly identify same-value or racing manual changes. The template also flags InComfort client 0.7.1's separate tenth-degree serialization issue; no protocol workaround is added here.

🤖 Generated with [OpenAI Codex](https://openai.com/codex/)
