### PR TITLE
my-PV HEA: derive heartbeat interval from power timeout register

### DIFF
--- a/charger/mypv-hea.go
+++ b/charger/mypv-hea.go
@@ -107,14 +107,20 @@ func NewMyPvHea(ctx context.Context, name string, settings modbus.TcpSettings, t
 		stepPower: stepPower,
 	}
 
-	go wb.heartbeat(ctx)
+	// device resets relays when not written within the power timeout; not writable more than once a day
+	timeout, err := wb.readUint16(myPvRegPowerTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	go wb.heartbeat(ctx, time.Duration(max(timeout, 10))*time.Second/2)
 
 	return wb, nil
 }
 
 // heartbeat rewrites the active relay mask so the device does not fall back to idle
-func (wb *MyPvHea) heartbeat(ctx context.Context) {
-	for tick := time.Tick(5 * time.Second); ; {
+func (wb *MyPvHea) heartbeat(ctx context.Context, interval time.Duration) {
+	for tick := time.Tick(interval); ; {
 		select {
 		case <-tick:
 		case <-ctx.Done():

--- a/charger/mypv-hea.go
+++ b/charger/mypv-hea.go
@@ -113,7 +113,7 @@ func NewMyPvHea(ctx context.Context, name string, settings modbus.TcpSettings, t
 		return nil, err
 	}
 
-	go wb.heartbeat(ctx, time.Duration(max(timeout, 10))*time.Second/2)
+	go wb.heartbeat(ctx, time.Duration(timeout)*time.Second/2)
 
 	return wb, nil
 }

--- a/charger/mypv-hea.go
+++ b/charger/mypv-hea.go
@@ -108,12 +108,12 @@ func NewMyPvHea(ctx context.Context, name string, settings modbus.TcpSettings, t
 	}
 
 	// device resets relays when not written within the power timeout; not writable more than once a day
-	timeout, err := wb.readUint16(myPvRegPowerTimeout)
+	b, err := wb.readUint16(myPvRegPowerTimeout)
 	if err != nil {
 		return nil, err
 	}
 
-	go wb.heartbeat(ctx, time.Duration(timeout)*time.Second/2)
+	go wb.heartbeat(ctx, time.Duration(b)*time.Second/2)
 
 	return wb, nil
 }

--- a/charger/mypv_common.go
+++ b/charger/mypv_common.go
@@ -28,6 +28,7 @@ import (
 const (
 	myPvRegPower          = 1000
 	myPvRegTempLimit      = 1002
+	myPvRegPowerTimeout   = 1004 // seconds, 10-600
 	myPvRegOperationState = 1077
 )
 

--- a/charger/mypv_common.go
+++ b/charger/mypv_common.go
@@ -28,7 +28,7 @@ import (
 const (
 	myPvRegPower          = 1000
 	myPvRegTempLimit      = 1002
-	myPvRegPowerTimeout   = 1004 // seconds, 10-600
+	myPvRegPowerTimeout   = 1004
 	myPvRegOperationState = 1077
 )
 


### PR DESCRIPTION
Follow-up to #33626. Instead of a fixed 5s heartbeat, read the device's power timeout (register 1004, R/W, 10-600 s) once at startup and rewrite the relay mask at half that interval.

Per the my-PV controls documentation, writable registers other than 1000/1078/1079/1080 must not be written more than once a day to protect non-volatile memory, so register 1004 is only read, never written. A device configured with a longer timeout now gets proportionally fewer modbus writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)