### PR TITLE
Remote access: bearer tokens for API clients

### DIFF
--- a/server/remote/clients.go
+++ b/server/remote/clients.go
@@ -139,6 +139,8 @@ func (r *Remote) DeleteClient(username string) error {
 		return fmt.Errorf("client %s not found", username)
 	}
 
+	r.revokeTokens(username)
+
 	return saveClients(slices.Delete(list, idx, idx+1))
 }
 

--- a/server/remote/clients.go
+++ b/server/remote/clients.go
@@ -139,7 +139,12 @@ func (r *Remote) DeleteClient(username string) error {
 		return fmt.Errorf("client %s not found", username)
 	}
 
-	r.revokeTokens(username)
+	// revoke the client's bearer tokens
+	for k, e := range r.tokens {
+		if e.user == username {
+			delete(r.tokens, k)
+		}
+	}
 
 	return saveClients(slices.Delete(list, idx, idx+1))
 }

--- a/server/remote/remote.go
+++ b/server/remote/remote.go
@@ -33,9 +33,10 @@ type Remote struct {
 	httpHandler http.Handler
 	log         *util.Logger
 	publisher   chan<- util.Param
-	lastSeen    map[string]time.Time // persisted: username → last activity
-	connected   map[string]int       // in-memory: active connection count per user
-	lastError   error                // last connect/registration error, published to UI
+	lastSeen    map[string]time.Time  // persisted: username → last activity
+	connected   map[string]int        // in-memory: active connection count per user
+	tokens      map[string]tokenEntry // in-memory: bearer token → client
+	lastError   error                 // last connect/registration error, published to UI
 }
 
 // New creates a new Remote manager, loads persisted settings, and connects if enabled.
@@ -47,6 +48,7 @@ func New(cloudHost string, httpHandler http.Handler, valueChan chan<- util.Param
 		publisher:   valueChan,
 		lastSeen:    make(map[string]time.Time),
 		connected:   make(map[string]int),
+		tokens:      make(map[string]tokenEntry),
 	}
 
 	// load saved settings
@@ -118,7 +120,7 @@ func (r *Remote) connect() {
 
 	r.log.INFO.Printf("remote access via %s", r.settings.URL)
 
-	tunnel := NewTunnel(r.settings.TunnelURL, r.settings.Token, r.httpHandler, r.Authenticate, r.TrackActivity, r.log, r.publish)
+	tunnel := NewTunnel(r.settings.TunnelURL, r.settings.Token, r.httpHandler, r, r.TrackActivity, r.log, r.publish)
 
 	r.mu.Lock()
 	r.tunnel = tunnel

--- a/server/remote/tokens.go
+++ b/server/remote/tokens.go
@@ -34,10 +34,6 @@ func (r *Remote) IssueToken(username string) (string, time.Time, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if r.tokens == nil {
-		r.tokens = make(map[string]tokenEntry)
-	}
-
 	// drop expired tokens
 	now := time.Now()
 	for k, e := range r.tokens {
@@ -62,13 +58,4 @@ func (r *Remote) ValidateToken(token string) (string, bool) {
 	}
 
 	return e.user, true
-}
-
-// revokeTokens drops all tokens of the given client. Must be called with mu held.
-func (r *Remote) revokeTokens(username string) {
-	for k, e := range r.tokens {
-		if e.user == username {
-			delete(r.tokens, k)
-		}
-	}
 }

--- a/server/remote/tokens.go
+++ b/server/remote/tokens.go
@@ -1,0 +1,74 @@
+package remote
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"time"
+)
+
+// tokenLifetime caps bearer token validity
+const tokenLifetime = 24 * time.Hour
+
+type tokenEntry struct {
+	user    string
+	expires time.Time
+}
+
+// IssueToken creates a random bearer token for an authenticated client.
+// Lifetime is capped by the client's expiry. Tokens are held in memory only,
+// so a restart invalidates them and clients must re-authenticate.
+func (r *Remote) IssueToken(username string) (string, time.Time, error) {
+	expires := time.Now().Add(tokenLifetime)
+	for _, c := range loadClients() {
+		if c.Username == username && c.ExpiresAt != nil && c.ExpiresAt.Before(expires) {
+			expires = *c.ExpiresAt
+		}
+	}
+
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", time.Time{}, err
+	}
+	token := hex.EncodeToString(buf)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.tokens == nil {
+		r.tokens = make(map[string]tokenEntry)
+	}
+
+	// drop expired tokens
+	now := time.Now()
+	for k, e := range r.tokens {
+		if now.After(e.expires) {
+			delete(r.tokens, k)
+		}
+	}
+
+	r.tokens[token] = tokenEntry{user: username, expires: expires}
+
+	return token, expires, nil
+}
+
+// ValidateToken returns the client username for a valid bearer token.
+func (r *Remote) ValidateToken(token string) (string, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	e, ok := r.tokens[token]
+	if !ok || time.Now().After(e.expires) {
+		return "", false
+	}
+
+	return e.user, true
+}
+
+// revokeTokens drops all tokens of the given client. Must be called with mu held.
+func (r *Remote) revokeTokens(username string) {
+	for k, e := range r.tokens {
+		if e.user == username {
+			delete(r.tokens, k)
+		}
+	}
+}

