### PR TITLE
Meter: require minsoc and maxsoc where active battery control writes them to the device

### DIFF
--- a/templates/definition/meter/alpha-ess-smile.yaml
+++ b/templates/definition/meter/alpha-ess-smile.yaml
@@ -19,6 +19,11 @@ params:
     id: 85
   - name: maxacpower
   - preset: battery-params
+  # active battery control writes these to the device, they must match its settings
+  - name: minsoc
+    required: true
+  - name: maxsoc
+    required: true
 render: |
   type: custom
   {{- if eq .usage "grid" }}

--- a/templates/definition/meter/atmoce.yaml
+++ b/templates/definition/meter/atmoce.yaml
@@ -23,12 +23,15 @@ params:
   - name: maxacpower
     service: modbus/read?address=60027&type=holding&encoding=uint32&scale=1&resulttype=int&{modbus}
   - preset: battery-minmaxsoc
+  # active battery control writes these to the device, they must match its settings
   - name: minsoc
     advanced: true
     default: 10
+    required: true
   - name: maxsoc
     advanced: true
     default: 100
+    required: true
   - name: firmware
     type: choice
     choice: ["<01.01.00.28.15", ">=01.01.00.28.15"]

--- a/templates/definition/meter/atmoce.yaml
+++ b/templates/definition/meter/atmoce.yaml
@@ -25,11 +25,9 @@ params:
   - preset: battery-minmaxsoc
   # active battery control writes these to the device, they must match its settings
   - name: minsoc
-    advanced: true
     default: 10
     required: true
   - name: maxsoc
-    advanced: true
     default: 100
     required: true
   - name: firmware

--- a/templates/definition/meter/deye-hybrid-3p.yaml
+++ b/templates/definition/meter/deye-hybrid-3p.yaml
@@ -20,6 +20,11 @@ params:
   - name: storageunit
     choice: ["1", "2"]
   - preset: battery-params
+  # active battery control writes these to the device, they must match its settings
+  - name: minsoc
+    required: true
+  - name: maxsoc
+    required: true
   - name: batterytype
     choice: ["lv", "hv"]
     required: true

--- a/templates/definition/meter/fox-ess-h3-smart.yaml
+++ b/templates/definition/meter/fox-ess-h3-smart.yaml
@@ -12,6 +12,11 @@ params:
     id: 247
   - name: maxacpower
   - preset: battery-params
+  # active battery control writes these to the device, they must match its settings
+  - name: minsoc
+    required: true
+  - name: maxsoc
+    required: true
   - name: maxchargepower
     required: true
 render: |

--- a/templates/definition/meter/fox-ess-h3.yaml
+++ b/templates/definition/meter/fox-ess-h3.yaml
@@ -18,10 +18,8 @@ params:
     advanced: true
   # active battery control writes these to the device, they must match its settings
   - name: minsoc
-    advanced: true
     required: true
   - name: maxsoc
-    advanced: true
     required: true
 render: |
   type: custom

--- a/templates/definition/meter/fox-ess-h3.yaml
+++ b/templates/definition/meter/fox-ess-h3.yaml
@@ -16,10 +16,13 @@ params:
     required: true
   - name: capacity
     advanced: true
+  # active battery control writes these to the device, they must match its settings
   - name: minsoc
     advanced: true
+    required: true
   - name: maxsoc
     advanced: true
+    required: true
 render: |
   type: custom
   {{- if eq .usage "grid" }}

--- a/templates/definition/meter/indevolt-battery.yaml
+++ b/templates/definition/meter/indevolt-battery.yaml
@@ -42,6 +42,11 @@ params:
   - name: cache
     default: 5s
   - preset: battery-params
+  # active battery control writes these to the device, they must match its settings
+  - name: minsoc
+    required: true
+  - name: maxsoc
+    required: true
   - name: maxchargepower
     default: 2400
     help:

--- a/templates/definition/meter/saj-h2.yaml
+++ b/templates/definition/meter/saj-h2.yaml
@@ -14,6 +14,11 @@ params:
     baudrate: 115200
     comset: 8N1
   - preset: battery-params
+  # active battery control writes these to the device, they must match its settings
+  - name: minsoc
+    required: true
+  - name: maxsoc
+    required: true
   # battery control
   - name: defaultmode
     default: 2

--- a/templates/definition/meter/tesla-powerwall-fleet.yaml
+++ b/templates/definition/meter/tesla-powerwall-fleet.yaml
@@ -51,7 +51,6 @@ params:
   # written to the device as backup reserve, must match its settings
   - name: minsoc
     default: 20
-    advanced: true
     required: true
     help:
       de: Backup-Reserve, die evcc im Normalbetrieb wiederherstellt

--- a/templates/definition/meter/tesla-powerwall-fleet.yaml
+++ b/templates/definition/meter/tesla-powerwall-fleet.yaml
@@ -48,9 +48,11 @@ params:
     help:
       en: optional product identifier of the energy site, use to override autodetection
       de: optionale Product ID dieser Energy Site, zum Übersteuern der automatischen Erkennung
+  # written to the device as backup reserve, must match its settings
   - name: minsoc
     default: 20
     advanced: true
+    required: true
     help:
       de: Backup-Reserve, die evcc im Normalbetrieb wiederherstellt
       en: Backup reserve evcc restores in normal operation


### PR DESCRIPTION
follows #33580, related #33578

Same latent issue as solis-hybrid-s: these templates write `minsoc`/`maxsoc` into the device via the battery mode switch, so an unset value renders empty and writes `0`. Both are now required for battery usage so the configured values must match what is set on the device.

- alpha-ess-smile, deye-hybrid-3p, fox-ess-h3, fox-ess-h3-smart, indevolt-battery, saj-h2: minsoc and maxsoc required
- atmoce: required added on top of the existing defaults
- tesla-powerwall-fleet: minsoc required (backup reserve), maxsoc stays deprecated
- breaking: existing battery meters of these templates must set both values

🤖 Generated with [Claude Code](https://claude.com/claude-code)