### PR TITLE
SolarEdge Hybrid: clarify battery energy counters (daily not lifetime)

### DIFF
--- a/templates/definition/meter/solaredge-hybrid.yaml
+++ b/templates/definition/meter/solaredge-hybrid.yaml
@@ -231,11 +231,13 @@ render: |
       address: 0xE184 # Battery 1 State of Energy (SOE)
       type: holding
       decode: float32nans
+  # Battery energy counters reset to zero daily and are not persistent lifetime totals.
+  # As a result, evcc history totals may differ slightly.
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 0xE176 # Battery 1 Lifetime Export Energy Counter (discharged)
+      address: 0xE176 # Battery 1 Daily Export Energy Counter (discharged)
       type: holding
       decode: uint64snan
     scale: 0.001
@@ -243,7 +245,7 @@ render: |
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 0xE17A # Battery 1 Lifetime Import Energy Counter (charged)
+      address: 0xE17A # Battery 1 Daily Import Energy Counter (charged)
       type: holding
       decode: uint64snan
     scale: 0.001


### PR DESCRIPTION
On my SolarEdge system, the battery import and export energy counters reset to zero daily (not at a fixed time). The current “Lifetime” wording therefore suggests persistent totals that these counters do not provide. Changing the comments to “Daily” reflects the observed behavior and explains why evcc history totals may differ slightly.