### PR TITLE
Server: immutable Cache-Control for content-hashed static assets

### DIFF
--- a/docs/agents/web-ui-api.md
+++ b/docs/agents/web-ui-api.md
@@ -4,6 +4,7 @@
 
 - **Router:** gorilla/mux, strict slash
 - **Middleware:** GZIP, CORS (`*`), ETag caching, request logging, JSON headers, JWT auth
+- **Static asset caching:** an existing file under `/assets/*` (content-hashed by Vite) gets `Cache-Control: private, max-age=31536000, immutable` so repeat loads skip revalidation entirely; a 404/redirect/directory under that prefix does not, so a URL that only later resolves isn't pinned; `index.html`, `/globals.js` stay `no-cache` (must always reflect the current build); `/meta/*`, `/i18n/*` are unhashed and untouched (still ETag-only)
 - **Timeouts:** Read 5s, Write 10s, Idle 120s
 - **Static assets:** embedded in binary (`fs.FS`)
 - **Default port:** 7070

--- a/server/http.go
+++ b/server/http.go
@@ -2,8 +2,10 @@ package server
 
 import (
 	"fmt"
+	"io/fs"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	eapi "github.com/evcc-io/evcc/api"
@@ -56,6 +58,28 @@ type Customization struct {
 	Email     string
 	Phone     string
 	Theme     string
+}
+
+// immutableCache adds a one-year immutable Cache-Control, but only when the
+// request path names an existing regular file in fsys. Vite content-hashes
+// every /assets/* filename, so for a hit "same URL" implies "same bytes". A
+// miss (404), a directory, or a redirect gets no such header, so a URL that
+// only later resolves to a file is not pinned for a year. private because
+// these responses sit behind auth.
+//
+// fsys is an embed.FS sub-filesystem: fs.ValidPath already rejects any name
+// containing "..", a leading/trailing slash or an empty element, and fs.Stat
+// on an fs.FS cannot escape its root regardless - there is no OS file access
+// here, and the request body is never read, only a response header is set.
+func immutableCache(fsys fs.FS, h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if name := strings.TrimPrefix(r.URL.Path, "/"); fs.ValidPath(name) {
+			if info, err := fs.Stat(fsys, name); err == nil && info.Mode().IsRegular() {
+				w.Header().Set("Cache-Control", "private, max-age=31536000, immutable")
+			}
+		}
+		h.ServeHTTP(w, r)
+	})
 }
 
 // NewHTTPd creates HTTP server with configured routes for loadpoint
@@ -136,7 +160,13 @@ func NewHTTPd(addr string, hub *SocketHub, custom Customization) *HTTPd {
 	static.HandleFunc("/globals.js", globalsJsHandler(custom))
 	static.HandleFunc("/", indexHandler())
 	for _, dir := range []string{"assets", "meta"} {
-		static.PathPrefix("/" + dir).Handler(http.FileServer(http.FS(assets.Web)))
+		h := http.Handler(http.FileServer(http.FS(assets.Web)))
+		if dir == "assets" {
+			// content-hashed filenames (index-D9lZvCVW.js) only change when their
+			// content does, so the browser can skip revalidation entirely
+			h = immutableCache(assets.Web, h)
+		}
+		static.PathPrefix("/" + dir).Handler(h)
 	}
 
 	static.PathPrefix("/i18n").Handler(http.StripPrefix("/i18n", http.FileServer(http.FS(assets.I18n))))

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -4,7 +4,9 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+	"testing/fstest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -35,4 +37,39 @@ func TestWriteTimeout(t *testing.T) {
 		_, err = io.ReadAll(resp.Body)
 	}
 	require.Error(t, err, "expected connection to be closed after write timeout")
+}
+
+// TestImmutableCache only tags responses that map to a real file, so a 404,
+// a directory, or a traversal attempt is not pinned for a year.
+func TestImmutableCache(t *testing.T) {
+	fsys := fstest.MapFS{
+		"assets/index-abc123.js": {Data: []byte("x")},
+		"assets/sub/keep.js":     {Data: []byte("y")},
+	}
+	h := immutableCache(fsys, http.FileServer(http.FS(fsys)))
+
+	const want = "private, max-age=31536000, immutable"
+
+	for _, tc := range []struct {
+		path   string
+		cached bool
+	}{
+		{"/assets/index-abc123.js", true},
+		{"/assets/missing-def456.js", false}, // 404
+		{"/assets/sub", false},               // directory
+		{"/assets/sub/", false},              // directory, trailing slash
+		{"/assets/../secret", false},         // traversal
+	} {
+		t.Run(tc.path, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, tc.path, nil))
+
+			got := rec.Header().Get("Cache-Control")
+			if tc.cached {
+				require.Equal(t, want, got)
+			} else {
+				require.Empty(t, got)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Problem

`/assets/*.js` and `.css` are served with no `Cache-Control`, so the browser re-requests every one of them on each page load — a conditional request per hashed chunk, cache-hit or not. Vite already content-hashes these filenames (`index-D9lZvCVW.js`), so the same URL is always byte-identical; a content change produces a new hash and a new URL.

This is most painful over a remote-access tunnel: each of those ~20 parallel per-load requests also pays a per-request Basic Auth check and a live gzip pass before the 304 comes back.

## Change

A small `immutableCache` middleware sets `Cache-Control: private, max-age=31536000, immutable` on the `/assets` prefix only (~12 lines in `server/http.go`):

- `private`, not `public`, because these responses sit behind auth
- `index.html` and `/globals.js` are never hashed and must always reflect the current build — untouched (already `no-cache`)
- `/meta/*` (favicons) and `/i18n/*.json` have plain, unhashed names — untouched, still ETag-only

Repeat loads (a kept tab, a bookmark) then serve every hashed asset straight from disk cache with zero revalidation.

## Relationship to #33593

#33593 fixed the same remote-access slowness from the other side — caching the per-request `bcrypt` Basic Auth verification so the requests that *do* reach the instance aren't CPU-bound. This change is complementary: it removes the asset re-requests entirely on repeat loads, so they never reach the tunnel at all. Neither supersedes the other, and this one isn't remote-specific — fewer conditional requests benefit every install.

## Scope / non-goals

Does **not** help a true first-ever cold load (nothing cached yet), nor a mobile webview that clears its cache each launch. It only removes revalidation traffic for clients that already have the assets.

## Test

`go build` / `go vet` / `go test ./server/...` clean. Manually verified `Cache-Control: private, max-age=31536000, immutable` on `/assets/*` responses and unchanged headers on `index.html`, `/globals.js`, `/meta/*`, `/i18n/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)