### PR TITLE
chore: make the backport command retryable

### DIFF
--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -168,7 +168,9 @@ jobs:
           fi
 
           git cherry-pick $mainline "$SHA"
-          git push origin "$BRANCH"
+          # a retry after a partial failure finds the branch of the previous
+          # attempt, the cherry-pick is reproducible so it is safe to replace
+          git push --force origin "$BRANCH"
 
       - name: Create pull request
         id: create
@@ -184,13 +186,18 @@ jobs:
           # into the release branch as the commit description.
           # the title stays untouched so the changelog filters and groups still
           # see the original prefix, the backport label identifies the pull request
-          url=$(gh pr create \
-            --base "$TARGET" \
-            --head "$BRANCH" \
-            --title "$TITLE" \
-            --label backport \
-            --assignee "$ACTOR" \
-            --body "")
+          # reuse the pull request of a previous attempt, the force push above
+          # already refreshed its head
+          url=$(gh pr list --base "$TARGET" --head "$BRANCH" --state open --json url --jq '.[0].url')
+          if [ -z "$url" ]; then
+            url=$(gh pr create \
+              --base "$TARGET" \
+              --head "$BRANCH" \
+              --title "$TITLE" \
+              --label backport \
+              --assignee "$ACTOR" \
+              --body "")
+          fi
           echo "url=$url" >> "$GITHUB_OUTPUT"
 
       - name: Comment result


### PR DESCRIPTION
Re-running the backport job after a partial failure (see https://github.com/evcc-io/evcc/actions/runs/34446992576) fails at the push because the branch of the previous attempt already exists and the fresh cherry-pick is not a fast-forward of it. Had the first attempt gotten as far as opening the pull request, the retry would fail there next.

The backport branch is bot-owned and the cherry-pick is reproducible, so force push it. Reuse an open pull request for the branch instead of creating a second one.

Makes both "Re-run failed jobs" and a repeated `/backport` comment idempotent, and clears the stale `backport/*` branches from earlier failed runs without manual cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)