### PR TITLE
MySkoda: prefer charge limit of current saved location

### DIFF
--- a/vehicle/myskoda/provider.go
+++ b/vehicle/myskoda/provider.go
@@ -116,22 +116,20 @@ var _ api.SocLimiter = (*Provider)(nil)
 
 // GetLimitSoc implements the api.SocLimiter interface
 func (v *Provider) GetLimitSoc() (int64, error) {
-	charging, err := v.charging()
+	res, err := v.charging()
 	if err != nil {
 		return 0, err
 	}
-
 	// prefer the limit of the saved location (e.g. home) the vehicle is currently at
-	if res, _ := v.dataG(); charging.IsVehicleInSavedLocation && res.Vehicle.ChargingProfiles != nil {
-		if p := res.Vehicle.ChargingProfiles.CurrentVehiclePositionProfile; p != nil && p.TargetStateOfChargeInPercent != nil {
+	if data, _ := v.dataG(); res.IsVehicleInSavedLocation {
+		if p := data.Vehicle.ChargingProfiles.CurrentVehiclePositionProfile; p != nil && p.TargetStateOfChargeInPercent != nil {
 			return int64(*p.TargetStateOfChargeInPercent), nil
 		}
 	}
-
-	if charging.Settings == nil || charging.Settings.TargetStateOfChargeInPercent == nil {
+	if res.Settings == nil || res.Settings.TargetStateOfChargeInPercent == nil {
 		return 0, api.ErrNotAvailable
 	}
-	return int64(*charging.Settings.TargetStateOfChargeInPercent), nil
+	return int64(*res.Settings.TargetStateOfChargeInPercent), nil
 }
 
 var _ api.VehicleOdometer = (*Provider)(nil)

--- a/vehicle/myskoda/provider.go
+++ b/vehicle/myskoda/provider.go
@@ -20,7 +20,7 @@ type Provider struct {
 func NewProvider(api *API, vin string, cache time.Duration) *Provider {
 	return &Provider{
 		dataG: util.Cached(func() (VehicleResponse, error) {
-			return api.Vehicle(vin, "charging", "odometer", "airConditioning")
+			return api.Vehicle(vin, "charging", "chargingProfiles", "odometer", "airConditioning")
 		}, cache),
 		action: func(action string) error {
 			return api.ChargeAction(vin, action)
@@ -116,14 +116,26 @@ var _ api.SocLimiter = (*Provider)(nil)
 
 // GetLimitSoc implements the api.SocLimiter interface
 func (v *Provider) GetLimitSoc() (int64, error) {
-	res, err := v.charging()
+	res, err := v.dataG()
 	if err != nil {
 		return 0, err
 	}
-	if res.Settings == nil || res.Settings.TargetStateOfChargeInPercent == nil {
+	charging := res.Vehicle.Charging
+	if charging == nil || charging.Status == nil {
+		return 0, partError(res, "CHARGING")
+	}
+
+	// prefer the limit of the saved location (e.g. home) the vehicle is currently at
+	if charging.IsVehicleInSavedLocation && res.Vehicle.ChargingProfiles != nil {
+		if p := res.Vehicle.ChargingProfiles.CurrentVehiclePositionProfile; p != nil && p.TargetStateOfChargeInPercent != nil {
+			return int64(*p.TargetStateOfChargeInPercent), nil
+		}
+	}
+
+	if charging.Settings == nil || charging.Settings.TargetStateOfChargeInPercent == nil {
 		return 0, api.ErrNotAvailable
 	}
-	return int64(*res.Settings.TargetStateOfChargeInPercent), nil
+	return int64(*charging.Settings.TargetStateOfChargeInPercent), nil
 }
 
 var _ api.VehicleOdometer = (*Provider)(nil)

--- a/vehicle/myskoda/provider.go
+++ b/vehicle/myskoda/provider.go
@@ -116,17 +116,13 @@ var _ api.SocLimiter = (*Provider)(nil)
 
 // GetLimitSoc implements the api.SocLimiter interface
 func (v *Provider) GetLimitSoc() (int64, error) {
-	res, err := v.dataG()
+	charging, err := v.charging()
 	if err != nil {
 		return 0, err
 	}
-	charging := res.Vehicle.Charging
-	if charging == nil || charging.Status == nil {
-		return 0, partError(res, "CHARGING")
-	}
 
 	// prefer the limit of the saved location (e.g. home) the vehicle is currently at
-	if charging.IsVehicleInSavedLocation && res.Vehicle.ChargingProfiles != nil {
+	if res, _ := v.dataG(); charging.IsVehicleInSavedLocation && res.Vehicle.ChargingProfiles != nil {
 		if p := res.Vehicle.ChargingProfiles.CurrentVehiclePositionProfile; p != nil && p.TargetStateOfChargeInPercent != nil {
 			return int64(*p.TargetStateOfChargeInPercent), nil
 		}

--- a/vehicle/myskoda/provider_test.go
+++ b/vehicle/myskoda/provider_test.go
@@ -110,3 +110,36 @@ func TestVehicleResponsePartErrors(t *testing.T) {
 	_, err = v.Odometer()
 	assert.ErrorIs(t, err, api.ErrNotAvailable)
 }
+
+func TestGetLimitSocPrefersSavedLocation(t *testing.T) {
+	global, home := 100, 80
+	res := VehicleResponse{Vehicle: Vehicle{
+		Charging: &Charging{
+			IsVehicleInSavedLocation: true,
+			Status:                   &ChargingStatus{},
+			Settings:                 &ChargingSettings{TargetStateOfChargeInPercent: &global},
+		},
+		ChargingProfiles: &ChargingProfiles{
+			CurrentVehiclePositionProfile: &CurrentVehiclePositionProfile{TargetStateOfChargeInPercent: &home},
+		},
+	}}
+
+	v := &Provider{dataG: func() (VehicleResponse, error) { return res, nil }}
+
+	soc, err := v.GetLimitSoc()
+	require.NoError(t, err)
+	assert.EqualValues(t, home, soc)
+
+	// not at saved location: fall back to global limit
+	res.Vehicle.Charging.IsVehicleInSavedLocation = false
+	soc, err = v.GetLimitSoc()
+	require.NoError(t, err)
+	assert.EqualValues(t, global, soc)
+
+	// profiles unsupported by vehicle: fall back to global limit
+	res.Vehicle.Charging.IsVehicleInSavedLocation = true
+	res.Vehicle.ChargingProfiles = nil
+	soc, err = v.GetLimitSoc()
+	require.NoError(t, err)
+	assert.EqualValues(t, global, soc)
+}

--- a/vehicle/myskoda/provider_test.go
+++ b/vehicle/myskoda/provider_test.go
@@ -119,10 +119,8 @@ func TestGetLimitSocPrefersSavedLocation(t *testing.T) {
 			Status:                   &ChargingStatus{},
 			Settings:                 &ChargingSettings{TargetStateOfChargeInPercent: &global},
 		},
-		ChargingProfiles: &ChargingProfiles{
-			CurrentVehiclePositionProfile: &CurrentVehiclePositionProfile{TargetStateOfChargeInPercent: &home},
-		},
 	}}
+	res.Vehicle.ChargingProfiles.CurrentVehiclePositionProfile = &struct{ TargetStateOfChargeInPercent *int }{&home}
 
 	v := &Provider{dataG: func() (VehicleResponse, error) { return res, nil }}
 
@@ -138,7 +136,7 @@ func TestGetLimitSocPrefersSavedLocation(t *testing.T) {
 
 	// profiles unsupported by vehicle: fall back to global limit
 	res.Vehicle.Charging.IsVehicleInSavedLocation = true
-	res.Vehicle.ChargingProfiles = nil
+	res.Vehicle.ChargingProfiles.CurrentVehiclePositionProfile = nil
 	soc, err = v.GetLimitSoc()
 	require.NoError(t, err)
 	assert.EqualValues(t, global, soc)

--- a/vehicle/myskoda/types.go
+++ b/vehicle/myskoda/types.go
@@ -22,7 +22,7 @@ type Vehicle struct {
 	Odometer         *Odometer
 	AirConditioning  *AirConditioning
 	Charging         *Charging
-	ChargingProfiles *ChargingProfiles
+	ChargingProfiles ChargingProfiles
 }
 
 type Odometer struct {
@@ -60,14 +60,8 @@ type ChargingSettings struct {
 	MaxChargeCurrentAcAmpere     int
 }
 
-// ChargingProfiles are the saved charging locations of the vehicle
 type ChargingProfiles struct {
-	CurrentVehiclePositionProfile *CurrentVehiclePositionProfile
-}
-
-// CurrentVehiclePositionProfile is the profile of the location the vehicle is currently at
-type CurrentVehiclePositionProfile struct {
-	ID                           int64
-	Name                         string
-	TargetStateOfChargeInPercent *int
+	CurrentVehiclePositionProfile *struct {
+		TargetStateOfChargeInPercent *int
+	}
 }

--- a/vehicle/myskoda/types.go
+++ b/vehicle/myskoda/types.go
@@ -16,12 +16,13 @@ type Error struct {
 
 // Vehicle is the vehicle and its current state
 type Vehicle struct {
-	VIN             string
-	Name            string
-	LicensePlate    string
-	Odometer        *Odometer
-	AirConditioning *AirConditioning
-	Charging        *Charging
+	VIN              string
+	Name             string
+	LicensePlate     string
+	Odometer         *Odometer
+	AirConditioning  *AirConditioning
+	Charging         *Charging
+	ChargingProfiles *ChargingProfiles
 }
 
 type Odometer struct {
@@ -33,8 +34,9 @@ type AirConditioning struct {
 }
 
 type Charging struct {
-	Status   *ChargingStatus
-	Settings *ChargingSettings
+	IsVehicleInSavedLocation bool
+	Status                   *ChargingStatus
+	Settings                 *ChargingSettings
 }
 
 type ChargingStatus struct {
@@ -56,4 +58,16 @@ type ChargingSettings struct {
 	TargetStateOfChargeInPercent *int
 	MaxChargeCurrentAc           string
 	MaxChargeCurrentAcAmpere     int
+}
+
+// ChargingProfiles are the saved charging locations of the vehicle
+type ChargingProfiles struct {
+	CurrentVehiclePositionProfile *CurrentVehiclePositionProfile
+}
+
+// CurrentVehiclePositionProfile is the profile of the location the vehicle is currently at
+type CurrentVehiclePositionProfile struct {
+	ID                           int64
+	Name                         string
+	TargetStateOfChargeInPercent *int
 }


### PR DESCRIPTION
Fixes #33611

The official-API MyŠkoda vehicle only read the global `settings.targetStateOfChargeInPercent`. Most users charge at home with a location-specific limit different from the global one.

- request the `chargingProfiles` part alongside `charging`
- `GetLimitSoc` returns `chargingProfiles.currentVehiclePositionProfile.targetStateOfChargeInPercent` when `charging.isVehicleInSavedLocation` is set
- falls back to the global limit if the vehicle is not in a saved location, the vehicle does not support charging profiles, or the profile has no target SoC

Based on https://public.api.connect.skoda-auto.cz/docs/myskoda-public-api.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)