### PR TITLE
Add display configuration and MQTT integration for OpenWB

### DIFF
--- a/charger/openwb-2.0.go
+++ b/charger/openwb-2.0.go
@@ -5,6 +5,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -15,6 +17,7 @@ import (
 	"github.com/evcc-io/evcc/plugin/mqtt"
 	"github.com/evcc-io/evcc/server/network"
 	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/config"
 	"github.com/evcc-io/evcc/util/modbus"
 )
 
@@ -57,6 +60,7 @@ func NewOpenWB20FromConfig(ctx context.Context, other map[string]any) (api.Charg
 		Phases1p3p         bool
 		Identify           bool
 		Display            bool
+		Query              string
 		mqtt.Config        `mapstructure:",squash"`
 		modbus.TcpSettings `mapstructure:",squash"`
 	}{
@@ -119,7 +123,11 @@ func NewOpenWB20FromConfig(ctx context.Context, other map[string]any) (api.Charg
 				stop := context.AfterFunc(ctx, disconnect)
 				defer stop()
 				defer disconnect()
-				err = openwb.ConfigureDisplay(ctx, log, client, uri)
+				query := strings.TrimLeft(cc.Query, "/?#")
+				if query == "" {
+					query = lookupOpenWB20LoadpointQuery(wb)
+				}
+				err = openwb.ConfigureDisplay(ctx, log, client, uri, query)
 			}
 			if err != nil && ctx.Err() != context.Canceled {
 				log.DEBUG.Printf("display setup: %v", err)
@@ -128,6 +136,30 @@ func NewOpenWB20FromConfig(ctx context.Context, other map[string]any) (api.Charg
 	}
 
 	return wb, nil
+}
+
+// lookupOpenWB20LoadpointQuery returns a "lp=n" filter for the loadpoint that uses wb as its
+// charger, or an empty string if none is (yet) configured. Best effort: does not wait for
+// loadpoints configured after this charger.
+func lookupOpenWB20LoadpointQuery(wb *OpenWB20) string {
+	var name string
+	for _, dev := range config.Chargers().Devices() {
+		if dev.Instance() == wb {
+			name = dev.Config().Name
+			break
+		}
+	}
+	if name == "" {
+		return ""
+	}
+
+	for idx, dev := range config.Loadpoints().Devices() {
+		if lp := dev.Instance(); lp != nil && lp.GetChargerRef() == name {
+			return "lp=" + strconv.Itoa(idx+1)
+		}
+	}
+
+	return ""
 }
 
 // NewOpenWB20 creates OpenWB20 charger

--- a/charger/openwb-2.0.go
+++ b/charger/openwb-2.0.go
@@ -4,9 +4,14 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"net"
+	"time"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/api/implement"
+	"github.com/evcc-io/evcc/charger/openwb"
+	"github.com/evcc-io/evcc/plugin/mqtt"
+	"github.com/evcc-io/evcc/server/network"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/modbus"
 )
