### PR TITLE
Vehicle: fix UI location in deprecated mode warning

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -545,7 +545,7 @@ func configureVehicles(static []config.Named, names ...string) error {
 			}
 
 			if _, ok := instance.OnIdentified().GetMode(); ok {
-				log.WARN.Printf("vehicle '%s': default charge 'mode' is deprecated, please configure via UI (charging plan > arrival)", cc.Name)
+				log.WARN.Printf("vehicle '%s': default charge 'mode' is deprecated, please configure via UI (more > vehicles)", cc.Name)
 			}
 
 			mu.Lock()


### PR DESCRIPTION
refs #33538

The deprecation warning for the yaml `mode` setting still points to "charging plan > arrival". The default mode moved to the vehicle settings modal.

- Warning now says "more > vehicles"

🤖 Generated with [Claude Code](https://claude.com/claude-code)