### PR TITLE
CI: label issue and pr waiting for feedback when pr build finished

### DIFF
--- a/.github/workflows/command-pr-build.yml
+++ b/.github/workflows/command-pr-build.yml
@@ -180,6 +180,10 @@ jobs:
 
             if (!ok) return;
 
+            // builds are ready to test: flag PR and linked issues as waiting for feedback
+            const labels = ['waiting for feedback'];
+            await github.rest.issues.addLabels({ owner, repo, issue_number: num, labels });
+
             // notify each issue this PR closes (via "fixes #N" keywords) that fresh builds exist
             const q = `query($owner:String!,$repo:String!,$num:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$num){closingIssuesReferences(first:20){nodes{number}}}}}`;
             const res = await github.graphql(q, { owner, repo, num });
@@ -187,6 +191,7 @@ jobs:
             for (const issue_number of issues) {
               const body = [`Test binaries for the fix in #${num} are ready to test:`, '', ...artifacts].join('\n');
               await github.rest.issues.createComment({ owner, repo, issue_number, body });
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels });
             }
 
       - name: Resolve command comment


### PR DESCRIPTION
After a successful `/build`, add the `waiting for feedback` label to the PR and to every issue it closes, alongside the existing "binaries ready" comments. The existing waiting-feedback workflow clears the label again once the opener replies.