--- a/server/remote/tokens_test.go
+++ b/server/remote/tokens_test.go
@@ -16,9 +16,9 @@ import (
 
 func TestTokenLifecycle(t *testing.T) {
 	require.NoError(t, settings.SetJson(keys.RemoteClients, []persistedClient{}))
-	r := &Remote{}
+	r := &Remote{tokens: make(map[string]tokenEntry)}
 
-	_, pw, err := r.CreateClient("app", 0)
+	_, _, err := r.CreateClient("app", 0)
 	require.NoError(t, err)
 
 	_, ok := r.ValidateToken("unknown")
@@ -43,12 +43,11 @@ func TestTokenLifecycle(t *testing.T) {
 	require.NoError(t, r.DeleteClient("app"))
 	_, ok = r.ValidateToken(token)
 	assert.False(t, ok)
-	assert.False(t, r.Authenticate("app", pw))
 }
 
 func TestTokenMiddleware(t *testing.T) {
 	require.NoError(t, settings.SetJson(keys.RemoteClients, []persistedClient{}))
-	r := &Remote{}
+	r := &Remote{tokens: make(map[string]tokenEntry)}
 	_, pw, err := r.CreateClient("app", 0)
 	require.NoError(t, err)
 

--- a/server/remote/tokens_test.go
+++ b/server/remote/tokens_test.go
@@ -1,0 +1,96 @@
+package remote
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/evcc-io/evcc/core/keys"
+	"github.com/evcc-io/evcc/db/settings"
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenLifecycle(t *testing.T) {
+	require.NoError(t, settings.SetJson(keys.RemoteClients, []persistedClient{}))
+	r := &Remote{}
+
+	_, pw, err := r.CreateClient("app", 0)
+	require.NoError(t, err)
+
+	_, ok := r.ValidateToken("unknown")
+	assert.False(t, ok)
+
+	token, expires, err := r.IssueToken("app")
+	require.NoError(t, err)
+	assert.WithinDuration(t, time.Now().Add(tokenLifetime), expires, time.Minute)
+
+	user, ok := r.ValidateToken(token)
+	assert.True(t, ok)
+	assert.Equal(t, "app", user)
+
+	// token expiry capped by client expiry
+	_, _, err = r.CreateClient("short", time.Hour)
+	require.NoError(t, err)
+	_, expires, err = r.IssueToken("short")
+	require.NoError(t, err)
+	assert.WithinDuration(t, time.Now().Add(time.Hour), expires, time.Minute)
+
+	// deleting the client revokes its tokens
+	require.NoError(t, r.DeleteClient("app"))
+	_, ok = r.ValidateToken(token)
+	assert.False(t, ok)
+	assert.False(t, r.Authenticate("app", pw))
+}
+
+func TestTokenMiddleware(t *testing.T) {
+	require.NoError(t, settings.SetJson(keys.RemoteClients, []persistedClient{}))
+	r := &Remote{}
+	_, pw, err := r.CreateClient("app", 0)
+	require.NoError(t, err)
+
+	tun := NewTunnel("", "", nil, r, nil, util.NewLogger("test"), nil)
+	handler := tun.basicAuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("pong"))
+	}))
+
+	do := func(req *http.Request) *httptest.ResponseRecorder {
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return rec
+	}
+
+	// token endpoint requires basic auth
+	req := httptest.NewRequest(http.MethodPost, tokenPath, nil)
+	assert.Equal(t, http.StatusUnauthorized, do(req).Code)
+
+	req = httptest.NewRequest(http.MethodPost, tokenPath, nil)
+	req.SetBasicAuth("app", pw)
+	rec := do(req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var res struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+	assert.Equal(t, "Bearer", res.TokenType)
+	assert.NotEmpty(t, res.AccessToken)
+	assert.Greater(t, res.ExpiresIn, 0)
+
+	// bearer token grants access without basic auth
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+res.AccessToken)
+	rec = do(req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "pong", rec.Body.String())
+
+	// invalid bearer token is rejected
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer nope")
+	assert.Equal(t, http.StatusUnauthorized, do(req).Code)
+}

