### PR TITLE
Loadpoint: resume charging during phase switch

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -882,7 +882,7 @@ func (lp *Loadpoint) syncCharger() error {
 	}
 
 	// #1: check charger logic, fix charger state if necessary (for chargers that start charging while being disabled)
-	if !enabled && lp.charging() {
+	if !enabled && lp.charging() && lp.phaseSwitchCompleted() {
 		lp.log.WARN.Println("charger logic error: disabled but charging")
 
 		// treat as enabled when charging for further validations

--- a/core/loadpoint_sync_test.go
+++ b/core/loadpoint_sync_test.go
@@ -49,6 +49,32 @@ func TestSyncCharger(t *testing.T) {
 	}
 }
 
+func TestSyncChargerDuringPhaseSwitch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	charger := api.NewMockCharger(ctrl)
+	charger.EXPECT().Status().Return(api.StatusB, nil)
+	charger.EXPECT().Enabled().Return(false, nil)
+	charger.EXPECT().Enable(true).Return(nil)
+
+	clock := clock.NewMock()
+	lp := &Loadpoint{
+		log:            util.NewLogger("foo"),
+		clock:          clock,
+		charger:        charger,
+		status:         api.StatusC,
+		enabled:        true,
+		phasesSwitched: clock.Now(),
+	}
+
+	changes, err := lp.getStatusChanges()
+	require.NoError(t, err)
+	require.Empty(t, changes)
+	require.Equal(t, api.StatusC, lp.GetStatus())
+
+	require.NoError(t, lp.syncCharger())
+	assert.True(t, lp.enabled)
+}
+
 func TestSyncChargerCurrentsByGetter(t *testing.T) {
 	tc := []struct {
 		lpCurrent, actualCurrent, outCurrent float64


### PR DESCRIPTION
Refs #33545, follow-up to #33109.

During phase switching, the retained charging status could mask a disabled charger and delay re-enabling until the 60-second grace period expired. Skip the disabled-but-charging correction during that period so the existing phase-switch recovery can run.

- Restore prompt re-enabling and avoid misleading charger logic warnings during phase switching.
- Add regression coverage for a suppressed charging interruption followed by charger synchronization.
- Addresses the delayed restart only; the persistent single-phase consumption reported in #33545 remains unresolved.

🤖 Generated with [OpenCode](https://opencode.ai)