### PR TITLE
Vehicle API: handle TeslaMate sleeping response

### DIFF
--- a/charger/vehicle-api.go
+++ b/charger/vehicle-api.go
@@ -54,21 +54,23 @@ func NewVehicleApiFromConfig(other map[string]any) (api.Charger, error) {
 }
 
 // asleep maps a vehicle api's sleeping response to api.ErrAsleep so the loadpoint
-// can trigger the existing wake-up logic. Proxies like TeslaBleHttpProxy answer
-// HTTP 503 with a json body stating the reason.
+// can trigger the existing wake-up logic.
 func asleep(err error) error {
 	var se *request.StatusError
-	if !errors.As(err, &se) || !se.HasStatus(http.StatusServiceUnavailable) {
+	if !errors.As(err, &se) || !se.HasStatus(http.StatusServiceUnavailable, http.StatusRequestTimeout) {
 		return err
 	}
 
 	var res struct {
+		Error    string
 		Response struct {
 			Reason string
 		}
 	}
 
-	if json.Unmarshal(se.Body(), &res) == nil && strings.Contains(strings.ToLower(res.Response.Reason), "sleep") {
+	if json.Unmarshal(se.Body(), &res) == nil &&
+		(se.HasStatus(http.StatusServiceUnavailable) && strings.Contains(strings.ToLower(res.Response.Reason), "sleep") ||
+			se.HasStatus(http.StatusRequestTimeout) && strings.Contains(res.Error, "vehicle unavailable")) {
 		return api.ErrAsleep
 	}
 

--- a/charger/vehicle-api_test.go
+++ b/charger/vehicle-api_test.go
@@ -47,3 +47,17 @@ func TestAsleep(t *testing.T) {
 	require.NotErrorIs(t, asleep(statusErr(t, http.StatusServiceUnavailable, "sleeping")), api.ErrAsleep)
 	require.NoError(t, asleep(nil))
 }
+
+func TestAsleepTeslaMate(t *testing.T) {
+	unavailable := `{"error":"vehicle unavailable: {error: \"vehicle unavailable:\"}","error_description":"","response":null}`
+	require.ErrorIs(t, asleep(statusErr(t, http.StatusRequestTimeout, unavailable)), api.ErrAsleep)
+
+	for _, err := range []error{
+		statusErr(t, http.StatusServiceUnavailable, unavailable),
+		statusErr(t, http.StatusRequestTimeout, `{"error":"request timed out"}`),
+		statusErr(t, http.StatusRequestTimeout, `{"response":{"reason":"vehicle is sleeping"}}`),
+		statusErr(t, http.StatusRequestTimeout, "vehicle unavailable"),
+	} {
+		require.Same(t, err, asleep(err))
+	}
+}


### PR DESCRIPTION
Fixes #33513

Recognize TeslaMate's HTTP 408 "vehicle unavailable" response as `api.ErrAsleep` so the existing loadpoint logic can wake the vehicle and retry.

- Preserve Tesla BLE's 503 mapping and unrelated HTTP errors.
- No changes to the HTTP plugin or configuration.

🤖 Generated with [OpenCode](https://opencode.ai)