--- a/server/remote/tokens_test.go
+++ b/server/remote/tokens_test.go
@@ -88,8 +88,18 @@ func TestTokenMiddleware(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "pong", rec.Body.String())
 
+	// scheme is case-insensitive
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "bearer "+res.AccessToken)
+	assert.Equal(t, http.StatusOK, do(req).Code)
+
 	// invalid bearer token is rejected
 	req = httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer nope")
+	assert.Equal(t, http.StatusUnauthorized, do(req).Code)
+
+	// bearer token cannot renew itself
+	req = httptest.NewRequest(http.MethodPost, tokenPath, nil)
+	req.Header.Set("Authorization", "Bearer "+res.AccessToken)
 	assert.Equal(t, http.StatusUnauthorized, do(req).Code)
 }

--- a/server/remote/tunnel.go
+++ b/server/remote/tunnel.go
@@ -2,10 +2,12 @@ package remote
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -19,14 +21,26 @@ import (
 // bad registration token or sponsor token
 var errCredentialsRejected = errors.New("remote access rejected")
 
-const minUptime = 5 * time.Second
+const (
+	minUptime = 5 * time.Second
+
+	// tokenPath issues a bearer token for basic-auth credentials (OAuth2 client credentials style)
+	tokenPath = "/api/remote/token"
+)
+
+// authenticator validates client credentials and manages bearer tokens.
+type authenticator interface {
+	Authenticate(user, pass string) bool
+	IssueToken(user string) (string, time.Time, error)
+	ValidateToken(token string) (string, bool)
+}
 
 // Tunnel manages a WebSocket+yamux tunnel to the cloud proxy.
 type Tunnel struct {
 	tunnelURL     string
 	token         string
 	httpHandler   http.Handler
-	authenticate  func(user, pass string) bool
+	authenticate  authenticator
 	trackActivity func(username string, active bool)
 	log           *util.Logger
 	cancel        func()
@@ -39,7 +53,7 @@ type Tunnel struct {
 }
 
 // NewTunnel creates a new tunnel client.
-func NewTunnel(tunnelURL, token string, httpHandler http.Handler, authenticate func(user, pass string) bool, trackActivity func(string, bool), log *util.Logger, onStateChange func()) *Tunnel {
+func NewTunnel(tunnelURL, token string, httpHandler http.Handler, authenticate authenticator, trackActivity func(string, bool), log *util.Logger, onStateChange func()) *Tunnel {
 	return &Tunnel{
 		tunnelURL:     tunnelURL,
 		token:         token,
@@ -206,9 +220,8 @@ func (t *Tunnel) Close() {
 	}
 }
 
-// basicAuthMiddleware wraps a handler with HTTP basic auth, validating
-// credentials against the given authenticate function per request.
-// It rate-limits failed attempts to prevent brute-force attacks.
+// basicAuthMiddleware wraps a handler with HTTP basic auth or a bearer token
+// issued by the token endpoint. It rate-limits failed attempts to prevent brute-force attacks.
 func (t *Tunnel) basicAuthMiddleware(next http.Handler) http.Handler {
 	rejectAuth := func(w http.ResponseWriter) {
 		w.Header().Set("WWW-Authenticate", `Basic realm="evcc"`)
@@ -216,23 +229,32 @@ func (t *Tunnel) basicAuthMiddleware(next http.Handler) http.Handler {
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		user, pass, ok := r.BasicAuth()
-		if !ok || t.authenticate == nil {
+		if t.authenticate == nil {
 			rejectAuth(w)
 			return
 		}
 
-		if !t.rateLimiter.allow() {
-			t.log.INFO.Printf("login blocked for %q (rate limited)", user)
-			http.Error(w, "Too many failed login attempts. Try again in 1 minute.", http.StatusTooManyRequests)
-			return
-		}
+		user, ok := t.bearerUser(r)
+		if !ok {
+			var pass string
+			user, pass, ok = r.BasicAuth()
+			if !ok {
+				rejectAuth(w)
+				return
+			}
 
-		if !t.authenticate(user, pass) {
-			t.rateLimiter.fail()
-			t.log.INFO.Printf("failed login attempt for %q", user)
-			rejectAuth(w)
-			return
+			if !t.rateLimiter.allow() {
+				t.log.INFO.Printf("login blocked for %q (rate limited)", user)
+				http.Error(w, "Too many failed login attempts. Try again in 1 minute.", http.StatusTooManyRequests)
+				return
+			}
+
+			if !t.authenticate.Authenticate(user, pass) {
+				t.rateLimiter.fail()
+				t.log.INFO.Printf("failed login attempt for %q", user)
+				rejectAuth(w)
+				return
+			}
 		}
 
 		if t.trackActivity != nil {
@@ -240,6 +262,37 @@ func (t *Tunnel) basicAuthMiddleware(next http.Handler) http.Handler {
 			defer t.trackActivity(user, false) // long-running requests (ws)
 		}
 
+		if r.Method == http.MethodPost && r.URL.Path == tokenPath {
+			t.issueToken(w, user)
+			return
+		}
+
 		next.ServeHTTP(w, r)
+	})
+}
+
+// bearerUser returns the client username for a valid bearer token in the Authorization header.
+func (t *Tunnel) bearerUser(r *http.Request) (string, bool) {
+	token, found := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer ")
+	if !found {
+		return "", false
+	}
+	return t.authenticate.ValidateToken(token)
+}
+
+// issueToken responds with an OAuth2-style token response (RFC 6749 section 5.1).
+func (t *Tunnel) issueToken(w http.ResponseWriter, user string) {
+	token, expires, err := t.authenticate.IssueToken(user)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"access_token": token,
+		"token_type":   "Bearer",
+		"expires_in":   int(time.Until(expires).Seconds()),
 	})
 }

--- a/server/remote/tunnel.go
+++ b/server/remote/tunnel.go
@@ -234,7 +234,7 @@ func (t *Tunnel) basicAuthMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		user, ok := t.bearerUser(r)
+		user, ok := t.authenticate.ValidateToken(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
 		if !ok {
 			var pass string
 			user, pass, ok = r.BasicAuth()
@@ -269,15 +269,6 @@ func (t *Tunnel) basicAuthMiddleware(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 	})
-}
-
-// bearerUser returns the client username for a valid bearer token in the Authorization header.
-func (t *Tunnel) bearerUser(r *http.Request) (string, bool) {
-	token, found := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer ")
-	if !found {
-		return "", false
-	}
-	return t.authenticate.ValidateToken(token)
 }
 
 // issueToken responds with an OAuth2-style token response (RFC 6749 section 5.1).

--- a/server/remote/tunnel.go
+++ b/server/remote/tunnel.go
@@ -234,7 +234,14 @@ func (t *Tunnel) basicAuthMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		user, ok := t.authenticate.ValidateToken(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+		// token endpoint requires basic auth; a bearer token must not renew itself
+		tokenRequest := r.Method == http.MethodPost && r.URL.Path == tokenPath
+
+		var user string
+		var ok bool
+		if scheme, token, _ := strings.Cut(r.Header.Get("Authorization"), " "); !tokenRequest && strings.EqualFold(scheme, "Bearer") {
+			user, ok = t.authenticate.ValidateToken(token)
+		}
 		if !ok {
 			var pass string
 			user, pass, ok = r.BasicAuth()
@@ -262,7 +269,7 @@ func (t *Tunnel) basicAuthMiddleware(next http.Handler) http.Handler {
 			defer t.trackActivity(user, false) // long-running requests (ws)
 		}
 
-		if r.Method == http.MethodPost && r.URL.Path == tokenPath {
+		if tokenRequest {
 			t.issueToken(w, user)
 			return
 		}

--- a/server/remote/tunnel_test.go
+++ b/server/remote/tunnel_test.go
@@ -16,6 +16,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// allowAll accepts any basic-auth credentials and issues no tokens.
+type allowAll struct{}
+
+func (allowAll) Authenticate(string, string) bool             { return true }
+func (allowAll) IssueToken(string) (string, time.Time, error) { return "", time.Time{}, nil }
+func (allowAll) ValidateToken(string) (string, bool)          { return "", false }
+
 // serveSession upgrades the request to a websocket, wraps it in a yamux server
 // session, hands it to the sessions channel and blocks until the session closes.
 func serveSession(w http.ResponseWriter, r *http.Request, sessions chan<- *yamux.Session) {
@@ -76,14 +83,12 @@ func TestTunnelReconnect(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("pong"))
 	})
-	authenticate := func(user, pass string) bool { return true }
-
 	sessions := make(chan *yamux.Session, 4)
 	srv := tunnelTestServer(t, sessions)
 
 	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
 
-	tun := NewTunnel(wsURL, "token", handler, authenticate, nil, util.NewLogger("test"), nil)
+	tun := NewTunnel(wsURL, "token", handler, allowAll{}, nil, util.NewLogger("test"), nil)
 	go tun.run()
 	defer tun.Close()
 
@@ -135,8 +140,6 @@ func TestTunnelReconnectsAfterTransientError(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("pong"))
 	})
-	authenticate := func(user, pass string) bool { return true }
-
 	var attempts atomic.Int32
 	sessions := make(chan *yamux.Session, 4)
 	srv := httptest.NewTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -151,7 +154,7 @@ func TestTunnelReconnectsAfterTransientError(t *testing.T) {
 
 	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
 
-	tun := NewTunnel(wsURL, "token", handler, authenticate, nil, util.NewLogger("test"), nil)
+	tun := NewTunnel(wsURL, "token", handler, allowAll{}, nil, util.NewLogger("test"), nil)
 	go tun.run()
 	defer tun.Close()
 


### PR DESCRIPTION
pairs with #33593, see https://github.com/evcc-io/evcc/pull/33593#issuecomment-5614742875

Adds a bearer token mechanism to remote access so API clients (curl, Home Assistant, scripts) authenticate once instead of sending basic-auth credentials on every request. Basic auth stays as is: the app WebView and browsers keep working unchanged, so this is additive to the credential cache in #33593 rather than a replacement.

- `POST /api/remote/token` with the client's basic-auth credentials returns an OAuth2 client-credentials style response: `{"access_token": "...", "token_type": "Bearer", "expires_in": 86400}`
- `Authorization: Bearer <token>` is accepted by the tunnel middleware before falling back to basic auth; token validation is a map lookup, no bcrypt
- tokens are random 256-bit values held in memory, valid 24h or until the client expires; deleting a client revokes its tokens; a restart invalidates all tokens and clients must re-authenticate
- endpoint exists only behind the tunnel, not on the local API

Example:

```
TOKEN=$(curl -s -u app:secret -X POST https://xyz.remote.evcc.io/api/remote/token | jq -r .access_token)
curl -H "Authorization: Bearer $TOKEN" https://xyz.remote.evcc.io/api/state
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
