### PR TITLE
Meter: default battery minsoc/maxsoc to 0/100

### DIFF
--- a/meter/meter.go
+++ b/meter/meter.go
@@ -43,10 +43,10 @@ func NewConfigurableFromConfig(ctx context.Context, other map[string]any) (api.M
 
 	// default soc limits (nil-preset avoids mapstructure coercing plugin config into the default's type)
 	if cc.batterySocLimitsCtx.MinSoc == nil {
-		cc.batterySocLimitsCtx.MinSoc = 20
+		cc.batterySocLimitsCtx.MinSoc = 0
 	}
 	if cc.batterySocLimitsCtx.MaxSoc == nil {
-		cc.batterySocLimitsCtx.MaxSoc = 95
+		cc.batterySocLimitsCtx.MaxSoc = 100
 	}
 
 	powerG, energyG, returnG, err := cc.Energy.Configure(ctx)

--- a/meter/usage_battery.go
+++ b/meter/usage_battery.go
@@ -134,9 +134,10 @@ type batterySocLimits struct {
 
 // var _ api.BatterySocLimiter = (*batterySocLimits)(nil)
 
-// Decorator returns an api.BatterySocLimiter decorator
+// Decorator returns an api.BatterySocLimiter decorator. The neutral defaults
+// (0/0 or 0/100) mean no limits configured.
 func (m *batterySocLimits) Decorator() func() (float64, float64) {
-	if m.MinSoc == 0 && m.MaxSoc == 0 {
+	if m.MinSoc == 0 && (m.MaxSoc == 0 || m.MaxSoc == 100) {
 		return nil
 	}
 	return func() (float64, float64) {

--- a/templates/definition/meter/solis-hybrid-s.yaml
+++ b/templates/definition/meter/solis-hybrid-s.yaml
@@ -25,6 +25,12 @@ params:
     id: 1
   - name: maxacpower
   - preset: battery-params
+  # active battery control writes these into the inverter's Battery Reserve SOC
+  # register, so they must reflect the values actually configured on the device
+  - name: minsoc
+    required: true
+  - name: maxsoc
+    required: true
 render: |
   type: custom
   {{- if eq .usage "grid" }}

--- a/templates/definition/meter/solis-hybrid-s.yaml
+++ b/templates/definition/meter/solis-hybrid-s.yaml
@@ -25,12 +25,6 @@ params:
     id: 1
   - name: maxacpower
   - preset: battery-params
-  # active battery control writes these into the inverter's Battery Reserve SOC
-  # register, so they must reflect the values actually configured on the device
-  - name: minsoc
-    required: true
-  - name: maxsoc
-    required: true
 render: |
   type: custom
   {{- if eq .usage "grid" }}

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -147,6 +147,7 @@ params:
       de: Untere Grenze wie am Batteriesystem eingestellt. Wird vom Optimizer genutzt.
       en: Lower limit as configured on the battery system. Used by optimizer.
     example: 25
+    default: 0
     type: int
     usages: ["battery"]
   - name: maxsoc
@@ -158,6 +159,7 @@ params:
       de: Obere Grenze wie am Batteriesystem eingestellt. Wird vom Optimizer und für Netzladen genutzt.
       en: Upper limit as configured on the battery system. Used by optimizer and for grid charging.
     example: 95
+    default: 100
     type: int
     usages: ["battery"]
   - name: mincurrent


### PR DESCRIPTION
alternative to #33587, related #33580 and #33578

Instead of requiring `minsoc`/`maxsoc` wherever a template writes them to the device, give them neutral defaults. An unset value then renders `0`/`100` instead of an empty string that the const plugin turned into `0` for both.

- `defaults.yaml`: `minsoc` defaults to 0, `maxsoc` to 100, so every battery template and the UI form pick them up
- custom meter: unset `minsoc`/`maxsoc` default to 0/100 instead of 20/95
- templates with their own defaults (fox-ess-avocado, marstek-venus-a, atmoce, tesla-powerwall-fleet) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)