### PR TITLE
Use official vite+ image for Devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/go
 {
 	"name": "evcc",
-	"image": "mcr.microsoft.com/devcontainers/go",
+	"image": "ghcr.io/voidzero-dev/vite-plus@sha256:de284eb61eb6ee5fe1da3824032ed6fb37827eecd597d0d796cacd4434f806ea",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
 			"moby": false,
@@ -11,12 +11,9 @@
 			"version": "latest",
 			"dockerDashComposeVersion": "v2"
 		},
-		"ghcr.io/devcontainers/features/node:1": {
-			"nodeGypDependencies": true,
-			"installYarnUsingApt": true,
-			"version": "26",
-			"pnpmVersion": "latest",
-			"nvmVersion": "latest"
+		"ghcr.io/devcontainers/features/go:1": {
+			"version": "1.27.0",
+			"installGoTools": false
 		}
 	},
 	"postCreateCommand": "make install-ui && make install",


### PR DESCRIPTION
fixes #33295 and replaces PR #33302 

Adopt changes in #33373 for Devcontainers too.
I successfully tested the changes in a local Devcontainer environment running on a Synology Diskstation and also with Github Codespaces.

The line to prevent Go Tools installation depends on a PR at the Go Devcontainer-Feature:
https://github.com/devcontainers/features/pull/1729

But it does not harm current or prior versions, although the Go-Installation takes a few moments longer then.