### PR TITLE
Loadpoint: derive remaining energy and duration from energy limit

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -2182,9 +2182,20 @@ func (lp *Loadpoint) publishSocAndRange() {
 	limitSoc := min(apiLimitSoc, lp.EffectiveLimitSoc())
 	v := lp.GetVehicle()
 
+	lp.RLock()
+	limitEnergy, energyLimited := lp.remainingLimitEnergy()
+	lp.RUnlock()
+
 	var d time.Duration
 	var e float64
 	switch {
+	case energyLimited:
+		// energy-limited session without soc: remaining energy and duration follow
+		// the limit, not the full capacity (#33627)
+		e = limitEnergy
+		if lp.charging() && lp.chargePower > 0 {
+			d = time.Duration(e * 1e3 / lp.chargePower * float64(time.Hour)).Round(time.Second)
+		}
 	case socEstimator != nil:
 		if lp.charging() {
 			d = socEstimator.RemainingChargeDuration(float64(limitSoc), lp.chargePower)

--- a/core/loadpoint_vehicle_test.go
+++ b/core/loadpoint_vehicle_test.go
@@ -193,6 +193,46 @@ func TestPublishSocAndRangeVehiclesAndChargers(t *testing.T) {
 	}
 }
 
+// https://github.com/evcc-io/evcc/issues/33627
+func TestPublishSocAndRangeEnergyLimit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	// offline vehicle with capacity: estimator exists but soc is unknown
+	vehicle := api.NewMockVehicle(ctrl)
+	vehicle.EXPECT().Soc().AnyTimes()
+	vehicle.EXPECT().Capacity().Return(4.0).AnyTimes()
+	vehicle.EXPECT().Features().Return([]api.Feature{api.Offline}).AnyTimes()
+
+	log := util.NewLogger("foo")
+	lp := &Loadpoint{
+		log:          log,
+		bus:          evbus.New(),
+		clock:        clock.NewMock(),
+		charger:      api.NewMockCharger(ctrl),
+		vehicle:      vehicle,
+		chargeMeter:  &Null{}, // silence nil panics
+		chargeRater:  &Null{}, // silence nil panics
+		chargeTimer:  &Null{}, // silence nil panics
+		socEstimator: soc.NewEstimator(log, vehicle),
+		minCurrent:   minA,
+		maxCurrent:   maxA,
+		phases:       1,
+		status:       api.StatusC,
+		mode:         api.ModeNow,
+		limitEnergy:  2,   // kWh
+		chargePower:  900, // W
+	}
+	lp.energyMetrics.totalKWh = 1.1
+
+	x, y, z := createChannels(t)
+	attachChannels(lp, x, y, z)
+
+	lp.publishSocAndRange()
+
+	assert.InDelta(t, 0.9, lp.GetRemainingEnergy(), 1e-9, "remaining energy")
+	assert.Equal(t, time.Hour, lp.GetRemainingDuration(), "remaining duration")
+}
+
 func TestVehicleDetectByID(t *testing.T) {
 	ctrl := gomock.NewController(t)
 


### PR DESCRIPTION
Fix #33627

For an energy-limited session (no soc, e.g. offline vehicle on a plug), remaining energy and duration were computed towards 100% of the vehicle capacity, ignoring the energy limit. Use the remaining limit energy and charge power instead.