### PR TITLE
Tariff (DWD, ESIOS): evaluate forecast dates per request

### DIFF
--- a/docs/agents/plugin-system.md
+++ b/docs/agents/plugin-system.md
@@ -51,6 +51,11 @@ maxcurrent:
 The generic configurable charger (`charger/charger.go`) wires these plugin
 configs into the `api.Charger` interface at runtime.
 
+Templates render once at config time. HTTP `uri` and `body` are templates
+themselves, evaluated per request (`util.ReplaceFormatted`: sprig, `addDate`,
+`timeRound`). Defer `now` to request time with a raw string:
+`` {{ `{{ now | date "2006-01-02" }}` }} ``.
+
 ## Key Files
 
 - `plugin/config.go` — plugin registry and config types

--- a/templates/README.md
+++ b/templates/README.md
@@ -369,3 +369,9 @@ Service endpoints must return an array of strings (e.g., `["value1", "value2"]`)
 ## `render`
 
 `render` contains the internal device configuration. All `param` `name` values can be used as a template variable, e.g. `{{ .host }}` for a param named `host`. The content is a go template, so all of go template feature can be used, e.g. `{{- if ... }}` statements, etc.
+
+`render` is evaluated once when the device is configured. Plugin fields like the HTTP `uri` and `body` are go templates themselves and are evaluated on every request (sprig functions plus `addDate` and `timeRound`). Time-dependent expressions must be deferred to request time by wrapping them in a raw string, otherwise `now` freezes at config time:
+
+```yaml
+uri: https://example.org/forecast?from={{ `{{ now | date "2006-01-02" }}` }}&to={{ `{{ addDate now 0 0 5 | date "2006-01-02" }}` }}
+```

--- a/templates/definition/tariff/dwd-temperature.yaml
+++ b/templates/definition/tariff/dwd-temperature.yaml
@@ -20,7 +20,7 @@ render: |
   tariff: temperature
   forecast:
     source: http
-    uri: https://api.brightsky.dev/weather?lat={{ .lat }}&lon={{ .lon }}&date={{ now | date "2006-01-02" }}&last_date={{ now | dateModify "+120h" | date "2006-01-02" }}&tz=UTC
+    uri: https://api.brightsky.dev/weather?lat={{ .lat }}&lon={{ .lon }}&date={{ `{{ now | date "2006-01-02" }}` }}&last_date={{ `{{ addDate now 0 0 5 | date "2006-01-02" }}` }}&tz=UTC
     jq: |
       def toZ: sub("\\+00:00$"; "Z"); # fromdateiso8601 needs a literal Z
       def epoch: toZ | fromdateiso8601;

--- a/templates/definition/tariff/esios.yaml
+++ b/templates/definition/tariff/esios.yaml
@@ -36,7 +36,7 @@ render: |
   {{ include "base" . }}
   forecast:
     source: http
-    uri: https://api.esios.ree.es/indicators/{{ .indicator }}?start_date={{ now | date "2006-01-02" }}T00:00&end_date={{ (now.AddDate 0 0 1) | date "2006-01-02" }}T23:59
+    uri: https://api.esios.ree.es/indicators/{{ .indicator }}?start_date={{ `{{ now | date "2006-01-02" }}` }}T00:00&end_date={{ `{{ addDate now 0 0 1 | date "2006-01-02" }}` }}T23:59
     method: GET
     headers:
       x-api-key: "{{ .securitytoken }}"


### PR DESCRIPTION
fixes #33599

The render section is evaluated once at config time, so an unescaped `now` freezes the requested date range. The DWD temperature forecast stopped updating future days and ESIOS only ever fetched its configuration day. Wrapping the date expressions in a raw string defers them to the HTTP plugin, which evaluates `uri` on every request.

- dwd-temperature and esios: escape `now` like ned, victron and green-grid-compass already do
- document the two-stage evaluation in templates/README.md and docs/agents/plugin-system.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)