### PR TITLE
Battery: combine limitsoc with batterymode, Solis holds at current soc

### DIFF
--- a/meter/meter.go
+++ b/meter/meter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/api/implement"
@@ -93,20 +94,21 @@ func NewConfigurableFromConfig(ctx context.Context, other map[string]any) (api.M
 		implement.May(m, implement.BatterySocLimiter(socLimiter))
 		implement.May(m, implement.BatteryPowerLimiter(powerLimiter))
 
-		switch {
-		case cc.Soc != nil && cc.LimitSoc != nil:
+		// limitSoc expresses normal/hold/charge through the reserve soc (hold uses the live soc),
+		// batteryMode switches the device's operating mode. Configured together the limit is written first.
+		var limitController func(api.BatteryMode) error
+		if cc.LimitSoc != nil {
 			limitSocS, err := cc.LimitSoc.FloatSetter(ctx, "limitSoc")
 			if err != nil {
 				return nil, fmt.Errorf("battery limit soc: %w", err)
 			}
 
-			limitController, err := cc.batterySocLimitsCtx.LimitController(ctx, socG, limitSocS)
-			if err != nil {
+			if limitController, err = cc.batterySocLimitsCtx.LimitController(ctx, socG, limitSocS); err != nil {
 				return nil, err
 			}
+		}
 
-			implement.Has(m, implement.BatteryController(batteryModesSocLimit, limitController))
-
+		switch {
 		case cc.BatteryMode != nil:
 			modeS, keys, err := cc.BatteryMode.IntSetterKeys(ctx, "batteryMode")
 			if err != nil {
@@ -127,8 +129,16 @@ func NewConfigurableFromConfig(ctx context.Context, other map[string]any) (api.M
 			}
 
 			implement.Has(m, implement.BatteryController(implement.BatteryModes(modes...), func(mode api.BatteryMode) error {
+				if limitController != nil && slices.Contains(batteryModesSocLimit(), mode) {
+					if err := limitController(mode); err != nil {
+						return err
+					}
+				}
 				return modeS(int64(mode))
 			}))
+
+		case limitController != nil:
+			implement.Has(m, implement.BatteryController(batteryModesSocLimit, limitController))
 		}
 
 		return m, nil

--- a/meter/meter_battery_test.go
+++ b/meter/meter_battery_test.go
@@ -1,0 +1,51 @@
+package meter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/plugin"
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBatteryLimitSocWithBatteryMode covers limitsoc and batterymode configured together:
+// the reserve soc is written first, then the mode
+func TestBatteryLimitSocWithBatteryMode(t *testing.T) {
+	ctx := context.TODO()
+
+	js := func(script string) map[string]any {
+		return map[string]any{"source": "js", "vm": "compose", "script": script}
+	}
+
+	m, err := NewConfigurableFromConfig(ctx, map[string]any{
+		"power":        map[string]any{"source": "const", "value": 0},
+		"soc":          map[string]any{"source": "const", "value": 42},
+		"minsoc":       10,
+		"maxsoc":       80,
+		"limitsoc":     js(`log = (typeof log === "undefined" ? "" : log) + "L" + limitSoc + ";"`),
+		"batterymode":  js(`log = (typeof log === "undefined" ? "" : log) + "M" + batteryMode + ";"`),
+		"batterymodes": []string{"normal", "hold", "charge", "holdcharge"},
+	})
+	require.NoError(t, err)
+
+	ctrl, ok := api.Cap[api.BatteryController](m)
+	require.True(t, ok)
+	require.Equal(t, []api.BatteryMode{api.BatteryNormal, api.BatteryHold, api.BatteryCharge, api.BatteryHoldCharge}, ctrl.BatteryModes())
+
+	for _, mode := range ctrl.BatteryModes() {
+		require.NoError(t, ctrl.SetBatteryMode(mode))
+	}
+
+	var cc plugin.Config
+	require.NoError(t, util.DecodeOther(js("log"), &cc))
+	logG, err := cc.StringGetter(ctx)
+	require.NoError(t, err)
+
+	log, err := logG()
+	require.NoError(t, err)
+
+	// holdcharge is not expressible via limit soc, only the mode is written
+	require.Equal(t, "L10;M1;L42;M2;L80;M3;M4;", log)
+}

--- a/templates/definition/meter/solis-hybrid-s.yaml
+++ b/templates/definition/meter/solis-hybrid-s.yaml
@@ -141,74 +141,49 @@ render: |
       address: 33139 # Battery capacity SOC
       type: input
       decode: uint16
+  # reserve soc per mode: normal minsoc, hold current soc, charge maxsoc
+  limitsoc:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 43024 # Battery Reserve SOC
+      type: writeholding
+      decode: uint16
   batterymode:
     source: switch
     switch:
     - case: 1  # normal
       set:
-        source: sequence
+        source: const
+        value: 17 # Bits 0+4: Self Use Mode (1) + Battery Reserve (16)
         set:
-        - source: const
-          value: {{ .minsoc }}
-          set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            register:
-              address: 43024 # Battery Reserve SOC
-              type: writeholding
-              decode: uint16
-        - source: const
-          value: 17 # Bits 0+4: Self Use Mode (1) + Battery Reserve (16)
-          set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            register:
-              address: 43110
-              type: writeholding
-              decode: uint16
+          source: modbus
+          {{- include "modbus" . | indent 8 }}
+          register:
+            address: 43110
+            type: writeholding
+            decode: uint16
     - case: 2  # hold
       set:
-        source: sequence
+        source: const
+        value: 17 # Bits 0+4: Self Use (1) + Battery Reserve (16)
         set:
-        - source: const
-          value: {{ .maxsoc }}
-          set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            register:
-              address: 43024 # Battery Reserve SOC
-              type: writeholding
-              decode: uint16
-        - source: const
-          value: 17 # Bits 0+4: Self Use (1) + Battery Reserve (16)
-          set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            register:
-              address: 43110
-              type: writeholding
-              decode: uint16
+          source: modbus
+          {{- include "modbus" . | indent 8 }}
+          register:
+            address: 43110
+            type: writeholding
+            decode: uint16
     - case: 3  # charge
       set:
-        source: sequence
+        source: const
+        value: 49 # Bits 0+4+5: Self Use Mode (1) + Battery Reserve (16) + Allow Grid Charge (32)
         set:
-        - source: const
-          value: {{ .maxsoc }}
-          set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            register:
-              address: 43024 # Battery Reserve SOC
-              type: writeholding
-              decode: uint16
-        - source: const
-          value: 49 # Bits 0+4+5: Self Use Mode (1) + Battery Reserve (16) + Allow Grid Charge (32)
-          set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            register:
-              address: 43110
-              type: writeholding
-              decode: uint16
+          source: modbus
+          {{- include "modbus" . | indent 8 }}
+          register:
+            address: 43110
+            type: writeholding
+            decode: uint16
   {{- include "battery-params" . }}
   {{- end }}


### PR DESCRIPTION
fixes #33622

The Solis template moved the Battery Reserve SOC write from `limitsoc` into `batterymode` to gain the grid charge bit, and lost the "hold at current soc" behaviour that `limitsoc` provides for free. A plugin setter cannot read the live soc, and `limitsoc` alone cannot tell the modes apart to set the grid charge bit, so the two need to work together.

- Custom meters may now configure `limitsoc` and `batterymode` together. The reserve soc is written first (normal: minsoc, hold: current soc, charge: maxsoc), then the device mode. Modes the limit cannot express, such as holdcharge, only go through `batterymode`. Previously `limitsoc` silently took precedence and `batterymode` was ignored
- Solis Hybrid S: reserve soc via `limitsoc`, mode bits on register 43110 via `batterymode`. Hold now keeps the battery at its current soc instead of charging or discharging towards `maxsoc`
- FoxESS H3 already declares both and now gets its `batterymode` block applied as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)