@@ -49,9 +54,12 @@ func NewOpenWB20FromConfig(ctx context.Context, other map[string]any) (api.Charg
 		Connector          uint16
 		Phases1p3p         bool
 		Identify           bool
+		Display            bool
+		mqtt.Config        `mapstructure:",squash"`
 		modbus.TcpSettings `mapstructure:",squash"`
 	}{
 		Connector: 1,
+		Display:   true,
 		TcpSettings: modbus.TcpSettings{
 			ID: 1,
 		},
@@ -72,6 +80,38 @@ func NewOpenWB20FromConfig(ctx context.Context, other map[string]any) (api.Charg
 
 	if cc.Identify {
 		implement.Has(wb, implement.Identifier(wb.identify))
+	}
+
+	log := util.NewLogger("openwb-2.0")
+	if !cc.Display {
+		log.DEBUG.Println("display setup disabled")
+	} else if network.Config().Port == 0 {
+		log.DEBUG.Println("display setup skipped: network not initialized")
+	} else {
+		uri := network.Config().InternalURL()
+		go func() {
+			ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			defer cancel()
+
+			if cc.Broker == "" {
+				host, _, err := net.SplitHostPort(util.DefaultPort(cc.URI, 1502))
+				if err != nil {
+					log.DEBUG.Printf("display setup skipped: invalid broker address: %v", err)
+					return
+				}
+				cc.Broker = net.JoinHostPort(host, "1883")
+			}
+			if ctx.Err() != nil {
+				return
+			}
+			client, err := mqtt.RegisteredClientOrDefault(log, cc.Config)
+			if err == nil {
+				err = openwb.ConfigureDisplay(ctx, log, client, uri)
+			}
+			if err != nil && ctx.Err() != context.Canceled {
+				log.DEBUG.Printf("display setup: %v", err)
+			}
+		}()
 	}
 
 	return wb, nil

--- a/charger/openwb-2.0.go
+++ b/charger/openwb-2.0.go
@@ -5,8 +5,10 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
+	paho "github.com/eclipse/paho.mqtt.golang"
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/api/implement"
 	"github.com/evcc-io/evcc/charger/openwb"
@@ -104,8 +106,19 @@ func NewOpenWB20FromConfig(ctx context.Context, other map[string]any) (api.Charg
 			if ctx.Err() != nil {
 				return
 			}
-			client, err := mqtt.RegisteredClientOrDefault(log, cc.Config)
+			client, err := mqtt.NewClient(log, cc.Broker, cc.User, cc.Password, mqtt.ClientID(), 1, cc.Insecure, cc.CaCert, cc.ClientCert, cc.ClientKey, func(options *paho.ClientOptions) {
+				options.SetAutoReconnect(false)
+				options.SetOnConnectHandler(nil)
+				options.SetConnectionLostHandler(func(_ paho.Client, err error) {
+					log.DEBUG.Printf("display setup: MQTT connection lost: %v", err)
+					cancel()
+				})
+			})
 			if err == nil {
+				disconnect := sync.OnceFunc(client.Disconnect)
+				stop := context.AfterFunc(ctx, disconnect)
+				defer stop()
+				defer disconnect()
 				err = openwb.ConfigureDisplay(ctx, log, client, uri)
 			}
 			if err != nil && ctx.Err() != context.Canceled {

--- a/charger/openwb-2.0.go
+++ b/charger/openwb-2.0.go
@@ -24,10 +24,21 @@ import (
 // OpenWB20 charger implementation
 type OpenWB20 struct {
 	implement.Caps
-	conn    *modbus.Connection
-	enabled bool
-	curr    uint16
-	base    uint16
+	conn        *modbus.Connection
+	enabled     bool
+	curr        uint16
+	base        uint16
+	display     *openWB20DisplayConfig
+	displayOnce sync.Once
+}
+
+type openWB20DisplayConfig struct {
+	ctx context.Context
+	log *util.Logger
+	mqtt.Config
+	chargerURI string
+	evccURI    string
+	query      string
 }
 
 const (
@@ -94,53 +105,72 @@ func NewOpenWB20FromConfig(ctx context.Context, other map[string]any) (api.Charg
 	} else if network.Config().Port == 0 {
 		log.DEBUG.Println("display setup skipped: network not initialized")
 	} else {
-		uri := network.Config().InternalURL()
-		go func() {
-			ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-			defer cancel()
-
-			if cc.Broker == "" {
-				host, _, err := net.SplitHostPort(util.DefaultPort(cc.URI, 1502))
-				if err != nil {
-					log.DEBUG.Printf("display setup skipped: invalid broker address: %v", err)
-					return
-				}
-				cc.Broker = net.JoinHostPort(host, "1883")
-			}
-			if ctx.Err() != nil {
-				return
-			}
-			client, err := mqtt.NewClient(log, cc.Broker, cc.User, cc.Password, mqtt.ClientID(), 1, cc.Insecure, cc.CaCert, cc.ClientCert, cc.ClientKey, func(options *paho.ClientOptions) {
-				options.SetAutoReconnect(false)
-				options.SetOnConnectHandler(nil)
-				options.SetConnectionLostHandler(func(_ paho.Client, err error) {
-					log.DEBUG.Printf("display setup: MQTT connection lost: %v", err)
-					cancel()
-				})
-			})
-			if err == nil {
-				disconnect := sync.OnceFunc(client.Disconnect)
-				stop := context.AfterFunc(ctx, disconnect)
-				defer stop()
-				defer disconnect()
-				query := strings.TrimLeft(cc.Query, "/?#")
-				if query == "" {
-					query = lookupOpenWB20LoadpointQuery(wb)
-				}
-				err = openwb.ConfigureDisplay(ctx, log, client, uri, query)
-			}
-			if err != nil && ctx.Err() != context.Canceled {
-				log.DEBUG.Printf("display setup: %v", err)
-			}
-		}()
+		wb.display = &openWB20DisplayConfig{
+			ctx:        ctx,
+			log:        log,
+			Config:     cc.Config,
+			chargerURI: cc.URI,
+			evccURI:    network.Config().InternalURL(),
+			query:      cc.Query,
+		}
 	}
 
 	return wb, nil
 }
 
+// ConfigComplete starts display configuration after chargers and loadpoints are registered.
+func (wb *OpenWB20) ConfigComplete() {
+	wb.displayOnce.Do(func() {
+		if wb.display == nil {
+			return
+		}
+
+		go wb.configureDisplay()
+	})
+}
+
+func (wb *OpenWB20) configureDisplay() {
+	cc := wb.display
+	ctx, cancel := context.WithTimeout(cc.ctx, 30*time.Second)
+	defer cancel()
+
+	if cc.Broker == "" {
+		host, _, err := net.SplitHostPort(util.DefaultPort(cc.chargerURI, 1502))
+		if err != nil {
+			cc.log.DEBUG.Printf("display setup skipped: invalid broker address: %v", err)
+			return
+		}
+		cc.Broker = net.JoinHostPort(host, "1883")
+	}
+	if ctx.Err() != nil {
+		return
+	}
+	client, err := mqtt.NewClient(cc.log, cc.Broker, cc.User, cc.Password, mqtt.ClientID(), 1, cc.Insecure, cc.CaCert, cc.ClientCert, cc.ClientKey, func(options *paho.ClientOptions) {
+		options.SetAutoReconnect(false)
+		options.SetOnConnectHandler(nil)
+		options.SetConnectionLostHandler(func(_ paho.Client, err error) {
+			cc.log.DEBUG.Printf("display setup: MQTT connection lost: %v", err)
+			cancel()
+		})
+	})
+	if err == nil {
+		disconnect := sync.OnceFunc(client.Disconnect)
+		stop := context.AfterFunc(ctx, disconnect)
+		defer stop()
+		defer disconnect()
+		query := strings.TrimLeft(cc.query, "/?#")
+		if query == "" {
+			query = lookupOpenWB20LoadpointQuery(wb)
+		}
+		err = openwb.ConfigureDisplay(ctx, cc.log, client, cc.evccURI, query)
+	}
+	if err != nil && ctx.Err() != context.Canceled {
+		cc.log.DEBUG.Printf("display setup: %v", err)
+	}
+}
+
 // lookupOpenWB20LoadpointQuery returns a "lp=n" filter for the loadpoint that uses wb as its
-// charger, or an empty string if none is (yet) configured. Best effort: does not wait for
-// loadpoints configured after this charger.
+// charger, or an empty string if none is configured.
 func lookupOpenWB20LoadpointQuery(wb *OpenWB20) string {
 	var name string
 	for _, dev := range config.Chargers().Devices() {

--- a/charger/openwb-2.0_test.go
+++ b/charger/openwb-2.0_test.go
@@ -2,8 +2,16 @@ package charger
 
 import (
 	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/eclipse/paho.mqtt.golang/packets"
+	"github.com/evcc-io/evcc/api/globalconfig"
 	"github.com/evcc-io/evcc/server/network"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/templates"
@@ -72,4 +80,125 @@ func TestOpenWB20DisplayTemplate(t *testing.T) {
 		return
 	}
 	t.Fatal("openwb-2.0 template not found")
+}
+
+func TestOpenWB20DisplayDisconnect(t *testing.T) {
+	previous := network.Config()
+	network.Start(globalconfig.Network{Port: 7070})
+	t.Cleanup(func() { network.Start(previous) })
+
+	for _, test := range []struct {
+		name      string
+		topic     string
+		value     string
+		cancel    bool
+		noSuback  bool
+		unchanged bool
+		reject    bool
+		timeout   bool
+		writes    int
+	}{
+		{name: "configured", writes: 2},
+		{name: "primary", topic: "openWB/general/extern", value: "false"},
+		{name: "inactive", topic: "openWB/optional/int_display/active", value: "false"},
+		{name: "unsupported", topic: "openWB/system/configurable/display_themes", value: "[]"},
+		{name: "malformed", topic: "openWB/general/extern", value: "invalid"},
+		{name: "canceled", cancel: true},
+		{name: "subscription canceled", cancel: true, noSuback: true},
+		{name: "unchanged", unchanged: true},
+		{name: "missing state", timeout: true},
+		{name: "rejected", reject: true, writes: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			require.NoError(t, err)
+			defer listener.Close()
+			require.NoError(t, listener.(*net.TCPListener).SetDeadline(time.Now().Add(5*time.Second)))
+
+			timeout := 5 * time.Second
+			if test.timeout || test.reject {
+				timeout = time.Second
+			}
+			ctx, cancel := context.WithTimeout(t.Context(), timeout)
+			defer cancel()
+			_, err = NewOpenWB20FromConfig(ctx, map[string]any{
+				"uri": "localhost:1502", "broker": listener.Addr().String(),
+			})
+			require.NoError(t, err)
+			conn, err := listener.Accept()
+			require.NoError(t, err)
+			defer conn.Close()
+			require.NoError(t, conn.SetDeadline(time.Now().Add(5*time.Second)))
+
+			packet, err := packets.ReadPacket(conn)
+			require.NoError(t, err)
+			connect, ok := packet.(*packets.ConnectPacket)
+			require.True(t, ok)
+			assert.True(t, connect.CleanSession)
+			require.NoError(t, packets.NewControlPacket(packets.Connack).Write(conn))
+
+			values := map[string]string{
+				"openWB/general/extern":                     "true",
+				"openWB/optional/int_display/active":        "true",
+				"openWB/system/configurable/display_themes": `[{"value":"url_display"}]`,
+				"openWB/optional/int_display/theme":         `{"type":"cards"}`,
+				"openWB/general/extern_display_mode":        `"primary"`,
+			}
+			if test.topic != "" {
+				values[test.topic] = test.value
+			}
+			if test.unchanged {
+				values["openWB/optional/int_display/theme"] = fmt.Sprintf(`{"type":"url_display","configuration":{"url":%q}}`, network.Config().InternalURL())
+				values["openWB/general/extern_display_mode"] = `"local"`
+			}
+			publish := func(topic, payload string) {
+				message := packets.NewControlPacket(packets.Publish).(*packets.PublishPacket)
+				message.TopicName = topic
+				message.Payload = []byte(payload)
+				require.NoError(t, message.Write(conn))
+			}
+
+			var writes int
+			for {
+				packet, err := packets.ReadPacket(conn)
+				if err != nil {
+					require.ErrorIs(t, err, io.EOF)
+					break
+				}
+				switch packet := packet.(type) {
+				case *packets.SubscribePacket:
+					ack := packets.NewControlPacket(packets.Suback).(*packets.SubackPacket)
+					ack.MessageID = packet.MessageID
+					ack.ReturnCodes = packet.Qoss
+					if !test.noSuback {
+						require.NoError(t, ack.Write(conn))
+					}
+					if test.cancel {
+						cancel()
+						continue
+					}
+					if test.timeout {
+						continue
+					}
+					for _, topic := range packet.Topics {
+						publish(topic, values[topic])
+					}
+				case *packets.PublishPacket:
+					writes++
+					assert.False(t, packet.Retain)
+					assert.True(t, strings.HasPrefix(packet.TopicName, "openWB/set/"))
+					ack := packets.NewControlPacket(packets.Puback).(*packets.PubackPacket)
+					ack.MessageID = packet.MessageID
+					require.NoError(t, ack.Write(conn))
+					if !test.reject {
+						publish(strings.Replace(packet.TopicName, "openWB/set/", "openWB/", 1), string(packet.Payload))
+					}
+				case *packets.DisconnectPacket:
+				default:
+					t.Fatalf("unexpected packet: %T", packet)
+				}
+			}
+			assert.Equal(t, test.writes, writes)
+		})
+	}
 }

--- a/charger/openwb-2.0_test.go
+++ b/charger/openwb-2.0_test.go
@@ -2,7 +2,6 @@ package charger
 
 import (
 	"bytes"
-	"context"
 	"testing"
 
 	"github.com/evcc-io/evcc/server/network"
@@ -35,9 +34,7 @@ func TestOpenWB20DisplayConfig(t *testing.T) {
 			if test.display != nil {
 				config["display"] = test.display
 			}
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			_, err := NewOpenWB20FromConfig(ctx, config)
+			_, err := NewOpenWB20FromConfig(t.Context(), config)
 			require.NoError(t, err)
 			assert.Contains(t, output.String(), test.message)
 		})

--- a/charger/openwb-2.0_test.go
+++ b/charger/openwb-2.0_test.go
@@ -119,6 +119,8 @@ func TestOpenWB20DisplayDisconnect(t *testing.T) {
 		name      string
 		topic     string
 		value     string
+		query     string
+		wantQuery string
 		cancel    bool
 		noSuback  bool
 		unchanged bool
@@ -127,6 +129,8 @@ func TestOpenWB20DisplayDisconnect(t *testing.T) {
 		writes    int
 	}{
 		{name: "configured", writes: 2},
+		{name: "automatic query", wantQuery: "lp=1", writes: 2},
+		{name: "explicit query", query: "?foo=bar", wantQuery: "foo=bar", writes: 2},
 		{name: "primary", topic: "openWB/general/extern", value: "false"},
 		{name: "inactive", topic: "openWB/optional/int_display/active", value: "false"},
 		{name: "unsupported", topic: "openWB/system/configurable/display_themes", value: "[]"},
@@ -138,6 +142,9 @@ func TestOpenWB20DisplayDisconnect(t *testing.T) {
 		{name: "rejected", reject: true, writes: 1},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			config.Reset()
+			t.Cleanup(config.Reset)
+
 			listener, err := net.Listen("tcp", "127.0.0.1:0")
 			require.NoError(t, err)
 			defer listener.Close()
@@ -149,10 +156,20 @@ func TestOpenWB20DisplayDisconnect(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(t.Context(), timeout)
 			defer cancel()
-			_, err = NewOpenWB20FromConfig(ctx, map[string]any{
-				"uri": "localhost:1502", "broker": listener.Addr().String(),
+			instance, err := NewOpenWB20FromConfig(ctx, map[string]any{
+				"uri": "localhost:1502", "broker": listener.Addr().String(), "query": test.query,
 			})
 			require.NoError(t, err)
+			wb := instance.(*OpenWB20)
+			require.NoError(t, config.Chargers().Add(config.NewStaticDevice(config.Named{Name: "wallbox"}, instance)))
+			if test.name == "automatic query" {
+				lp := loadpoint.NewMockAPI(gomock.NewController(t))
+				lp.EXPECT().GetChargerRef().Return("wallbox").AnyTimes()
+				require.NoError(t, config.Loadpoints().Add(config.NewStaticDevice(config.Named{Name: "lp-1"}, loadpoint.API(lp))))
+			}
+			wb.ConfigComplete()
+			wb.ConfigComplete()
+
 			conn, err := listener.Accept()
 			require.NoError(t, err)
 			defer conn.Close()
@@ -190,7 +207,11 @@ func TestOpenWB20DisplayDisconnect(t *testing.T) {
 			for {
 				packet, err := packets.ReadPacket(conn)
 				if err != nil {
-					require.ErrorIs(t, err, io.EOF)
+					if test.cancel {
+						require.Error(t, err)
+					} else {
+						require.ErrorIs(t, err, io.EOF)
+					}
 					break
 				}
 				switch packet := packet.(type) {
@@ -215,6 +236,9 @@ func TestOpenWB20DisplayDisconnect(t *testing.T) {
 					writes++
 					assert.False(t, packet.Retain)
 					assert.True(t, strings.HasPrefix(packet.TopicName, "openWB/set/"))
+					if test.wantQuery != "" && packet.TopicName == "openWB/set/optional/int_display/theme" {
+						assert.Contains(t, string(packet.Payload), "/#/?"+test.wantQuery)
+					}
 					ack := packets.NewControlPacket(packets.Puback).(*packets.PubackPacket)
 					ack.MessageID = packet.MessageID
 					require.NoError(t, ack.Write(conn))

--- a/charger/openwb-2.0_test.go
+++ b/charger/openwb-2.0_test.go
@@ -1,0 +1,78 @@
+package charger
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/evcc-io/evcc/server/network"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/templates"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v4"
+)
+
+func TestOpenWB20DisplayConfig(t *testing.T) {
+	require.Zero(t, network.Config().Port)
+	log := util.NewLogger("openwb-2.0")
+	writer := log.DEBUG.Writer()
+	t.Cleanup(func() { log.DEBUG.SetOutput(writer) })
+
+	for _, test := range []struct {
+		name    string
+		display any
+		message string
+	}{
+		{"default", nil, "display setup skipped: network not initialized"},
+		{"enabled", true, "display setup skipped: network not initialized"},
+		{"disabled", false, "display setup disabled"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var output bytes.Buffer
+			log.DEBUG.SetOutput(&output)
+			config := map[string]any{"uri": "localhost:1502"}
+			if test.display != nil {
+				config["display"] = test.display
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			_, err := NewOpenWB20FromConfig(ctx, config)
+			require.NoError(t, err)
+			assert.Contains(t, output.String(), test.message)
+		})
+	}
+}
+
+func TestOpenWB20DisplayTemplate(t *testing.T) {
+	for _, tmpl := range templates.ByClass(templates.Charger) {
+		if tmpl.Template != "openwb-2.0" {
+			continue
+		}
+		for _, enabled := range []bool{true, false} {
+			values := tmpl.Defaults(templates.RenderModeUnitTest)
+			assert.Equal(t, "true", values["display"])
+			values["host"] = "localhost"
+			values["display"] = enabled
+			values["broker"] = "tls://openwb:8883"
+			values["user"] = "display"
+			values["password"] = "test-password"
+			values[templates.ModbusKeyTCPIP] = true
+			tmpl.ModbusValues(templates.RenderModeUnitTest, values)
+			data, _, err := tmpl.RenderResult(templates.Charger, templates.RenderModeInstance, values)
+			require.NoError(t, err)
+			var config map[string]any
+			require.NoError(t, yaml.Unmarshal(data, &config))
+			assert.Equal(t, enabled, config["display"])
+			if enabled {
+				assert.Equal(t, values["broker"], config["broker"])
+				assert.Equal(t, values["user"], config["user"])
+				assert.Equal(t, values["password"], config["password"])
+			} else {
+				assert.NotContains(t, config, "broker")
+			}
+		}
+		return
+	}
+	t.Fatal("openwb-2.0 template not found")
+}

--- a/charger/openwb-2.0_test.go
+++ b/charger/openwb-2.0_test.go
@@ -11,14 +11,42 @@ import (
 	"time"
 
 	"github.com/eclipse/paho.mqtt.golang/packets"
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/api/globalconfig"
+	"github.com/evcc-io/evcc/core/loadpoint"
 	"github.com/evcc-io/evcc/server/network"
 	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/config"
 	"github.com/evcc-io/evcc/util/templates"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 	"go.yaml.in/yaml/v4"
 )
+
+func TestOpenWB20LoadpointQuery(t *testing.T) {
+	config.Reset()
+	t.Cleanup(config.Reset)
+
+	wb := &OpenWB20{}
+	other := &OpenWB20{}
+	assert.Empty(t, lookupOpenWB20LoadpointQuery(wb))
+
+	require.NoError(t, config.Chargers().Add(config.NewStaticDevice(config.Named{Name: "wallbox"}, api.Charger(wb))))
+	require.NoError(t, config.Chargers().Add(config.NewStaticDevice(config.Named{Name: "other"}, api.Charger(other))))
+	assert.Empty(t, lookupOpenWB20LoadpointQuery(wb), "charger not (yet) referenced by any loadpoint")
+
+	ctrl := gomock.NewController(t)
+	lp1 := loadpoint.NewMockAPI(ctrl)
+	lp1.EXPECT().GetChargerRef().Return("other").AnyTimes()
+	lp2 := loadpoint.NewMockAPI(ctrl)
+	lp2.EXPECT().GetChargerRef().Return("wallbox").AnyTimes()
+	require.NoError(t, config.Loadpoints().Add(config.NewStaticDevice(config.Named{Name: "lp-1"}, loadpoint.API(lp1))))
+	require.NoError(t, config.Loadpoints().Add(config.NewStaticDevice(config.Named{Name: "lp-2"}, loadpoint.API(lp2))))
+
+	assert.Equal(t, "lp=2", lookupOpenWB20LoadpointQuery(wb))
+	assert.Equal(t, "lp=1", lookupOpenWB20LoadpointQuery(other))
+}
 
 func TestOpenWB20DisplayConfig(t *testing.T) {
 	require.Zero(t, network.Config().Port)
@@ -113,9 +141,9 @@ func TestOpenWB20DisplayDisconnect(t *testing.T) {
 			listener, err := net.Listen("tcp", "127.0.0.1:0")
 			require.NoError(t, err)
 			defer listener.Close()
-			require.NoError(t, listener.(*net.TCPListener).SetDeadline(time.Now().Add(5*time.Second)))
+			require.NoError(t, listener.(*net.TCPListener).SetDeadline(time.Now().Add(10*time.Second)))
 
-			timeout := 5 * time.Second
+			timeout := 10 * time.Second
 			if test.timeout || test.reject {
 				timeout = time.Second
 			}
@@ -128,7 +156,7 @@ func TestOpenWB20DisplayDisconnect(t *testing.T) {
 			conn, err := listener.Accept()
 			require.NoError(t, err)
 			defer conn.Close()
-			require.NoError(t, conn.SetDeadline(time.Now().Add(5*time.Second)))
+			require.NoError(t, conn.SetDeadline(time.Now().Add(10*time.Second)))
 
 			packet, err := packets.ReadPacket(conn)
 			require.NoError(t, err)

--- a/charger/openwb/display.go
+++ b/charger/openwb/display.go
@@ -1,0 +1,190 @@
+package openwb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sync"
+
+	"github.com/evcc-io/evcc/util"
+)
+
+const (
+	displaySecondaryTopic = "openWB/general/extern"
+	displayActiveTopic    = "openWB/optional/int_display/active"
+	displayThemesTopic    = "openWB/system/configurable/display_themes"
+	displayThemeTopic     = "openWB/optional/int_display/theme"
+	displayModeTopic      = "openWB/general/extern_display_mode"
+)
+
+type displayClient interface {
+	Listen(string, func(string)) error
+	Publish(string, bool, string)
+}
+
+type displayTheme struct {
+	Type          string `json:"type"`
+	Configuration struct {
+		URL string `json:"url"`
+	} `json:"configuration"`
+}
+
+type displayState struct {
+	mu      sync.Mutex
+	values  map[string]string
+	updated chan struct{}
+}
+
+func (state *displayState) receive(ctx context.Context, topic string, payload string) {
+	if ctx.Err() != nil {
+		return
+	}
+	state.mu.Lock()
+	state.values[topic] = payload
+	state.mu.Unlock()
+	select {
+	case state.updated <- struct{}{}:
+	default:
+	}
+}
+
+func (state *displayState) value(topic string) string {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	return state.values[topic]
+}
+
+func (state *displayState) wait(ctx context.Context, topic string, target any, accept func() bool) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("%s: %w", topic, err)
+		}
+		if payload := state.value(topic); payload != "" {
+			if err := json.Unmarshal([]byte(payload), target); err != nil {
+				return fmt.Errorf("%s: %w", topic, err)
+			}
+			if accept == nil || accept() {
+				return nil
+			}
+		}
+		select {
+		case <-ctx.Done():
+		case <-state.updated:
+		}
+	}
+}
+
+// ConfigureDisplay configures an active secondary display once, using acknowledged MQTT state.
+func ConfigureDisplay(ctx context.Context, log *util.Logger, client displayClient, uri string) error {
+	parsed, err := url.Parse(uri)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Hostname() == "" || parsed.Port() == "0" || parsed.User != nil {
+		return fmt.Errorf("invalid internal URL")
+	}
+
+	state := &displayState{values: make(map[string]string), updated: make(chan struct{}, 1)}
+	subscribe := func(topic string) error {
+		return client.Listen(topic, func(payload string) { state.receive(ctx, topic, payload) })
+	}
+	for _, topic := range []string{displaySecondaryTopic, displayActiveTopic} {
+		if err := subscribe(topic); err != nil {
+			return err
+		}
+		var enabled bool
+		if err := state.wait(ctx, topic, &enabled, nil); err != nil {
+			return err
+		}
+		if !enabled {
+			log.DEBUG.Printf("display setup skipped: %s is not true", topic)
+			return nil
+		}
+	}
+
+	if err := subscribe(displayThemesTopic); err != nil {
+		return err
+	}
+	var themes []struct {
+		Value string `json:"value"`
+	}
+	if err := state.wait(ctx, displayThemesTopic, &themes, nil); err != nil {
+		return err
+	}
+	var supported bool
+	for _, theme := range themes {
+		supported = supported || theme.Value == "url_display"
+	}
+	if !supported {
+		log.DEBUG.Println("display setup skipped: URL theme not supported")
+		return nil
+	}
+
+	for _, topic := range []string{displayThemeTopic, displayModeTopic} {
+		if err := subscribe(topic); err != nil {
+			return err
+		}
+	}
+	var current displayTheme
+	if err := state.wait(ctx, displayThemeTopic, &current, nil); err != nil {
+		return err
+	}
+	if current.Type == "" {
+		return fmt.Errorf("display theme is missing its type")
+	}
+	var mode string
+	if err := state.wait(ctx, displayModeTopic, &mode, nil); err != nil {
+		return err
+	}
+
+	publish := func(topic, payload string) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		for _, gate := range []string{displaySecondaryTopic, displayActiveTopic} {
+			var enabled bool
+			if err := json.Unmarshal([]byte(state.value(gate)), &enabled); err != nil || !enabled {
+				return fmt.Errorf("display setup stopped: %s is not true", gate)
+			}
+		}
+		log.DEBUG.Printf("configuring display: %s", topic)
+		client.Publish(topic, false, payload)
+		return nil
+	}
+
+	changed := current.Type != "url_display" || current.Configuration.URL != uri
+	if changed {
+		var desired displayTheme
+		desired.Type = "url_display"
+		desired.Configuration.URL = uri
+		payload, err := json.Marshal(desired)
+		if err != nil {
+			return err
+		}
+		if err := publish("openWB/set/optional/int_display/theme", string(payload)); err != nil {
+			return err
+		}
+		if err := state.wait(ctx, displayThemeTopic, &current, func() bool { return current == desired }); err != nil {
+			if ctx.Err() != context.Canceled {
+				log.WARN.Printf("display theme update not confirmed: %v", err)
+			}
+			return err
+		}
+	}
+	if mode != "local" {
+		if err := publish("openWB/set/general/extern_display_mode", `"local"`); err != nil {
+			return err
+		}
+		if err := state.wait(ctx, displayModeTopic, &mode, func() bool { return mode == "local" }); err != nil {
+			if ctx.Err() != context.Canceled {
+				log.WARN.Printf("display mode update not confirmed: %v", err)
+			}
+			return err
+		}
+		changed = true
+	}
+	if changed {
+		log.INFO.Println("display configured to show evcc")
+	} else {
+		log.DEBUG.Println("display already configured to show evcc")
+	}
+	return nil
+}

--- a/charger/openwb/display.go
+++ b/charger/openwb/display.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strings"
 	"sync"
 
 	"github.com/evcc-io/evcc/util"
@@ -76,10 +77,14 @@ func (state *displayState) wait(ctx context.Context, topic string, target any, a
 }
 
 // ConfigureDisplay configures an active secondary display once, using acknowledged MQTT state.
-func ConfigureDisplay(ctx context.Context, log *util.Logger, client displayClient, uri string) error {
+// query is an optional caller-supplied query string (without a leading '/', '?' or '#') appended to uri as "uri/?query".
+func ConfigureDisplay(ctx context.Context, log *util.Logger, client displayClient, uri, query string) error {
 	parsed, err := url.Parse(uri)
 	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Hostname() == "" || parsed.Port() == "0" || parsed.User != nil {
 		return fmt.Errorf("invalid internal URL")
+	}
+	if query = strings.TrimLeft(query, "/?#"); query != "" {
+		uri += "/?" + query
 	}
 
 	state := &displayState{values: make(map[string]string), updated: make(chan struct{}, 1)}

--- a/charger/openwb/display.go
+++ b/charger/openwb/display.go
@@ -77,14 +77,14 @@ func (state *displayState) wait(ctx context.Context, topic string, target any, a
 }
 
 // ConfigureDisplay configures an active secondary display once, using acknowledged MQTT state.
-// query is an optional caller-supplied query string (without a leading '/', '?' or '#') appended to uri as "uri/?query".
+// query is an optional caller-supplied query string (without a leading '/', '?' or '#') appended to uri as "uri/#/?query".
 func ConfigureDisplay(ctx context.Context, log *util.Logger, client displayClient, uri, query string) error {
 	parsed, err := url.Parse(uri)
 	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Hostname() == "" || parsed.Port() == "0" || parsed.User != nil {
 		return fmt.Errorf("invalid internal URL")
 	}
 	if query = strings.TrimLeft(query, "/?#"); query != "" {
-		uri += "/?" + query
+		uri += "/#/?" + query
 	}
 
 	state := &displayState{values: make(map[string]string), updated: make(chan struct{}, 1)}
@@ -150,7 +150,7 @@ func ConfigureDisplay(ctx context.Context, log *util.Logger, client displayClien
 				return fmt.Errorf("display setup stopped: %s is not true", gate)
 			}
 		}
-		log.DEBUG.Printf("configuring display: %s", topic)
+		log.DEBUG.Printf("configuring display: %s with value: %s", topic, payload)
 		client.Publish(topic, false, payload)
 		return nil
 	}

--- a/charger/openwb/display_test.go
+++ b/charger/openwb/display_test.go
@@ -113,10 +113,10 @@ func TestConfigureDisplayQuery(t *testing.T) {
 	for _, test := range []struct {
 		query, url string
 	}{
-		{"lp=1", "http://evcc:7070/?lp=1"},
-		{"?lp=1", "http://evcc:7070/?lp=1"},
-		{"/?lp=1", "http://evcc:7070/?lp=1"},
-		{"#/?lp=1", "http://evcc:7070/?lp=1"},
+		{"lp=1", "http://evcc:7070/#/?lp=1"},
+		{"?lp=1", "http://evcc:7070/#/?lp=1"},
+		{"/?lp=1", "http://evcc:7070/#/?lp=1"},
+		{"#/?lp=1", "http://evcc:7070/#/?lp=1"},
 	} {
 		t.Run(test.query, func(t *testing.T) {
 			client := newDisplayTestClient()

--- a/charger/openwb/display_test.go
+++ b/charger/openwb/display_test.go
@@ -1,0 +1,151 @@
+package openwb
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type displayTestClient struct {
+	values    map[string]string
+	listeners map[string]func(string)
+	writes    []string
+	retained  []bool
+	onWrite   func(string)
+}
+
+func (client *displayTestClient) Listen(topic string, callback func(string)) error {
+	client.listeners[topic] = callback
+	if payload, ok := client.values[topic]; ok {
+		callback(payload)
+	}
+	return nil
+}
+
+func (client *displayTestClient) Publish(topic string, retained bool, payload string) {
+	client.writes = append(client.writes, topic+"="+payload)
+	client.retained = append(client.retained, retained)
+	if client.onWrite != nil {
+		client.onWrite(topic)
+		return
+	}
+	client.listeners[strings.Replace(topic, "openWB/set/", "openWB/", 1)](payload)
+}
+
+func TestConfigureDisplay(t *testing.T) {
+	const uri = "http://192.168.1.10:7070"
+	const desired = `{"type":"url_display","configuration":{"url":"` + uri + `"}}`
+	for _, test := range []struct {
+		name   string
+		topic  string
+		value  string
+		writes []string
+		fail   bool
+	}{
+		{name: "configure", writes: []string{"openWB/set/optional/int_display/theme=" + desired, `openWB/set/general/extern_display_mode="local"`}},
+		{name: "primary", topic: displaySecondaryTopic, value: "false"},
+		{name: "inactive", topic: displayActiveTopic, value: "false"},
+		{name: "unsupported", topic: displayThemesTopic, value: `[{"value":"cards"}]`},
+		{name: "invalid secondary", topic: displaySecondaryTopic, value: "invalid", fail: true},
+		{name: "missing secondary", topic: displaySecondaryTopic, value: "", fail: true},
+		{name: "invalid themes", topic: displayThemesTopic, value: "invalid", fail: true},
+		{name: "invalid active", topic: displayActiveTopic, value: `"true"`, fail: true},
+		{name: "null secondary", topic: displaySecondaryTopic, value: "null"},
+		{name: "null theme", topic: displayThemeTopic, value: "null", fail: true},
+		{name: "invalid mode", topic: displayModeTopic, value: "{}", fail: true},
+		{name: "theme matches", topic: displayThemeTopic, value: desired, writes: []string{`openWB/set/general/extern_display_mode="local"`}},
+		{name: "mode matches", topic: displayModeTopic, value: `"local"`, writes: []string{"openWB/set/optional/int_display/theme=" + desired}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			client := newDisplayTestClient()
+			if test.topic != "" {
+				client.values[test.topic] = test.value
+			}
+			timeout := 5 * time.Second
+			if test.name == "missing secondary" {
+				timeout = 100 * time.Millisecond
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			err := ConfigureDisplay(ctx, util.NewLogger("test"), client, uri)
+			if test.fail {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, test.writes, client.writes)
+			for _, retained := range client.retained {
+				assert.False(t, retained)
+			}
+		})
+	}
+}
+
+func newDisplayTestClient() *displayTestClient {
+	return &displayTestClient{
+		values: map[string]string{
+			displaySecondaryTopic: "true",
+			displayActiveTopic:    "true",
+			displayThemesTopic:    `[{"value":"url_display"}]`,
+			displayThemeTopic:     `{"type":"cards","configuration":{}}`,
+			displayModeTopic:      `"primary"`,
+		},
+		listeners: make(map[string]func(string)),
+	}
+}
+
+func TestConfigureDisplayUnchanged(t *testing.T) {
+	client := newDisplayTestClient()
+	client.values[displayThemeTopic] = `{"type":"url_display","configuration":{"url":"http://evcc:7070"},"name":"URL Display","official":false}`
+	client.values[displayModeTopic] = `"local"`
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, ConfigureDisplay(ctx, util.NewLogger("test"), client, "http://evcc:7070"))
+	assert.Empty(t, client.writes)
+}
+
+func TestConfigureDisplayRejected(t *testing.T) {
+	client := newDisplayTestClient()
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	client.onWrite = func(topic string) {}
+	require.ErrorIs(t, ConfigureDisplay(ctx, util.NewLogger("test"), client, "http://evcc:7070"), context.DeadlineExceeded)
+	require.Len(t, client.writes, 1)
+	assert.True(t, strings.HasPrefix(client.writes[0], "openWB/set/optional/int_display/theme="))
+}
+
+func TestConfigureDisplaySecondaryChanges(t *testing.T) {
+	client := newDisplayTestClient()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	client.onWrite = func(topic string) {
+		client.listeners[displaySecondaryTopic]("false")
+		client.listeners[displayThemeTopic](`{"type":"url_display","configuration":{"url":"http://evcc:7070"}}`)
+	}
+	require.ErrorContains(t, ConfigureDisplay(ctx, util.NewLogger("test"), client, "http://evcc:7070"), "is not true")
+	require.Len(t, client.writes, 1)
+}
+
+func TestConfigureDisplayInvalidURL(t *testing.T) {
+	for _, uri := range []string{"", "file:///tmp/evcc", "http://evcc:0", "http://user:password@evcc"} {
+		t.Run(uri, func(t *testing.T) {
+			client := newDisplayTestClient()
+			require.Error(t, ConfigureDisplay(context.Background(), util.NewLogger("test"), client, uri))
+			assert.Empty(t, client.listeners)
+			assert.Empty(t, client.writes)
+		})
+	}
+}
+
+func TestConfigureDisplayCanceled(t *testing.T) {
+	client := newDisplayTestClient()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, ConfigureDisplay(ctx, util.NewLogger("test"), client, "http://evcc:7070"), context.Canceled)
+	assert.Empty(t, client.writes)
+}

--- a/charger/openwb/display_test.go
+++ b/charger/openwb/display_test.go
@@ -72,7 +72,7 @@ func TestConfigureDisplay(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
-			err := ConfigureDisplay(ctx, util.NewLogger("test"), client, uri)
+			err := ConfigureDisplay(ctx, util.NewLogger("test"), client, uri, "")
 			if test.fail {
 				require.Error(t, err)
 			} else {
@@ -105,8 +105,28 @@ func TestConfigureDisplayUnchanged(t *testing.T) {
 	client.values[displayModeTopic] = `"local"`
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	require.NoError(t, ConfigureDisplay(ctx, util.NewLogger("test"), client, "http://evcc:7070"))
+	require.NoError(t, ConfigureDisplay(ctx, util.NewLogger("test"), client, "http://evcc:7070", ""))
 	assert.Empty(t, client.writes)
+}
+
+func TestConfigureDisplayQuery(t *testing.T) {
+	for _, test := range []struct {
+		query, url string
+	}{
+		{"lp=1", "http://evcc:7070/?lp=1"},
+		{"?lp=1", "http://evcc:7070/?lp=1"},
+		{"/?lp=1", "http://evcc:7070/?lp=1"},
+		{"#/?lp=1", "http://evcc:7070/?lp=1"},
+	} {
+		t.Run(test.query, func(t *testing.T) {
+			client := newDisplayTestClient()
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			require.NoError(t, ConfigureDisplay(ctx, util.NewLogger("test"), client, "http://evcc:7070", test.query))
+			require.Len(t, client.writes, 2)
+			assert.Equal(t, `openWB/set/optional/int_display/theme={"type":"url_display","configuration":{"url":"`+test.url+`"}}`, client.writes[0])
+		})
+	}
 }
 
 func TestConfigureDisplayRejected(t *testing.T) {
@@ -114,7 +134,7 @@ func TestConfigureDisplayRejected(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 	client.onWrite = func(topic string) {}
-	require.ErrorIs(t, ConfigureDisplay(ctx, util.NewLogger("test"), client, "http://evcc:7070"), context.DeadlineExceeded)
+	require.ErrorIs(t, ConfigureDisplay(ctx, util.NewLogger("test"), client, "http://evcc:7070", ""), context.DeadlineExceeded)
 	require.Len(t, client.writes, 1)
 	assert.True(t, strings.HasPrefix(client.writes[0], "openWB/set/optional/int_display/theme="))
 }
@@ -127,7 +147,7 @@ func TestConfigureDisplaySecondaryChanges(t *testing.T) {
 		client.listeners[displaySecondaryTopic]("false")
 		client.listeners[displayThemeTopic](`{"type":"url_display","configuration":{"url":"http://evcc:7070"}}`)
 	}
-	require.ErrorContains(t, ConfigureDisplay(ctx, util.NewLogger("test"), client, "http://evcc:7070"), "is not true")
+	require.ErrorContains(t, ConfigureDisplay(ctx, util.NewLogger("test"), client, "http://evcc:7070", ""), "is not true")
 	require.Len(t, client.writes, 1)
 }
 
@@ -135,7 +155,7 @@ func TestConfigureDisplayInvalidURL(t *testing.T) {
 	for _, uri := range []string{"", "file:///tmp/evcc", "http://evcc:0", "http://user:password@evcc"} {
 		t.Run(uri, func(t *testing.T) {
 			client := newDisplayTestClient()
-			require.Error(t, ConfigureDisplay(context.Background(), util.NewLogger("test"), client, uri))
+			require.Error(t, ConfigureDisplay(context.Background(), util.NewLogger("test"), client, uri, ""))
 			assert.Empty(t, client.listeners)
 			assert.Empty(t, client.writes)
 		})
@@ -146,6 +166,6 @@ func TestConfigureDisplayCanceled(t *testing.T) {
 	client := newDisplayTestClient()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	require.ErrorIs(t, ConfigureDisplay(ctx, util.NewLogger("test"), client, "http://evcc:7070"), context.Canceled)
+	require.ErrorIs(t, ConfigureDisplay(ctx, util.NewLogger("test"), client, "http://evcc:7070", ""), context.Canceled)
 	assert.Empty(t, client.writes)
 }

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -1413,7 +1413,21 @@ func configureSiteAndLoadpoints(conf *globalconfig.All) (*core.Site, error) {
 		}
 	}
 
+	completeChargerConfiguration()
+
 	return site, nil
+}
+
+type configCompleter interface {
+	ConfigComplete()
+}
+
+func completeChargerConfiguration() {
+	for _, dev := range config.Chargers().Devices() {
+		if charger, ok := dev.Instance().(configCompleter); ok {
+			charger.ConfigComplete()
+		}
+	}
 }
 
 func validateCircuits(loadpoints []*core.Loadpoint) error {

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/evcc-io/evcc/api/globalconfig"
 	"github.com/evcc-io/evcc/core"
 	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/config"
+	"github.com/stretchr/testify/require"
 )
 
 func TestYamlOff(t *testing.T) {
@@ -31,4 +33,25 @@ func TestYamlOff(t *testing.T) {
 	if lp.DefaultMode != api.ModeOff {
 		t.Errorf("expected `off`, got %s", lp.DefaultMode)
 	}
+}
+
+type configCompleteCharger struct {
+	api.Charger
+	complete bool
+}
+
+func (c *configCompleteCharger) ConfigComplete() {
+	c.complete = true
+}
+
+func TestCompleteChargerConfiguration(t *testing.T) {
+	config.Reset()
+	t.Cleanup(config.Reset)
+
+	charger := &configCompleteCharger{}
+	require.NoError(t, config.Chargers().Add(config.NewStaticDevice(config.Named{Name: "test"}, api.Charger(charger))))
+
+	completeChargerConfiguration()
+
+	require.True(t, charger.complete)
 }

--- a/plugin/mqtt/client.go
+++ b/plugin/mqtt/client.go
@@ -74,6 +74,7 @@ func NewClient(log *util.Logger, broker, user, password, clientID string, qos by
 		listener: make(map[string][]func(string)),
 		inflight: semaphore.NewWeighted(parallelInflightLimit),
 	}
+	mc.renewConnContext()
 
 	options := paho.NewClientOptions()
 	options.AddBroker(broker)
@@ -121,12 +122,22 @@ func NewClient(log *util.Logger, broker, user, password, clientID string, qos by
 	log.INFO.Printf("connecting %s at %s", clientID, mc.broker)
 
 	if token := client.Connect(); token.Wait() && token.Error() != nil {
+		mc.cancelConnContext()
 		return nil, fmt.Errorf("error connecting: %w", token.Error())
 	}
 
 	mc.client = client
 
 	return mc, nil
+}
+
+// Disconnect closes an owned client and releases its listeners. Do not use it on registered clients.
+func (m *Client) Disconnect() {
+	m.cancelConnContext()
+	m.client.Disconnect(100)
+	m.mux.Lock()
+	clear(m.listener)
+	m.mux.Unlock()
 }
 
 // connContext returns a context that is cancelled on disconnect and replaced

--- a/templates/definition/charger/openwb-2.0.yaml
+++ b/templates/definition/charger/openwb-2.0.yaml
@@ -52,6 +52,14 @@ params:
     advanced: true
   - name: password
     advanced: true
+  - name: query
+    advanced: true
+    description:
+      en: Display URL parameters
+      de: URL-Parameter des Displays
+    help:
+      en: Optional query string appended to the evcc URL, e.g. lp=2 to preselect a loadpoint. Leave empty to automatically select the loadpoint using this charger, if any. See the web UI documentation for available parameters.
+      de: Optionale Query-Parameter für die evcc-URL, z. B. lp=2, um einen Ladepunkt vorauszuwählen. Leer lassen, um automatisch den Ladepunkt zu wählen, der diesen Lader verwendet, sofern vorhanden. Verfügbare Parameter siehe Web-UI-Dokumentation.
   - name: insecure
   - name: phases1p3p
     type: bool
@@ -80,6 +88,9 @@ render: |
   {{- end }}
   user: {{ .user | quote }}
   password: {{ .password | quote }}
+  {{- if .query }}
+  query: {{ .query | quote }}
+  {{- end }}
   insecure: {{ .insecure }}
   {{- end }}
   phases1p3p: {{ .phases1p3p }}

--- a/templates/definition/charger/openwb-2.0.yaml
+++ b/templates/definition/charger/openwb-2.0.yaml
@@ -30,6 +30,29 @@ params:
     port: 1502
     id: 1
   - name: connector
+  - name: display
+    type: bool
+    default: true
+    advanced: true
+    description:
+      en: Show evcc on the display
+      de: evcc auf dem Display anzeigen
+    help:
+      en: Automatically configures an active display in secondary mode if the URL theme is supported. Requires MQTT access and an internal evcc URL reachable from openWB. Disabling this option leaves the current display settings unchanged.
+      de: Konfiguriert ein aktives Display im Secondary-Modus automatisch, wenn das URL-Theme vorhanden ist. Erfordert MQTT-Zugriff und eine von openWB erreichbare interne evcc-URL. Das Deaktivieren dieser Option belässt die aktuellen Display-Einstellungen unverändert.
+  - name: broker
+    advanced: true
+    description:
+      en: Display MQTT broker
+      de: MQTT-Broker des Displays
+    help:
+      en: Optional override for the openWB MQTT address. Defaults to the charger host on port 1883. Use tls://host:8883 for TLS.
+      de: Optionale MQTT-Adresse der openWB. Standard ist der Host der Wallbox auf Port 1883. Für TLS tls://host:8883 verwenden.
+  - name: user
+    advanced: true
+  - name: password
+    advanced: true
+  - name: insecure
   - name: phases1p3p
     type: bool
     description:
@@ -50,5 +73,14 @@ render: |
   type: openwb-2.0
   {{- include "modbus" . }}
   connector: {{ .connector }}
+  display: {{ .display }}
+  {{- if .display }}
+  {{- if .broker }}
+  broker: {{ .broker | quote }}
+  {{- end }}
+  user: {{ .user | quote }}
+  password: {{ .password | quote }}
+  insecure: {{ .insecure }}
+  {{- end }}
   phases1p3p: {{ .phases1p3p }}
   identify: {{ .identify }}


### PR DESCRIPTION
Enhance OpenWB 2.x with a new automatic display configuration feature. Detects if a display is configured, if the required url_theme https://github.com/openWB/core/pull/3205 is supported by the openWB software and will then set the URL pointing to evcc. This will display the evcc UI on the integrated display of the openWB charger. 