### PR TITLE
Sungrow: Recalculate SOC

### DIFF
--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -184,7 +184,7 @@ render: |
       type: input
       decode: uint32s
     scale: 0.1
-soc:
+  soc:
     source: go
     script: |
       nomsoc := {{ .minsoc }} + (soc / 100 * ({{ .maxsoc }} - {{ .minsoc }}))

--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -186,12 +186,34 @@ render: |
     source: go
     script: |
       {{- if and .minsoc .maxsoc }}
-      nomsoc := {{ .minsoc }} + (soc / 100 * ({{ .maxsoc }} - {{ .minsoc }}))
+      nomsoc := min + (soc / 100 * (max - min))
       nomsoc
       {{- else }}
       soc
       {{- end }}
     in:
+    {{- if and .minsoc .maxsoc }}
+    - name: min
+      type: float
+      config:
+        source: modbus
+        {{- include "modbus" . | indent 6 }}
+        register:
+          type: holding
+          address: 13058 # min SOC
+          decode: int16
+        scale: 0.1
+    - name: max
+      type: float
+      config:
+        source: modbus
+        {{- include "modbus" . | indent 6 }}
+        register:
+          type: holding
+          address: 13057 # max SOC
+          decode: int16
+        scale: 0.1
+    {{- end }}
     - name: soc
       type: float
       config:

--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -183,16 +183,17 @@ render: |
       decode: uint32s
     scale: 0.1
   soc:
+    {{- $hasMinMax := and .minsoc .maxsoc }}
     source: go
     script: |
-      {{- if and .minsoc .maxsoc }}
+      {{- if $hasMinMax }}
       nomsoc := min + (soc / 100 * (max - min))
       nomsoc
       {{- else }}
       soc
       {{- end }}
     in:
-    {{- if and .minsoc .maxsoc }}
+    {{- if $hasMinMax }}
     - name: min
       type: float
       config:
@@ -220,8 +221,8 @@ render: |
         source: modbus
         {{- include "modbus" . | indent 6 }}
         register:
-          address: 13022 # Battery level
           type: input
+          address: 13022 # Battery level
           decode: int16
         scale: 0.1
   batterymode:

--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -29,6 +29,12 @@ params:
   - name: maxdischargepower
     service: modbus/read?address=33047&type=holding&encoding=uint16&scale=10&{modbus}
     required: true
+  - name: maxsoc
+    service: modbus/read?address=13057&type=holding&encoding=uint16&scale=0.1&{modbus}
+    required: true
+  - name: minsoc
+    service: modbus/read?address=13058&type=holding&encoding=uint16&scale=0.1&{modbus}
+    required: true
   - name: capacity
     service: modbus/read?address=5638&type=input&encoding=uint16&scale=0.01&resulttype=float&{modbus}
   - name: timeout
@@ -178,14 +184,22 @@ render: |
       type: input
       decode: uint32s
     scale: 0.1
-  soc:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      address: 13022 # Battery level
-      type: input
-      decode: int16
-    scale: 0.1
+soc:
+    source: go
+    script: |
+      nomsoc := {{ .minsoc }} + (soc / 100 * ({{ .maxsoc }} - {{ .minsoc }}))
+      nomsoc
+    in:
+    - name: soc
+      type: float
+      config:
+        source: modbus
+        {{- include "modbus" . | indent 6 }}
+        register:
+          address: 13022 # Battery level
+          type: input
+          decode: int16
+        scale: 0.1
   batterymode:
     source: switch
     switch:

--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -31,10 +31,8 @@ params:
     required: true
   - name: maxsoc
     service: modbus/read?address=13057&type=holding&encoding=uint16&scale=0.1&{modbus}
-    required: true
   - name: minsoc
     service: modbus/read?address=13058&type=holding&encoding=uint16&scale=0.1&{modbus}
-    required: true
   - name: capacity
     service: modbus/read?address=5638&type=input&encoding=uint16&scale=0.01&resulttype=float&{modbus}
   - name: timeout
@@ -187,8 +185,12 @@ render: |
   soc:
     source: go
     script: |
+      {{- if and .minsoc .maxsoc }}
       nomsoc := {{ .minsoc }} + (soc / 100 * ({{ .maxsoc }} - {{ .minsoc }}))
       nomsoc
+      {{- else }}
+      soc
+      {{- end }}
     in:
     - name: soc
       type: float


### PR DESCRIPTION
Add minsoc & maxsoc, read from modbus config.

Sungrow only provides a recalculated SOC based on minSoc & maxSoc via modbus.
As a result, when maxSoc != 100% capacity is not correctly displayed in EVCC.
Recalculate soc to provide a nominal battery SOC to evcc.