### PR TITLE
Solis Hybrid S: require minsoc and maxsoc for active battery control

### DIFF
--- a/templates/definition/meter/solis-hybrid-s.yaml
+++ b/templates/definition/meter/solis-hybrid-s.yaml
@@ -25,6 +25,12 @@ params:
     id: 1
   - name: maxacpower
   - preset: battery-params
+  # active battery control writes these into the inverter's Battery Reserve SOC
+  # register, so they must reflect the values actually configured on the device
+  - name: minsoc
+    required: true
+  - name: maxsoc
+    required: true
 render: |
   type: custom
   {{- if eq .usage "grid" }}


### PR DESCRIPTION
## Description

Fixes #33578.

The `batterymode` switch added in b10c9e7 (#27796) replaced the old `limitsoc`
hold mechanism. It writes `{{ .maxsoc }}` (hold / charge) or `{{ .minsoc }}`
(normal) into the **Battery Reserve SOC** holding register 43024:

```yaml
- source: const
  value: {{ .maxsoc }}
  set:
    source: modbus
    register:
      address: 43024 # Battery Reserve SOC
```

`minsoc` / `maxsoc` come from the `battery-params` preset and are optional with
no default. When they are not configured the template renders `value:` empty and
`constPlugin.IntSetter` turns the empty string into `0`. So in **hold** mode
evcc writes a reserve of `0`, which removes the discharge floor entirely — the
inverter keeps discharging the battery while evcc shows it as held. In **charge**
mode the grid-charge target collapses to `0`.

Reproduced by rendering the template with the reporter's config (battery meter
with only `capacity` set): the `hold` case emits `value:` (empty) → `0` written
to 43024. Before b10c9e7, `hold` used `limitsoc`, which the core set to the live
battery SOC, so it worked with no extra configuration.

## Fix

Mark `minsoc` and `maxsoc` as `required: true` for the battery usage, so the
configured values have to match what is actually set on the inverter. This
matches how `fox-ess-avocado` already treats them, and keeps the template
writing the real values (no silent fallback that could be wrong for the
grid-charge target). Per-usage validation means `grid` / `pv` meters of the same
template are unaffected.

CI stays green because the template unit test renders with the preset examples
(`minsoc: 25`, `maxsoc: 95`).

## Breaking change

Existing `solis-hybrid-s` **battery** meters must set `minsoc` and `maxsoc`.
YAML configs fail on start until both are present; UI-configured meters flag the
now-mandatory fields on next edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)