### PR TITLE
chore: skip update check for dev and nightly builds

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -506,8 +506,8 @@ func runRoot(cmd *cobra.Command, args []string) {
 		once.Do(func() { close(stopC) })     // signal loop to end
 	}, viper.ConfigFileUsed(), remoteAccess)
 
-	// show and check version, reduce api load during development
-	if util.Version != util.DevVersion {
+	// skip update check for dev and nightly builds, reduces api load
+	if util.Version != util.DevVersion && !strings.Contains(util.Version, "-dev.") {
 		go updater.Run(log, httpd, valueChan)
 	}
 


### PR DESCRIPTION
pairs with #32663

The updater guard only skipped the plain `0.0.0` version. Since untagged builds are stamped as `x.y.z-dev.<timestamp>`, every `make build` binary queried the GitHub releases API on start. Parallel Playwright instances hit the unauthenticated rate limit, both locally and in the Integration CI job.

- Skip the update check for `-dev.` versions as well, matching the UI which already hides update hints for nightly builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)