### PR TITLE
Voltie: detect phase switching from the capability register

### DIFF
--- a/charger/voltie.go
+++ b/charger/voltie.go
@@ -56,10 +56,10 @@ import (
 // phase powers. Those capabilities are only offered when the charger reports
 // that firmware, and the block read lengths follow the firmware as well.
 //
-// Phase switching additionally depends on the power board, which the firmware
-// does not expose over Modbus. The same firmware also runs on older boards that
-// have no L2/L3 relay and reject the write, so the capability is enabled by
-// configuration rather than guessed.
+// Phase switching depends on the power board rather than on the firmware: the
+// same firmware also runs on older boards that have no L2/L3 relay and reject
+// the write. From firmware 357 the charger reports that in a capability
+// bitmask, so it is detected; on older firmware it comes from configuration.
 
 const (
 	// register blocks fetched in bulk
@@ -73,6 +73,9 @@ const (
 	// firmware 352 extends both blocks
 	voltieLenStatusBlockExt = 15 // 0x000A..0x0018
 	voltieLenMeterBlockExt  = 30 // 0x2000..0x201D
+
+	// firmware 357 extends the status block again
+	voltieLenStatusBlockCap = 17 // 0x000A..0x001A
 
 	// identification block. The 64 bit serial numbers are sent
 	// least-significant word first, unlike the metering values.
@@ -102,6 +105,13 @@ const (
 	voltieRegQueryTimeout = 0x0017 // INT16 communication timeout [s]
 	voltieRegMaxCurrent   = 0x0018 // INT16 hardware current limit [mA]
 
+	// status block, firmware 357
+	voltieRegCapability = 0x0019 // INT16 capability bitmask
+	voltieRegPhasesUsed = 0x001A // INT16 phases carrying load while charging
+
+	// bits of the capability bitmask at 0x0019
+	voltieCapPhaseSwitch = 0x0001 // the power board can switch phases
+
 	// meter block
 	voltieRegVoltages = 0x2000 // 3x INT32 phase voltage [mV]
 	voltieRegCurrents = 0x2006 // 3x INT32 phase charging current [mA]
@@ -125,6 +135,9 @@ const (
 	// firmware that adds phase switching, the communication timeout, the
 	// hardware current limit, lifetime energy and the phase powers
 	voltieExtFirmware = 352
+
+	// firmware that reports the capability bitmask and the loaded phase count
+	voltieCapFirmware = 357
 
 	// the L2/L3 contactor must not be switched under load, so the firmware
 	// rejects a phase switch while charging and holds the contactor for up to
@@ -220,13 +233,14 @@ var voltieStopReasons = map[uint16]string{
 // Voltie is an api.Charger implementation for Voltie wallboxes
 type Voltie struct {
 	implement.Caps
-	conn   *modbus.Connection
-	log    *util.Logger
-	cache  *modbus.Cache
-	status modbus.Block
-	meter  modbus.Block
-	info   modbus.Block
-	ext    bool // firmware provides the extended register blocks
+	conn        *modbus.Connection
+	log         *util.Logger
+	cache       *modbus.Cache
+	status      modbus.Block
+	meter       modbus.Block
+	info        modbus.Block
+	ext         bool // firmware provides the extended register blocks
+	reportsCaps bool // firmware reports its capabilities at 0x0019
 }
 
 // read fetches a register block through the shared bulk read cache, so all
@@ -321,6 +335,11 @@ func NewVoltie(ctx context.Context, settings modbus.TcpSettings, cache time.Dura
 		switch {
 		case fw < voltieMinFirmware:
 			log.WARN.Printf("firmware %d is outdated, Modbus TCP requires %d or later", fw, voltieMinFirmware)
+		case fw >= voltieCapFirmware:
+			wb.ext = true
+			wb.reportsCaps = true
+			wb.status.Count = voltieLenStatusBlockCap
+			wb.meter.Count = voltieLenMeterBlockExt
 		case fw >= voltieExtFirmware:
 			wb.ext = true
 			wb.status.Count = voltieLenStatusBlockExt
@@ -339,6 +358,19 @@ func NewVoltie(ctx context.Context, settings modbus.TcpSettings, cache time.Dura
 		implement.Has(wb, implement.MeterEnergy(wb.totalEnergy))
 		implement.Has(wb, implement.PhasePowers(wb.powers))
 		implement.Has(wb, implement.CurrentLimiter(wb.getMinMaxCurrent))
+
+		// from firmware 357 the charger knows whether its power board can switch
+		// phases, which makes the setting unnecessary
+		if wb.reportsCaps {
+			if supported, err := wb.hasCapability(voltieCapPhaseSwitch); err != nil {
+				log.WARN.Printf("capability register unavailable, keeping the configured phase switching: %v", err)
+			} else {
+				if phaseSwitching && !supported {
+					log.WARN.Println("phase switching is configured but the charger reports it is not supported")
+				}
+				phaseSwitching = supported
+			}
+		}
 
 		if phaseSwitching {
 			implement.Has(wb, implement.PhaseSwitcher(wb.phases1p3p))
@@ -546,6 +578,16 @@ func (wb *Voltie) Voltages() (float64, float64, float64, error) {
 	return wb.getPhaseValues(voltieRegVoltages, 1e3)
 }
 
+// hasCapability reports whether the charger's capability bitmask has the bit set
+func (wb *Voltie) hasCapability(bit uint16) (bool, error) {
+	b, err := wb.read(wb.status)
+	if err != nil {
+		return false, err
+	}
+
+	return voltieU16(wb.status, b, voltieRegCapability)&bit != 0, nil
+}
+
 // phases1p3p implements the api.PhaseSwitcher interface. The firmware never
 // accepts the write while charging, so charging is paused for the switch.
 func (wb *Voltie) phases1p3p(phases int) error {
@@ -696,6 +738,11 @@ func (wb *Voltie) Diagnose() {
 			fmt.Printf("\tSingle phase:\t%d\n", voltieU16(wb.status, b, voltieRegSinglePhase))
 			fmt.Printf("\tQuery timeout:\t%d s\n", voltieU16(wb.status, b, voltieRegQueryTimeout))
 			fmt.Printf("\tMax capacity:\t%d mA\n", voltieU16(wb.status, b, voltieRegMaxCurrent))
+		}
+
+		if wb.reportsCaps {
+			fmt.Printf("\tCapabilities:\t0x%04X\n", voltieU16(wb.status, b, voltieRegCapability))
+			fmt.Printf("\tPhases used:\t%d\n", voltieU16(wb.status, b, voltieRegPhasesUsed))
 		}
 	}
 

--- a/templates/definition/charger/voltie.yaml
+++ b/templates/definition/charger/voltie.yaml
@@ -15,8 +15,8 @@ caveats:
       de: Das Modbus-TCP-Gateway leitet höchstens zwei Transaktionen pro Sekunde weiter. Kürzere Abfrageintervalle führen zu Zeitüberschreitungen, nicht zu aktuelleren Daten.
       en: The Modbus TCP gateway forwards at most two transactions per second. Shorter polling intervals produce timeouts rather than fresher data.
   - description:
-      de: Die Phasenumschaltung ist nur auf Ladegeräten ab Baujahr 2026 verfügbar (Seriennummer beginnt mit 1026). Auf älteren Geräten weist das Ladegerät die Umschaltung ab.
-      en: Phase switching is only available on chargers manufactured from 2026 (serial number starting with 1026). On older hardware the charger rejects the switch.
+      de: Die Phasenumschaltung ist nur auf Ladegeräten ab Baujahr 2026 verfügbar (Seriennummer beginnt mit 1026). Ab Firmware 357 liest evcc die Fähigkeit vom Ladegerät und bietet die Phasenumschaltung nur dort an, wo sie unterstützt wird.
+      en: Phase switching is only available on chargers manufactured from 2026 (serial number starting with 1026). From firmware 357 evcc reads the capability from the charger and only offers phase switching where it is supported.
 params:
   - name: modbus
     choice: ["tcpip"]
@@ -28,12 +28,9 @@ params:
     description:
       de: Phasenumschaltung
       en: Phase switching
-    help:
-      de: Nur für EVSE-Firmware älter als 357 nötig; ab 357 meldet das Ladegerät selbst, ob es umschalten kann. Verfügbar nur auf Ladegeräten ab Baujahr 2026, deren Seriennummer mit 1026 beginnt.
-      en: Only needed on EVSE firmware older than 357; from 357 the charger reports whether it can switch. Available only on chargers manufactured from 2026, whose serial number starts with 1026.
+    deprecated: true
     type: bool
     default: false
-    advanced: true
 render: |
   type: voltie
   {{- include "modbus" . }}

--- a/templates/definition/charger/voltie.yaml
+++ b/templates/definition/charger/voltie.yaml
@@ -1,13 +1,11 @@
 template: voltie
 products:
   - brand: Voltie
-    description:
-      generic: Charger
 capabilities: ["mA", "1p3p", "meter", "dim"]
 requirements:
   description:
-    de: Modbus muss in der Voltie App im Modbus-Konfigurationsbildschirm auf "TCP" gestellt werden; die dort eingestellte Slave-Adresse (Standard 11) muss mit der ID übereinstimmen. Der Kommunikations-Timeout regelt die Ladung nach Verbindungsverlust auf 0 A herunter, er muss daher auf 0 gesetzt (deaktiviert) oder größer als das evcc-Aktualisierungsintervall gewählt werden. Benötigt EVSE-Firmware 350 oder neuer und Ladegerät-Software 1.3.40 oder neuer. Phasenumschaltung, Gesamtzähler, Phasenleistungen und die Strom-Grenzwerte benötigen EVSE-Firmware 352 oder neuer.
-    en: Modbus must be set to "TCP" on the Modbus config screen of the Voltie app, and the slave address configured there (default 11) must match the ID. The communication timeout reduces the charging current to 0 A after a loss of communication, so it has to be set to 0 (disabled) or to a value larger than the evcc update interval. Requires EVSE firmware 350 or later and charger software 1.3.40 or later. Phase switching, the total energy counter, the phase powers and the current limits require EVSE firmware 352 or later.
+    de: Modbus muss in der Voltie App im Modbus-Konfigurationsbildschirm auf "TCP" gestellt werden; die dort eingestellte Slave-Adresse (Standard 11) muss mit der ID übereinstimmen. Der Kommunikations-Timeout regelt die Ladung nach Verbindungsverlust auf 0 A herunter, er muss daher auf 0 gesetzt (deaktiviert) oder größer als das evcc-Aktualisierungsintervall gewählt werden.
+    en: Modbus must be set to "TCP" on the Modbus config screen of the Voltie app, and the slave address configured there (default 11) must match the ID. The communication timeout reduces the charging current to 0 A after a loss of communication, so it has to be set to 0 (disabled) or to a value larger than the evcc update interval.
   evcc: ["sponsorship"]
 caveats:
   - description:

--- a/templates/definition/charger/voltie.yaml
+++ b/templates/definition/charger/voltie.yaml
@@ -29,8 +29,8 @@ params:
       de: Phasenumschaltung
       en: Phase switching
     help:
-      de: Nur auf Ladegeräten ab Baujahr 2026 verfügbar, deren Seriennummer mit 1026 beginnt. Auf älterer Hardware weist das Ladegerät die Umschaltung ab.
-      en: Only available on chargers manufactured from 2026, whose serial number starts with 1026. On older hardware the charger rejects the switch.
+      de: Nur für EVSE-Firmware älter als 357 nötig; ab 357 meldet das Ladegerät selbst, ob es umschalten kann. Verfügbar nur auf Ladegeräten ab Baujahr 2026, deren Seriennummer mit 1026 beginnt.
+      en: Only needed on EVSE firmware older than 357; from 357 the charger reports whether it can switch. Available only on chargers manufactured from 2026, whose serial number starts with 1026.
     type: bool
     default: false
     advanced: true


### PR DESCRIPTION
Follow-up to #33070. Phase switching depends on the power board, which the firmware did not expose, so that PR put the capability behind the `phases1p3p` setting. Firmware 357 reports it in a bitmask at `0x0019`, so the driver reads it instead.

- phase switching is offered when bit 0 is set; below firmware 357 the setting still decides it, and it is deprecated rather than removed so existing configurations keep loading
- the status block now ends at `0x001A`, the number of phases actually loaded while charging, which the diagnostics print next to the capability bitmask
- the product is listed as `Voltie`, and the firmware and software versions are dropped from the requirements: the app only offers the Modbus TCP option on a charger that has them, so the numbers give the user nothing to act on

Tested on two chargers with firmware 360: switching in both directions on a three-phase charger with a car charging, and on a charger whose power board cannot switch the capability is not offered.
