### PR TITLE
LG ThinQ: add water heater boost via target temperature

### DIFF
--- a/charger/lg-thinq.go
+++ b/charger/lg-thinq.go
@@ -19,6 +19,7 @@ package charger
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
@@ -28,7 +29,7 @@ import (
 	"github.com/samber/lo"
 )
 
-// LgThinq controls an LG ThinQ water heater by raising its target temperature during boost
+// LgThinq controls an LG ThinQ water heater by switching its target temperature between normal and boost
 type LgThinq struct {
 	*SgReady
 }
@@ -44,7 +45,8 @@ func NewLgThinqFromConfig(ctx context.Context, other map[string]any) (api.Charge
 		Token    string
 		Country  string
 		Device   string
-		Setpoint float64
+		Normal   float64 // target temperature outside boost
+		Setpoint float64 // target temperature during boost
 		Cache    time.Duration
 	}{
 		embed: embed{
@@ -52,6 +54,7 @@ func NewLgThinqFromConfig(ctx context.Context, other map[string]any) (api.Charge
 			Features_: []api.Feature{api.Continuous, api.Heating, api.IntegratedDevice, api.SwitchDevice},
 		},
 		Country:  "DE",
+		Normal:   50,
 		Setpoint: 60,
 		Cache:    time.Minute,
 	}
@@ -62,6 +65,10 @@ func NewLgThinqFromConfig(ctx context.Context, other map[string]any) (api.Charge
 
 	if cc.Token == "" {
 		return nil, api.ErrMissingCredentials
+	}
+
+	if cc.Normal <= 0 || cc.Setpoint <= cc.Normal {
+		return nil, fmt.Errorf("invalid temperatures: boost setpoint %.1f must exceed normal %.1f", cc.Setpoint, cc.Normal)
 	}
 
 	log := util.NewLogger("lg-thinq").Redact(cc.Token)
@@ -87,44 +94,23 @@ func NewLgThinqFromConfig(ctx context.Context, other map[string]any) (api.Charge
 		return res, err
 	}, cc.Cache)
 
-	// target temperature before boost, restored when boost ends
-	var normal float64
-
 	set := func(mode int64) error {
+		var temp float64
 		switch mode {
 		case Normal:
-			if normal == 0 {
-				return nil
-			}
-
-			if err := conn.WaterHeaterTargetTemperature(deviceId, normal); err != nil {
-				return err
-			}
-
-			normal = 0
-			stateG.Reset()
-			return nil
-
+			temp = cc.Normal
 		case Boost:
-			state, err := stateG.Get()
-			if err != nil {
-				return err
-			}
-
-			if temp, ok := state.Celsius(); ok && normal == 0 {
-				normal = temp.TargetTemperature
-			}
-
-			if err := conn.WaterHeaterTargetTemperature(deviceId, cc.Setpoint); err != nil {
-				return err
-			}
-
-			stateG.Reset()
-			return nil
-
+			temp = cc.Setpoint
 		default:
 			return api.ErrNotAvailable
 		}
+
+		if err := conn.WaterHeaterTargetTemperature(deviceId, temp); err != nil {
+			return err
+		}
+
+		stateG.Reset()
+		return nil
 	}
 
 	res := new(LgThinq)

--- a/charger/lg-thinq.go
+++ b/charger/lg-thinq.go
@@ -1,0 +1,152 @@
+package charger
+
+// LICENSE
+
+// Copyright (c) evcc.io (andig, naltatis, premultiply)
+
+// This module is NOT covered by the MIT license. All rights reserved.
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import (
+	"context"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/api/implement"
+	"github.com/evcc-io/evcc/charger/lgthinq"
+	"github.com/evcc-io/evcc/util"
+	"github.com/samber/lo"
+)
+
+// LgThinq controls an LG ThinQ water heater by raising its target temperature during boost
+type LgThinq struct {
+	*SgReady
+}
+
+func init() {
+	registry.AddCtx("lg-thinq", NewLgThinqFromConfig)
+}
+
+// NewLgThinqFromConfig creates an LG ThinQ water heater charger from generic config
+func NewLgThinqFromConfig(ctx context.Context, other map[string]any) (api.Charger, error) {
+	cc := struct {
+		embed    `mapstructure:",squash"`
+		Token    string
+		Country  string
+		Device   string
+		Setpoint float64
+		Cache    time.Duration
+	}{
+		embed: embed{
+			Icon_:     "waterheater",
+			Features_: []api.Feature{api.Continuous, api.Heating, api.IntegratedDevice, api.SwitchDevice},
+		},
+		Country:  "DE",
+		Setpoint: 60,
+		Cache:    time.Minute,
+	}
+
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	if cc.Token == "" {
+		return nil, api.ErrMissingCredentials
+	}
+
+	log := util.NewLogger("lg-thinq").Redact(cc.Token)
+	conn := lgthinq.NewAPI(log, cc.Token, cc.Country)
+
+	device, err := ensureEx("device", cc.Device, func() ([]lgthinq.Device, error) {
+		devices, err := conn.Devices()
+		return lo.Filter(devices, func(d lgthinq.Device, _ int) bool {
+			return d.DeviceInfo.DeviceType == lgthinq.DeviceTypeWaterHeater
+		}), err
+	}, func(d lgthinq.Device) (string, error) {
+		return d.DeviceId, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	deviceId := device.DeviceId
+
+	stateG := util.ResettableCached(func() (lgthinq.WaterHeaterState, error) {
+		var res lgthinq.WaterHeaterState
+		err := conn.State(deviceId, &res)
+		return res, err
+	}, cc.Cache)
+
+	// target temperature before boost, restored when boost ends
+	var normal float64
+
+	set := func(mode int64) error {
+		switch mode {
+		case Normal:
+			if normal == 0 {
+				return nil
+			}
+
+			if err := conn.WaterHeaterTargetTemperature(deviceId, normal); err != nil {
+				return err
+			}
+
+			normal = 0
+			stateG.Reset()
+			return nil
+
+		case Boost:
+			state, err := stateG.Get()
+			if err != nil {
+				return err
+			}
+
+			if temp, ok := state.Celsius(); ok && normal == 0 {
+				normal = temp.TargetTemperature
+			}
+
+			if err := conn.WaterHeaterTargetTemperature(deviceId, cc.Setpoint); err != nil {
+				return err
+			}
+
+			stateG.Reset()
+			return nil
+
+		default:
+			return api.ErrNotAvailable
+		}
+	}
+
+	res := new(LgThinq)
+
+	res.SgReady, err = NewSgReady(ctx, &cc.embed, set, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	implement.Has(res, implement.Battery(func() (float64, error) {
+		state, err := stateG.Get()
+		if err != nil {
+			return 0, err
+		}
+
+		temp, ok := state.Celsius()
+		if !ok {
+			return 0, api.ErrNotAvailable
+		}
+
+		return temp.CurrentTemperature, nil
+	}))
+
+	return res, nil
+}

--- a/charger/lgthinq/api.go
+++ b/charger/lgthinq/api.go
@@ -1,0 +1,177 @@
+package lgthinq
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/request"
+	"github.com/evcc-io/evcc/util/transport"
+)
+
+// ThinQ Connect API, see https://smartsolution.lge.com/thinq-connect (PAT at https://connect-pat.lgthinq.com)
+
+// ApiKey is the public ThinQ Connect api key
+const ApiKey = "v6GFvkweNo7DK7yD3ylIZ9w52aKBU0eJ7wLXkSR3"
+
+const DeviceTypeWaterHeater = "DEVICE_WATER_HEATER"
+
+var (
+	kic = []string{"AU", "BD", "CN", "HK", "ID", "IN", "JP", "KH", "KR", "LA", "LK", "MM", "MY", "NP", "NZ", "PH", "SG", "TH", "TW", "VN"}
+	aic = []string{"AG", "AR", "AW", "BB", "BO", "BR", "BS", "BZ", "CA", "CL", "CO", "CR", "CU", "DM", "DO", "EC", "GD", "GT", "GY", "HN", "HT", "JM", "KN", "LC", "MX", "NI", "PA", "PE", "PR", "PY", "SR", "SV", "TT", "US", "UY", "VC", "VE"}
+)
+
+// region returns the api region for the given ISO 3166-1 alpha-2 country code
+func region(country string) string {
+	switch {
+	case slices.Contains(kic, country):
+		return "kic"
+	case slices.Contains(aic, country):
+		return "aic"
+	default:
+		return "eic"
+	}
+}
+
+func randomId() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+type Device struct {
+	DeviceId   string `json:"deviceId"`
+	DeviceInfo struct {
+		DeviceType string `json:"deviceType"`
+		ModelName  string `json:"modelName"`
+		Alias      string `json:"alias"`
+		Reportable bool   `json:"reportable"`
+	} `json:"deviceInfo"`
+}
+
+type response struct {
+	Response any `json:"response"`
+	Error    struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+type API struct {
+	*request.Helper
+	base string
+}
+
+// NewAPI creates a ThinQ Connect api client using a personal access token
+func NewAPI(log *util.Logger, token, country string) *API {
+	country = strings.ToUpper(country)
+
+	api := &API{
+		Helper: request.NewHelper(log),
+		base:   fmt.Sprintf("https://api-%s.lgthinq.com", region(country)),
+	}
+
+	clientId := "evcc-" + randomId()
+
+	api.Client.Transport = &transport.Decorator{
+		Base: api.Client.Transport,
+		Decorator: func(req *http.Request) error {
+			req.Header.Set("Authorization", "Bearer "+token)
+			req.Header.Set("x-api-key", ApiKey)
+			req.Header.Set("x-client-id", clientId)
+			req.Header.Set("x-country", country)
+			req.Header.Set("x-message-id", randomId())
+			req.Header.Set("x-service-phase", "OP")
+			return nil
+		},
+	}
+
+	return api
+}
+
+func (api *API) do(method, path string, body, res any) error {
+	var data io.Reader
+	headers := request.AcceptJSON
+	if body != nil {
+		data = request.MarshalJSON(body)
+		headers = request.JSONEncoding
+	}
+
+	req, err := request.New(method, api.base+path, data, headers)
+	if err != nil {
+		return err
+	}
+
+	var resp response
+	if res != nil {
+		resp.Response = res
+	}
+
+	if err := api.DoJSON(req, &resp); err != nil {
+		if resp.Error.Code != "" {
+			return fmt.Errorf("%s: %s", resp.Error.Code, resp.Error.Message)
+		}
+		return err
+	}
+
+	return nil
+}
+
+// Devices returns the list of devices
+func (api *API) Devices() ([]Device, error) {
+	var res []Device
+	err := api.do(http.MethodGet, "/devices", nil, &res)
+	return res, err
+}
+
+// State returns the device state
+func (api *API) State(deviceId string, res any) error {
+	return api.do(http.MethodGet, "/devices/"+deviceId+"/state", nil, res)
+}
+
+// Control sends a control command to the device
+func (api *API) Control(deviceId string, body any) error {
+	return api.do(http.MethodPost, "/devices/"+deviceId+"/control", body, nil)
+}
+
+// WaterHeaterState is the state of a DEVICE_WATER_HEATER
+type WaterHeaterState struct {
+	WaterHeaterJobMode struct {
+		CurrentJobMode string `json:"currentJobMode"`
+	} `json:"waterHeaterJobMode"`
+	Operation struct {
+		WaterHeaterOperationMode string `json:"waterHeaterOperationMode"`
+	} `json:"operation"`
+	TemperatureInUnits []Temperature `json:"temperatureInUnits"`
+}
+
+type Temperature struct {
+	CurrentTemperature float64 `json:"currentTemperature"`
+	TargetTemperature  float64 `json:"targetTemperature"`
+	Unit               string  `json:"unit"`
+}
+
+// Celsius returns the celsius temperature
+func (s WaterHeaterState) Celsius() (Temperature, bool) {
+	for _, t := range s.TemperatureInUnits {
+		if t.Unit == "C" {
+			return t, true
+		}
+	}
+	return Temperature{}, false
+}
+
+// WaterHeaterTargetTemperature sets the water heater target temperature in celsius
+func (api *API) WaterHeaterTargetTemperature(deviceId string, temp float64) error {
+	return api.Control(deviceId, map[string]any{
+		"temperatureInUnits": map[string]any{
+			"targetTemperature": temp,
+			"unit":              "C",
+		},
+	})
+}

--- a/charger/lgthinq/api_test.go
+++ b/charger/lgthinq/api_test.go
@@ -1,0 +1,47 @@
+package lgthinq
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/transport"
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPI(t *testing.T) {
+	api := NewAPI(util.NewLogger("test"), "pat", "de")
+
+	// mock below the header decorator
+	api.Client.Transport.(*transport.Decorator).Base = httpmock.DefaultTransport
+	defer httpmock.Reset()
+
+	assert.Equal(t, "https://api-eic.lgthinq.com", api.base)
+
+	httpmock.RegisterResponder(http.MethodGet, api.base+"/devices/1/state", func(req *http.Request) (*http.Response, error) {
+		assert.Equal(t, "Bearer pat", req.Header.Get("Authorization"))
+		assert.Equal(t, "DE", req.Header.Get("x-country"))
+		assert.NotEmpty(t, req.Header.Get("x-message-id"))
+
+		return httpmock.NewStringResponse(http.StatusOK, `{"messageId":"x","timestamp":"y","response":{
+			"waterHeaterJobMode":{"currentJobMode":"HEAT_PUMP"},
+			"operation":{"waterHeaterOperationMode":"POWER_ON"},
+			"temperatureInUnits":[{"currentTemperature":45,"targetTemperature":50,"unit":"C"},{"currentTemperature":113,"targetTemperature":122,"unit":"F"}]
+		}}`), nil
+	})
+
+	httpmock.RegisterResponder(http.MethodPost, api.base+"/devices/1/control",
+		httpmock.NewStringResponder(http.StatusBadRequest, `{"messageId":"x","timestamp":"y","error":{"code":"1207","message":"NOT_SUPPORTED_PRODUCT"}}`))
+
+	var state WaterHeaterState
+	require.NoError(t, api.State("1", &state))
+
+	temp, ok := state.Celsius()
+	require.True(t, ok)
+	assert.Equal(t, 45.0, temp.CurrentTemperature)
+	assert.Equal(t, 50.0, temp.TargetTemperature)
+
+	assert.EqualError(t, api.WaterHeaterTargetTemperature("1", 60), "1207: NOT_SUPPORTED_PRODUCT")
+}

--- a/templates/definition/charger/lg-thinq.yaml
+++ b/templates/definition/charger/lg-thinq.yaml
@@ -10,11 +10,11 @@ requirements:
     de: |
       Steuert LG Warmwasser-Wärmepumpen (z.B. WH27S) über die LG ThinQ Connect Cloud API.
       Ein persönlicher Zugriffstoken (PAT) muss unter https://connect-pat.lgthinq.com mit den Rechten "Geräte anzeigen", "Gerätestatus abfragen" und "Geräte steuern" erstellt werden.
-      Die Boost Funktion setzt die Zieltemperatur des Warmwasserbereiters auf die Boost Temperatur und stellt anschließend die vorherige Zieltemperatur wieder her.
+      evcc setzt die Zieltemperatur des Warmwasserbereiters: außerhalb des Boosts auf die normale Temperatur, während des Boosts auf die Boost Temperatur.
     en: |
       Controls LG heat pump water heaters (e.g. WH27S) via the LG ThinQ Connect cloud API.
       A personal access token (PAT) must be created at https://connect-pat.lgthinq.com with the permissions "view devices", "view device status" and "control devices".
-      The boost function sets the water heater target temperature to the boost temperature and restores the previous target temperature afterwards.
+      evcc sets the water heater target temperature: the normal temperature outside of boost, the boost temperature during boost.
 params:
   - name: token
     required: true
@@ -36,6 +36,16 @@ params:
     help:
       de: Notwendig falls mehrere Warmwasserbereiter im Konto vorhanden sind
       en: Required if multiple water heaters are present in the account
+  - name: normal
+    type: float
+    unit: °C
+    default: 50
+    description:
+      de: Normale Temperatur
+      en: Normal temperature
+    help:
+      de: Zieltemperatur außerhalb des Boosts
+      en: Target temperature outside of boost
   - name: setpoint
     type: float
     unit: °C
@@ -43,6 +53,9 @@ params:
     description:
       de: Boost Temperatur
       en: Boost temperature
+    help:
+      de: Zieltemperatur während des Boosts, muss über der normalen Temperatur liegen
+      en: Target temperature during boost, must exceed the normal temperature
   - name: cache
     default: 1m
 render: |
@@ -52,5 +65,6 @@ render: |
   {{- if .device }}
   device: {{ .device }}
   {{- end }}
+  normal: {{ .normal }}
   setpoint: {{ .setpoint }}
   cache: {{ .cache }}

--- a/templates/definition/charger/lg-thinq.yaml
+++ b/templates/definition/charger/lg-thinq.yaml
@@ -1,0 +1,56 @@
+template: lg-thinq
+products:
+  - brand: LG
+    description:
+      de: Warmwasser-Wärmepumpe (ThinQ)
+      en: Heat pump water heater (ThinQ)
+group: heating
+requirements:
+  description:
+    de: |
+      Steuert LG Warmwasser-Wärmepumpen (z.B. WH27S) über die LG ThinQ Connect Cloud API.
+      Ein persönlicher Zugriffstoken (PAT) muss unter https://connect-pat.lgthinq.com mit den Rechten "Geräte anzeigen", "Gerätestatus abfragen" und "Geräte steuern" erstellt werden.
+      Die Boost Funktion setzt die Zieltemperatur des Warmwasserbereiters auf die Boost Temperatur und stellt anschließend die vorherige Zieltemperatur wieder her.
+    en: |
+      Controls LG heat pump water heaters (e.g. WH27S) via the LG ThinQ Connect cloud API.
+      A personal access token (PAT) must be created at https://connect-pat.lgthinq.com with the permissions "view devices", "view device status" and "control devices".
+      The boost function sets the water heater target temperature to the boost temperature and restores the previous target temperature afterwards.
+params:
+  - name: token
+    required: true
+    description:
+      de: Persönlicher Zugriffstoken (PAT)
+      en: Personal access token (PAT)
+  - name: country
+    default: DE
+    description:
+      de: Ländercode
+      en: Country code
+    help:
+      de: Ländercode des LG Kontos (ISO 3166-1 alpha-2)
+      en: Country code of the LG account (ISO 3166-1 alpha-2)
+  - name: device
+    description:
+      de: Geräte-ID
+      en: Device ID
+    help:
+      de: Notwendig falls mehrere Warmwasserbereiter im Konto vorhanden sind
+      en: Required if multiple water heaters are present in the account
+  - name: setpoint
+    type: float
+    unit: °C
+    default: 60
+    description:
+      de: Boost Temperatur
+      en: Boost temperature
+  - name: cache
+    default: 1m
+render: |
+  type: lg-thinq
+  token: {{ .token }}
+  country: {{ .country }}
+  {{- if .device }}
+  device: {{ .device }}
+  {{- end }}
+  setpoint: {{ .setpoint }}
+  cache: {{ .cache }}


### PR DESCRIPTION
fixes #33590

Adds an LG ThinQ Connect cloud integration for LG heat pump water heaters such as the WH27S. It follows the Vaillant approach: an SG Ready style heating device whose boost raises the hot water target temperature, with the current tank temperature exposed as the loadpoint "soc".

- New `lg-thinq` charger and template in the heating group: personal access token from connect-pat.lgthinq.com, account country, optional device id, normal and boost temperature
- Outside of boost evcc writes the normal target temperature, during boost the boost temperature; both are explicit config so a restart during boost cannot leave the device stuck at the boost value
- Current tank temperature is read from the device state (cached) so limit handling in the loadpoint works as for Vaillant
- Small ThinQ Connect client (device list, state, control) with API region derived from the country code

**TODO**
- [ ] Verify against a real WH27: state payload shape (`temperatureInUnits` list) and that the control call is accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)