### PR TITLE
Site: hide disabled loadpoints in energy flow

### DIFF
--- a/assets/js/components/Site/Site.vue
+++ b/assets/js/components/Site/Site.vue
@@ -177,7 +177,10 @@ export default defineComponent({
 			return store.state?.experimental;
 		},
 		energyflow() {
-			return this.collectProps(Energyflow);
+			return {
+				...this.collectProps(Energyflow),
+				loadpoints: this.orderedVisibleLoadpoints,
+			};
 		},
 		vehicleList() {
 			return vehicleList(this.vehicles);

--- a/tests/config-disable.spec.ts
+++ b/tests/config-disable.spec.ts
@@ -395,6 +395,14 @@ test.describe("disabled loadpoint behavior", async () => {
     await expect(page.getByTestId("loadpoint").nth(0)).toContainText("Carport");
     await expect(page.getByTestId("loadpoint").nth(1)).toContainText("Süd");
 
+    // energy flow excludes disabled loadpoints as well
+    const energyflow = page.getByTestId("energyflow");
+    await energyflow.click();
+    const loadpointsEntry = page.getByTestId("energyflow-entry-loadpoints");
+    await expect(loadpointsEntry).toContainText("Carport");
+    await expect(loadpointsEntry).toContainText("Süd");
+    await expect(loadpointsEntry).not.toContainText("Garage");
+
     // state keeps disabled loadpoint at its position
     const state = await (await page.request.get("/api/state")).json();
     expect(state.loadpoints).toHaveLength(3);


### PR DESCRIPTION
Fixes: #33640

Disabled loadpoints were excluded from the dashboard carousel but still reached the Energyflow component through its generic prop collector. Pass the shared visible, enabled loadpoint list to Energyflow so its expanded "Out" entry only lists active loadpoints.

- Add browser coverage for disabled loadpoints in Energyflow details.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)