### PR TITLE
Go-e: Disable charging on fault and verify write confirmations

### DIFF
--- a/charger/go-e.go
+++ b/charger/go-e.go
@@ -36,7 +36,8 @@ import (
 // GoE charger implementation
 type GoE struct {
 	implement.Caps
-	api goe.API
+	api             goe.API
+	disabledOnFault bool
 }
 
 func init() {
@@ -112,11 +113,26 @@ func (c *GoE) Status() (api.ChargeStatus, error) {
 
 	switch car := resp.Status(); car {
 	case 1:
+		c.disabledOnFault = false
 		return api.StatusA, nil
 	case 2:
+		c.disabledOnFault = false
 		return api.StatusC, nil
 	case 3, 4:
+		c.disabledOnFault = false
 		return api.StatusB, nil
+	case 5:
+		if !c.disabledOnFault {
+			if err := c.Enable(false); err != nil {
+				return api.StatusNone, fmt.Errorf("disable charger after fault: %w", err)
+			}
+			c.disabledOnFault = true
+		}
+
+		if err := resp.Error(); err != 0 {
+			return api.StatusNone, fmt.Errorf("charger error: %d", err)
+		}
+		return api.StatusNone, fmt.Errorf("car error: %d", car)
 	default:
 		return api.StatusNone, fmt.Errorf("car unknown result: %d", car)
 	}

--- a/charger/go-e/api.go
+++ b/charger/go-e/api.go
@@ -16,6 +16,7 @@ const CloudURI = "https://api.go-e.co"
 // Response is the v1 and v2 api response interface
 type Response interface {
 	Status() int
+	Error() int
 	Enabled() bool
 	CurrentPower() float64
 	ChargedEnergy() float64
@@ -86,7 +87,7 @@ func (c *LocalAPI) response(partial string, res any) error {
 func (c *LocalAPI) status() (Response, error) {
 	if c.v2 {
 		var res StatusResponse2
-		err := c.response("status?filter=alw,car,eto,nrg,wh,trx,cards", &res)
+		err := c.response("status?filter=alw,car,err,eto,nrg,wh,trx,cards", &res)
 		return &res, err
 	}
 

--- a/charger/go-e/api.go
+++ b/charger/go-e/api.go
@@ -103,7 +103,7 @@ func (c *LocalAPI) Status() (Response, error) {
 func (c *LocalAPI) Update(payload string) error {
 	c.statusG.Reset() // invalidate cache so the next Status refetches
 
-	res := new(UpdateResponse)
+	var res UpdateResponse
 
 	if c.v2 {
 		return c.response(fmt.Sprintf("set?%s", payload), &res)

--- a/charger/go-e/api.go
+++ b/charger/go-e/api.go
@@ -3,6 +3,7 @@ package goe
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -106,7 +107,28 @@ func (c *LocalAPI) Update(payload string) error {
 	var res UpdateResponse
 
 	if c.v2 {
-		return c.response(fmt.Sprintf("set?%s", payload), &res)
+		params, err := url.ParseQuery(payload)
+		if err != nil {
+			return fmt.Errorf("invalid update payload: %w", err)
+		}
+		if len(params) == 0 {
+			return errors.New("empty update payload")
+		}
+
+		if err := c.response(fmt.Sprintf("set?%s", payload), &res); err != nil {
+			return err
+		}
+
+		for key := range params {
+			value, ok := res[key]
+			if !ok {
+				return fmt.Errorf("set %s: missing confirmation", key)
+			}
+			if accepted, ok := value.(bool); !ok || !accepted {
+				return fmt.Errorf("set %s: %v", key, value)
+			}
+		}
+		return nil
 	}
 
 	return c.response(fmt.Sprintf("mqtt?payload=%s", payload), &res)

--- a/charger/go-e/api_test.go
+++ b/charger/go-e/api_test.go
@@ -7,10 +7,12 @@ import (
 	"testing"
 
 	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/require"
 )
 
 type handler struct {
-	uri string
+	uri      string
+	response string
 }
 
 func (h *handler) expect(uri string) {
@@ -25,7 +27,11 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	fmt.Println(path)
 
 	if path == h.uri {
-		fmt.Fprint(w, "{}")
+		if h.response != "" {
+			fmt.Fprint(w, h.response)
+		} else {
+			fmt.Fprint(w, "{}")
+		}
 	} else {
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintf(w, "expected %s", h.uri)
@@ -65,7 +71,57 @@ func TestLocalV2(t *testing.T) {
 	}
 
 	h.expect("/api/set?foo=bar")
+	h.response = `{"foo":true}`
 	if err := local.Update("foo=bar"); err != nil {
 		t.Error(err)
+	}
+}
+
+func TestLocalV2UpdateResponse(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		payload  string
+		response string
+		err      string
+	}{
+		{"confirmed", "frc=1", `{"frc":true}`, ""},
+		{"rejected", "frc=1", `{"frc":"write rejected"}`, "set frc: write rejected"},
+		{"false", "frc=1", `{"frc":false}`, "set frc: false"},
+		{"missing", "frc=1", `{}`, "set frc: missing confirmation"},
+		{"null response", "frc=1", `null`, "set frc: missing confirmation"},
+		{"null value", "frc=1", `{"frc":null}`, "set frc: <nil>"},
+		{"wrong key", "frc=1", `{"amp":true}`, "set frc: missing confirmation"},
+		{"string true", "frc=1", `{"frc":"true"}`, "set frc: true"},
+		{"numeric true", "frc=1", `{"frc":1}`, "set frc: 1"},
+		{"current", "amp=6", `{"amp":true}`, ""},
+		{"phases", "psm=1", `{"psm":true}`, ""},
+		{"multiple", "frc=1&amp=6", `{"frc":true,"amp":true}`, ""},
+		{"partial", "frc=1&amp=6", `{"frc":true}`, "set amp: missing confirmation"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/status":
+					fmt.Fprint(w, `{"alw":false}`)
+				case "/api/set":
+					if r.URL.RawQuery != tc.payload {
+						t.Errorf("unexpected update: %s", r.URL.RawQuery)
+					}
+					fmt.Fprint(w, tc.response)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			srv.Start()
+
+			local := NewLocal(util.NewLogger("foo"), srv.URL, 0)
+			require.True(t, local.IsV2())
+			err := local.Update(tc.payload)
+			if tc.err == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tc.err)
+			}
+		})
 	}
 }

--- a/charger/go-e/api_test.go
+++ b/charger/go-e/api_test.go
@@ -65,7 +65,7 @@ func TestLocalV2(t *testing.T) {
 	h.expect("/api/status?filter=alw")
 	local := NewLocal(util.NewLogger("foo"), srv.URL, 0)
 
-	h.expect("/api/status?filter=alw,car,eto,nrg,wh,trx,cards")
+	h.expect("/api/status?filter=alw,car,err,eto,nrg,wh,trx,cards")
 	if _, err := local.Status(); err != nil {
 		t.Error(err)
 	}

--- a/charger/go-e/types.go
+++ b/charger/go-e/types.go
@@ -37,6 +37,10 @@ func (g *StatusResponse) Status() int {
 	return g.Car
 }
 
+func (g *StatusResponse) Error() int {
+	return g.Err
+}
+
 func (g *StatusResponse) Enabled() bool {
 	return g.Alw == 1
 }

--- a/charger/go-e/types2.go
+++ b/charger/go-e/types2.go
@@ -28,6 +28,10 @@ func (g *StatusResponse2) Status() int {
 	return g.Car
 }
 
+func (g *StatusResponse2) Error() int {
+	return g.Err
+}
+
 func (g *StatusResponse2) Enabled() bool {
 	return g.Alw
 }

--- a/charger/go-e_test.go
+++ b/charger/go-e_test.go
@@ -1,13 +1,18 @@
 package charger
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/evcc-io/evcc/api"
+	goe "github.com/evcc-io/evcc/charger/go-e"
+	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/sponsor"
+	"github.com/stretchr/testify/require"
 )
 
 type handler struct {
@@ -87,5 +92,152 @@ func TestGoEV2(t *testing.T) {
 
 	if _, ok := api.Cap[api.PhaseSwitcher](wb); !ok {
 		t.Error("missing PhaseSwitcher api")
+	}
+}
+
+type goEAPI struct {
+	response  goe.Response
+	updates   []string
+	updateErr error
+}
+
+func (c *goEAPI) IsV2() bool {
+	return true
+}
+
+func (c *goEAPI) Status() (goe.Response, error) {
+	return c.response, nil
+}
+
+func (c *goEAPI) Update(payload string) error {
+	c.updates = append(c.updates, payload)
+	return c.updateErr
+}
+
+func TestGoEFaultDisable(t *testing.T) {
+	res := &goe.StatusResponse2{Car: 5, Err: 5}
+	conn := &goEAPI{response: res}
+	wb := &GoE{api: conn}
+
+	_, err := wb.Status()
+	require.EqualError(t, err, "charger error: 5")
+	require.Equal(t, []string{"frc=1"}, conn.updates)
+
+	_, err = wb.Status()
+	require.EqualError(t, err, "charger error: 5")
+	require.Equal(t, []string{"frc=1"}, conn.updates)
+
+	res.Car = 1
+	status, err := wb.Status()
+	require.NoError(t, err)
+	require.Equal(t, api.StatusA, status)
+
+	res.Car = 5
+	_, err = wb.Status()
+	require.EqualError(t, err, "charger error: 5")
+	require.Equal(t, []string{"frc=1", "frc=1"}, conn.updates)
+}
+
+func TestGoEFaultReset(t *testing.T) {
+	for _, tc := range []struct {
+		car     int
+		status  api.ChargeStatus
+		updates int
+	}{
+		{1, api.StatusA, 2},
+		{2, api.StatusC, 2},
+		{3, api.StatusB, 2},
+		{4, api.StatusB, 2},
+		{0, api.StatusNone, 1},
+		{6, api.StatusNone, 1},
+	} {
+		t.Run(fmt.Sprint(tc.car), func(t *testing.T) {
+			res := &goe.StatusResponse2{Car: 5, Err: 5}
+			conn := &goEAPI{response: res}
+			wb := &GoE{api: conn}
+
+			_, err := wb.Status()
+			require.EqualError(t, err, "charger error: 5")
+
+			res.Car = tc.car
+			res.Err = 0
+			status, err := wb.Status()
+			require.Equal(t, tc.status, status)
+			if tc.status == api.StatusNone {
+				require.EqualError(t, err, fmt.Sprintf("car unknown result: %d", tc.car))
+			} else {
+				require.NoError(t, err)
+			}
+
+			res.Car = 5
+			res.Err = 5
+			_, err = wb.Status()
+			require.EqualError(t, err, "charger error: 5")
+			require.Len(t, conn.updates, tc.updates)
+		})
+	}
+}
+
+func TestGoEFaultDisableRetry(t *testing.T) {
+	res := &goe.StatusResponse2{Car: 5, Err: 5}
+	conn := &goEAPI{
+		response:  res,
+		updateErr: errors.New("failed"),
+	}
+	wb := &GoE{api: conn}
+
+	_, err := wb.Status()
+	require.EqualError(t, err, "disable charger after fault: failed")
+
+	conn.updateErr = nil
+	_, err = wb.Status()
+	require.EqualError(t, err, "charger error: 5")
+	require.Equal(t, []string{"frc=1", "frc=1"}, conn.updates)
+}
+
+func TestGoEFaultDisableHTTP(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		response string
+		err      string
+	}{
+		{"rejected", `{"frc":"write rejected"}`, "set frc: write rejected"},
+		{"missing", `{}`, "set frc: missing confirmation"},
+		{"false", `{"frc":false}`, "set frc: false"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var attempts atomic.Int32
+			srv := httptest.NewTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/status":
+					fmt.Fprint(w, `{"car":5,"err":5,"alw":false}`)
+				case "/api/set":
+					if r.URL.RawQuery != "frc=1" {
+						t.Errorf("unexpected update: %s", r.URL.RawQuery)
+					}
+					if attempts.Add(1) == 1 {
+						fmt.Fprint(w, tc.response)
+					} else {
+						fmt.Fprint(w, `{"frc":true}`)
+					}
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			srv.Start()
+			wb := &GoE{api: goe.NewLocal(util.NewLogger("go-e"), srv.URL, 0)}
+
+			status, err := wb.Status()
+			require.Equal(t, api.StatusNone, status)
+			require.EqualError(t, err, "disable charger after fault: "+tc.err)
+			require.EqualValues(t, 1, attempts.Load())
+
+			for range 2 {
+				status, err = wb.Status()
+				require.Equal(t, api.StatusNone, status)
+				require.EqualError(t, err, "charger error: 5")
+				require.EqualValues(t, 2, attempts.Load())
+			}
+		})
 	}
 }


### PR DESCRIPTION
Observed with **evcc 0.314.5**, a **go-e Charger CORE running firmware 60.5**, and a **VW e-up**. Charging was controlled through the **local HTTP API v2**, in **PV mode**, with a **30-second update interval**.

The charger reported `car=5` with `err=5`. The go-e API reference defines these as [Error (`car=5`)](https://github.com/goecharger/go-eCharger-API-v2/blob/main/API_KEYS_FIRMWARE/apikeys_Firmware_60.4_sorted.md?plain=1#L53) and [Overamp (`err=5`)](https://github.com/goecharger/go-eCharger-API-v2/blob/main/API_KEYS_FIRMWARE/apikeys_Firmware_60.4_sorted.md?plain=1#L93). evcc repeatedly returned `car unknown result: 5`, aborting the loadpoint update before charger synchronization or disabling could run.

A separate API query while faulted returned these selected fields:

```json
{"car":5,"err":5,"alw":false,"fwv":"60.5"}
```

The charger had already stopped charging. The purpose of this change is to request an **explicit shutdown while faulted**, not to stop an ongoing overcurrent condition.

Unplugging cleared the hardware fault. After reconnecting, the charger briefly started charging despite evcc expecting it to remain disabled. Normal processing then resumed, and evcc successfully sent `frc=1` to stop charging.

The changes are split into three commits:

- **`4fee91806`: Simplify update response declaration.** Replace the pointer-to-map allocation with a map variable, removing an unnecessary pointer level before adding response inspection.
- **`0b3efd408`: Validate API v2 write confirmations.** The [go-e HTTP API documentation](https://github.com/goecharger/go-eCharger-API-v2/blob/main/http-en.md#setting-values) specifies a response entry for each requested key: boolean `true` for success or a string error message. Check these confirmations rather than treating successful HTTP/JSON processing alone as command acceptance. Include HTTP-level regression coverage for rejected, missing, and invalid confirmations.
- **`3de6b77ae`: Disable charging on fault.** Recognize `car=5` and call the existing `Enable(false)` method. Suppress further shutdown requests only after confirmation; retry failed shutdowns on subsequent polls. Reset this bookkeeping only on known normal states `1–4`. Read and report the actual `err` code through the existing ERROR logging and UI notification path.

The existing API v2 mapping to `frc=1` is unchanged. The shutdown request is issued in the go-e status error path because the loadpoint otherwise aborts before reaching its normal synchronization and disable logic.

<details>
<summary>Observed logs, September 10, 2026</summary>

The status error repeated until the vehicle was unplugged:

```text
[lp-2  ] ERROR 2026/09/10 09:46:26 charger status: car unknown result: 5
[lp-2  ] ERROR 2026/09/10 09:47:26 charger status: car unknown result: 5
```

After unplugging and reconnecting, evcc detected unexpected charging and sent a confirmed shutdown command. The charger address is redacted:

```text
[lp-2  ] INFO 2026/09/10 21:49:35 car connected
[lp-2  ] INFO 2026/09/10 21:49:35 start charging ->
[lp-2  ] WARN 2026/09/10 21:49:35 charger out of sync: expected disabled, got enabled
[go-e  ] TRACE 2026/09/10 21:49:35 GET http://<charger>/api/set?frc=1
[go-e  ] TRACE 2026/09/10 21:49:35 {"frc":true}
[lp-2  ] INFO 2026/09/10 21:50:35 stop charging <-
```

</details>

**This change has not been tested against the actual hardware failure because I do not know how to reproduce it.** Regression coverage uses simulated responses. The confirmed shutdown above occurred **after the fault cleared**, not during `car=5`.

Whether the charger accepts shutdown while faulted, retains that setting across unplugging and reconnecting, and consequently avoids the brief charging restart remains unverified. This change does **not** fix the underlying Overamp cause, clear the hardware fault, or automatically restart charging.

*Generated with GitHub Copilot.*
