### PR TITLE
Revert "Zaptec Go 2: disable phase switching with APM active"

### DIFF
--- a/charger/zaptec.go
+++ b/charger/zaptec.go
@@ -90,7 +90,7 @@ func NewZaptecFromConfig(ctx context.Context, other map[string]any) (api.Charger
 }
 
 // NewZaptec creates Zaptec charger
-func NewZaptec(ctx context.Context, user, password, id string, priority bool, passive bool, cache time.Duration, startPrevention bool) (api.Charger, error) {
+func NewZaptec(_ context.Context, user, password, id string, priority bool, passive bool, cache time.Duration, startPrevention bool) (api.Charger, error) {
 	log := util.NewLogger("zaptec").Redact(user, password)
 
 	if !sponsor.IsAuthorized() {
@@ -106,6 +106,14 @@ func NewZaptec(ctx context.Context, user, password, id string, priority bool, pa
 		startPrevention: startPrevention,
 	}
 
+	// Add User-Agent header for Zaptec API compliance
+	c.Client.Transport = &transport.Decorator{
+		Decorator: transport.DecorateHeaders(map[string]string{
+			"User-Agent": "evcc/" + util.Version,
+		}),
+		Base: c.Client.Transport,
+	}
+
 	// setup cached values
 	c.statusG = util.ResettableCached(func() (zaptec.StateResponse, error) {
 		var res zaptec.StateResponse
@@ -116,16 +124,11 @@ func NewZaptec(ctx context.Context, user, password, id string, priority bool, pa
 		return res, err
 	}, cache)
 
-	// Add User-Agent header for Zaptec API compliance
-	tr := &transport.Decorator{
-		Decorator: transport.DecorateHeaders(map[string]string{
-			"User-Agent": "evcc/" + util.Version,
-		}),
-		Base: c.Transport,
-	}
-
-	// token requests need their own client- c.Transport is wrapped in oauth2.Transport below
-	tsCtx := context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Transport: tr})
+	// Create a separate HTTP client for OAuth token requests to avoid circular dependency
+	// (c.Transport will be modified to use oauth2.Transport, which would create a loop)
+	tsCtx := context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{
+		Transport: c.Transport,
+	})
 
 	// Get shared token source for this user (per-user uniqueness)
 	ts, err := zaptec.TokenSource(tsCtx, user, password)
@@ -135,7 +138,7 @@ func NewZaptec(ctx context.Context, user, password, id string, priority bool, pa
 
 	c.Transport = &oauth2.Transport{
 		Source: ts,
-		Base:   tr,
+		Base:   c.Transport,
 	}
 
 	c.instance, err = ensureChargerEx(id, c.chargers, func(charger zaptec.Charger) (string, error) {
@@ -151,24 +154,13 @@ func NewZaptec(ctx context.Context, user, password, id string, priority bool, pa
 	}
 
 	inst, err := c.installation()
-
-	switch {
-	case c.version != zaptec.ZaptecGo2:
+	if err == nil || c.version == zaptec.ZaptecGo1_Pro {
 		implement.Has(c, implement.PhaseSwitcher(c.phases1p3p))
+	}
 
-	case err != nil:
-		c.log.WARN.Println("phase switching not available:", err)
-
-	// the Zaptec Go 2 switches phases by updating the installation, which is rejected
-	// as long as adaptive power management (APM) is active
-	case inst.EnabledFeatures.Has(zaptec.FeaturePowerManagementApm):
-		c.log.WARN.Println("phase switching not available: installation uses adaptive power management (APM)")
-
-	default:
-		implement.Has(c, implement.PhaseSwitcher(c.phases1p3p))
-
-		// the Zaptec Go 2 switches phases via the installation's per-phase available current;
-		// 1p->3p only works when all phases are set equal, so warn about an inconsistent setting
+	// the Zaptec Go 2 switches phases via the installation's per-phase available current;
+	// 1p->3p only works when all phases are set equal, so warn about an inconsistent setting
+	if err == nil && c.version == zaptec.ZaptecGo2 {
 		if p1, p2, p3 := inst.AvailableCurrentPhase1, inst.AvailableCurrentPhase2, inst.AvailableCurrentPhase3; p2 != p1 || p3 != p1 {
 			c.log.WARN.Printf("installation available current is unequal across phases (%.3gA/%.3gA/%.3gA); phase switching back to 3p requires available current on all phases", p1, p2, p3)
 		}

--- a/charger/zaptec/const.go
+++ b/charger/zaptec/const.go
@@ -146,16 +146,3 @@ const (
 	ZaptecGo1_Pro = 0
 	ZaptecGo2     = 1
 )
-
-// Features is the installation's feature flag bitmask
-type Features int
-
-// See https://api.zaptec.com/swagger/v1/swagger.json
-const (
-	FeaturePowerManagementApm Features = 4 // adaptive power management
-)
-
-// Has reports whether the feature set contains the given feature
-func (f Features) Has(feature Features) bool {
-	return f&feature != 0
-}

--- a/charger/zaptec/types.go
+++ b/charger/zaptec/types.go
@@ -85,12 +85,11 @@ type SessionPriority struct {
 }
 
 type Installation struct {
-	Id                     string   `json:"id"`
-	MaxCurrent             float64  `json:"maxCurrent"`
-	AvailableCurrentPhase1 float64  `json:"availableCurrentPhase1"`
-	AvailableCurrentPhase2 float64  `json:"availableCurrentPhase2"`
-	AvailableCurrentPhase3 float64  `json:"availableCurrentPhase3"`
-	EnabledFeatures        Features `json:"enabledFeatures"`
+	Id                     string  `json:"id"`
+	MaxCurrent             float64 `json:"maxCurrent"`
+	AvailableCurrentPhase1 float64 `json:"availableCurrentPhase1"`
+	AvailableCurrentPhase2 float64 `json:"availableCurrentPhase2"`
+	AvailableCurrentPhase3 float64 `json:"availableCurrentPhase3"`
 }
 
 type UpdateInstallation struct {


### PR DESCRIPTION
Reverts d10ea1985 (#33255) on the 0.315.1 release line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)