### PR TITLE
my-PV HEA: add 5s heartbeat to rewrite active relays

### DIFF
--- a/charger/mypv-hea.go
+++ b/charger/mypv-hea.go
@@ -36,8 +36,8 @@ type MyPvHea struct {
 	log       *util.Logger
 	relays    uint16
 	stepPower uint16
-	enabled   atomic.Bool
-	mask      atomic.Uint32
+	mask      atomic.Uint32 // requested stage mask
+	active    atomic.Uint32 // last written mask
 	current   atomic.Uint64
 }
 
@@ -122,7 +122,7 @@ func (wb *MyPvHea) heartbeat(ctx context.Context, interval time.Duration) {
 			return
 		}
 
-		if mask := uint16(wb.mask.Load()); wb.enabled.Load() && mask != 0 {
+		if mask := uint16(wb.active.Load()); mask != 0 {
 			if err := wb.setRelays(mask); err != nil {
 				wb.log.ERROR.Println("heartbeat:", err)
 			}
@@ -161,6 +161,9 @@ func (wb *MyPvHea) Enabled() (bool, error) {
 
 func (wb *MyPvHea) setRelays(mask uint16) error {
 	_, err := wb.conn.WriteSingleRegister(heaRegSetPower, mask)
+	if err == nil {
+		wb.active.Store(uint32(mask))
+	}
 	return err
 }
 
@@ -171,12 +174,7 @@ func (wb *MyPvHea) Enable(enable bool) error {
 		mask = uint16(wb.mask.Load())
 	}
 
-	err := wb.setRelays(mask)
-	if err == nil {
-		wb.enabled.Store(enable)
-	}
-
-	return err
+	return wb.setRelays(mask)
 }
 
 // MaxCurrent implements the api.Charger interface

--- a/charger/mypv-hea.go
+++ b/charger/mypv-hea.go
@@ -107,14 +107,14 @@ func NewMyPvHea(ctx context.Context, name string, settings modbus.TcpSettings, t
 		stepPower: stepPower,
 	}
 
-	go wb.heartbeat(ctx, 5*time.Second)
+	go wb.heartbeat(ctx)
 
 	return wb, nil
 }
 
 // heartbeat rewrites the active relay mask so the device does not fall back to idle
-func (wb *MyPvHea) heartbeat(ctx context.Context, interval time.Duration) {
-	for tick := time.Tick(interval); ; {
+func (wb *MyPvHea) heartbeat(ctx context.Context) {
+	for tick := time.Tick(5 * time.Second); ; {
 		select {
 		case <-tick:
 		case <-ctx.Done():

--- a/charger/mypv-hea.go
+++ b/charger/mypv-hea.go
@@ -36,7 +36,7 @@ type MyPvHea struct {
 	log       *util.Logger
 	relays    uint16
 	stepPower uint16
-	mask      atomic.Uint32 // last written relay mask
+	mask      atomic.Uint32
 	current   atomic.Uint64
 }
 

--- a/charger/mypv-hea.go
+++ b/charger/mypv-hea.go
@@ -36,8 +36,7 @@ type MyPvHea struct {
 	log       *util.Logger
 	relays    uint16
 	stepPower uint16
-	mask      atomic.Uint32 // requested stage mask
-	active    atomic.Uint32 // last written mask
+	mask      atomic.Uint32 // last written relay mask
 	current   atomic.Uint64
 }
 
@@ -122,7 +121,7 @@ func (wb *MyPvHea) heartbeat(ctx context.Context, interval time.Duration) {
 			return
 		}
 
-		if mask := uint16(wb.active.Load()); mask != 0 {
+		if mask := uint16(wb.mask.Load()); mask != 0 {
 			if err := wb.setRelays(mask); err != nil {
 				wb.log.ERROR.Println("heartbeat:", err)
 			}
@@ -162,19 +161,18 @@ func (wb *MyPvHea) Enabled() (bool, error) {
 func (wb *MyPvHea) setRelays(mask uint16) error {
 	_, err := wb.conn.WriteSingleRegister(heaRegSetPower, mask)
 	if err == nil {
-		wb.active.Store(uint32(mask))
+		wb.mask.Store(uint32(mask))
 	}
 	return err
 }
 
 // Enable implements the api.Charger interface
 func (wb *MyPvHea) Enable(enable bool) error {
-	var mask uint16
 	if enable {
-		mask = uint16(wb.mask.Load())
+		return wb.MaxCurrentMillis(math.Float64frombits(wb.current.Load()))
 	}
 
-	return wb.setRelays(mask)
+	return wb.setRelays(0)
 }
 
 // MaxCurrent implements the api.Charger interface
@@ -204,7 +202,6 @@ func (wb *MyPvHea) MaxCurrentMillis(current float64) error {
 
 	err := wb.setRelays(mask)
 	if err == nil {
-		wb.mask.Store(uint32(mask))
 		wb.current.Store(math.Float64bits(current))
 	}
 

--- a/charger/mypv-hea.go
+++ b/charger/mypv-hea.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math"
 	"sync/atomic"
+	"time"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
@@ -32,8 +33,10 @@ import (
 // MyPvHea charger implementation
 type MyPvHea struct {
 	myPvBase
+	log       *util.Logger
 	relays    uint16
 	stepPower uint16
+	enabled   atomic.Bool
 	mask      atomic.Uint32
 	current   atomic.Uint64
 }
@@ -100,11 +103,31 @@ func NewMyPvHea(ctx context.Context, name string, settings modbus.TcpSettings, t
 
 	wb := &MyPvHea{
 		myPvBase:  newMyPvBase(conn, heaTemp[tempSource-1]),
+		log:       log,
 		relays:    relays,
 		stepPower: stepPower,
 	}
 
+	go wb.heartbeat(ctx, 5*time.Second)
+
 	return wb, nil
+}
+
+// heartbeat rewrites the active relay mask so the device does not fall back to idle
+func (wb *MyPvHea) heartbeat(ctx context.Context, interval time.Duration) {
+	for tick := time.Tick(interval); ; {
+		select {
+		case <-tick:
+		case <-ctx.Done():
+			return
+		}
+
+		if mask := uint16(wb.mask.Load()); wb.enabled.Load() && mask != 0 {
+			if err := wb.setRelays(mask); err != nil {
+				wb.log.ERROR.Println("heartbeat:", err)
+			}
+		}
+	}
 }
 
 // Status implements the api.Charger interface
@@ -148,7 +171,12 @@ func (wb *MyPvHea) Enable(enable bool) error {
 		mask = uint16(wb.mask.Load())
 	}
 
-	return wb.setRelays(mask)
+	err := wb.setRelays(mask)
+	if err == nil {
+		wb.enabled.Store(enable)
+	}
+
+	return err
 }
 
 // MaxCurrent implements the api.Charger interface


### PR DESCRIPTION
Follow-up to #33500. The HEA THOR resets its relay mask when it is not rewritten periodically, so evcc now rewrites the active mask every 5s while the charger is enabled, mirroring the AC-THOR/ELWA heartbeat in `mypv.go`.

- `Enable` records the enabled state on successful write
- heartbeat goroutine rewrites the last mask every 5s only while enabled and mask is non-zero
- nothing is written while disabled, so a switched-off device stays off

🤖 Generated with [Claude Code](https://claude.com/claude-code)