### PR TITLE
Škoda: expose welcomecharge for MyŠkoda public api template

### DIFF
--- a/templates/definition/vehicle/myskoda.yaml
+++ b/templates/definition/vehicle/myskoda.yaml
@@ -10,6 +10,8 @@ requirements:
 params:
   - preset: vehicle-common
   - preset: vehicle-online
+  - name: welcomecharge
+    advanced: true
   - name: apikey
     required: true
     help:


### PR DESCRIPTION
The `myskoda` template renders the shared vehicle `features` include, but declares only the `vehicle-common` and `vehicle-online` presets. Neither preset contains `welcomecharge`, so configuring it fails with:

```
cannot create vehicle type 'template': invalid key: welcomecharge
```

This is the same declaration/render mismatch that was fixed for the legacy `skoda` template in #32636 (issue #32586). It re-appeared with the MyŠkoda public api template added in #33234, so users migrating to the new API lose the setting again.

`vw`, `audi`, `seat` and `seat-cupra` all declare the param explicitly; `myskoda` is the only online-vehicle template that renders it without declaring it.

### Change

```diff
 params:
   - preset: vehicle-common
   - preset: vehicle-online
+  - name: welcomecharge
+    advanced: true
   - name: apikey
```

### Verification

Rendering the template with `welcomecharge: true` (`RenderModeInstance`):

| | `ParamByName("welcomecharge")` | result |
| --- | --- | --- |
| before | `-1` | `invalid key: welcomecharge` |
| after | `15` | no error, renders `features:` / `- welcomecharge` |

`go test ./util/templates/...` and `go test ./vehicle/ -run TestVehicleFeatureParamsConsistent` pass.