### PR TITLE
Add ABL SURSUM EVCC controller

### DIFF
--- a/charger/abl-evcc.go
+++ b/charger/abl-evcc.go
@@ -1,0 +1,322 @@
+package charger
+
+// LICENSE
+
+// Copyright (c) evcc.io (andig, naltatis, premultiply)
+
+// This module is NOT covered by the MIT license. All rights reserved.
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/api/implement"
+	"github.com/evcc-io/evcc/charger/ablevcc"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/sponsor"
+)
+
+// ABLevcc charger implementation for the pre-modbus ABL SURSUM EVCC controller
+// https://web.archive.org/web/20160122105853/http://www.abl-sursum.com/global/downloads/bedienungsanleitungen/EVCC.pdf
+type ABLevcc struct {
+	implement.Caps
+	conn    *ablevcc.Connection
+	addr    uint8
+	curr    int // duty cycle in 0.1% steps
+	maxA    float64
+	enabled bool
+}
+
+const (
+	ablEvccCmdFirmware    = 1
+	ablEvccCmdStatus      = 2
+	ablEvccCmdInputs      = 10
+	ablEvccCmdGetPwm      = 11
+	ablEvccCmdSetPwm      = 12
+	ablEvccCmdGetDefault  = 26
+	ablEvccCmdSetBreak    = 27
+	ablEvccCmdClearBreak  = 28
+	ablEvccCmdGetBreak    = 29
+	ablEvccCmdEnterAPrime = 30
+	ablEvccCmdLeaveAPrime = 31
+
+	ablEvccPwmMin      = 100 // 10.0% = 6A
+	ablEvccPwmMax      = 970 // 97.0% = 82.5A
+	ablEvccPwmDisabled = 999 // charging not allowed
+
+	ablEvccMinCurrent = 6
+)
+
+// ablEvccStatus maps the device state machine to the charge status. The status
+// is mapped directly since api.ChargeStatusString only evaluates the first
+// character and would return both a status and an error for the error states.
+var ablEvccStatus = map[int]api.ChargeStatus{
+	0:  api.StatusA, // A  waiting for EV
+	17: api.StatusA, // A' CP off, EV detection disabled
+	4:  api.StatusB, // B2 enabled, waiting for charge request
+	9:  api.StatusB, // B' charging stopped by EV
+	12: api.StatusB, // B1 halted by bBreakCharge (undocumented)
+	13: api.StatusB, // B1 EV detected
+	5:  api.StatusC, // C  charging
+	6:  api.StatusC, // D  charging with ventilation
+}
+
+var ablEvccErrors = map[int]string{
+	33:  "CS error",
+	35:  "EV error",
+	37:  "lock error",
+	39:  "ventilation error",
+	255: "manual mode",
+}
+
+func init() {
+	registry.AddCtx("abl-evcc", NewABLevccFromConfig)
+}
+
+// NewABLevccFromConfig creates an ABL EVCC charger from generic config
+func NewABLevccFromConfig(ctx context.Context, other map[string]any) (api.Charger, error) {
+	cc := struct {
+		Device  string
+		URI     string
+		Address uint8
+		Timeout time.Duration
+	}{
+		Address: 1,
+		Timeout: ablevcc.Timeout,
+	}
+
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	return NewABLevcc(ctx, cc.Device, cc.URI, cc.Address, cc.Timeout)
+}
+
+// NewABLevcc creates an ABL EVCC charger
+func NewABLevcc(ctx context.Context, device, uri string, addr uint8, timeout time.Duration) (api.Charger, error) {
+	if addr < 1 || addr > 8 {
+		return nil, fmt.Errorf("invalid address: %d", addr)
+	}
+
+	// keep before connecting- the template test instantiates every template
+	if !sponsor.IsAuthorized() {
+		return nil, api.ErrSponsorRequired
+	}
+
+	log := util.NewLogger("abl-evcc")
+
+	conn, err := ablevcc.Instance(ctx, log, device, uri, timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	wb := &ABLevcc{
+		Caps: implement.New(),
+		conn: conn,
+		addr: addr,
+		curr: ablEvccPwmMin,
+		maxA: ablEvccCurrent(ablEvccPwmMax),
+	}
+
+	// verify device presence
+	if _, err := conn.Transact(addr, ablEvccCmdFirmware, ""); err != nil {
+		return nil, fmt.Errorf("firmware: %w", err)
+	}
+
+	// the available current is limited by the module's default current
+	if v, err := wb.get(ablEvccCmdGetDefault); err == nil {
+		wb.maxA = ablEvccCurrent(v)
+		implement.Has(wb, implement.CurrentLimiter(wb.getMinMaxCurrent))
+	}
+
+	if wb.enabled, err = wb.Enabled(); err != nil {
+		return nil, err
+	}
+
+	return wb, nil
+}
+
+// ablEvccCurrent converts a duty cycle in 0.1% steps into the signalled current
+func ablEvccCurrent(pwm int) float64 {
+	d := float64(pwm) / 10
+
+	if d > 85 {
+		return (d - 64) * 2.5
+	}
+
+	return d * 0.6
+}
+
+// ablEvccPwm converts a current into a duty cycle in 0.1% steps
+func ablEvccPwm(current float64) int {
+	var pwm int
+
+	switch {
+	case current <= 51:
+		pwm = int(math.Round(current / 0.06))
+	case current < 52.75:
+		pwm = 850 // gap between both duty cycle ranges, limit to 51A
+	default:
+		pwm = int(math.Round((current/2.5 + 64) * 10))
+	}
+
+	return min(max(pwm, ablEvccPwmMin), ablEvccPwmMax)
+}
+
+func (wb *ABLevcc) get(cmd uint8) (int, error) {
+	return wb.conn.Int(wb.addr, cmd, "")
+}
+
+func (wb *ABLevcc) setPwm(pwm int) error {
+	_, err := wb.conn.Transact(wb.addr, ablEvccCmdSetPwm, fmt.Sprintf("%04d", pwm))
+	return err
+}
+
+// Status implements the api.Charger interface
+func (wb *ABLevcc) Status() (api.ChargeStatus, error) {
+	v, err := wb.get(ablEvccCmdStatus)
+	if err != nil {
+		return api.StatusNone, err
+	}
+
+	if status, ok := ablEvccStatus[v]; ok {
+		return status, nil
+	}
+
+	status, ok := ablEvccErrors[v]
+	if !ok {
+		status = fmt.Sprintf("%04d", v)
+	}
+
+	return api.StatusNone, fmt.Errorf("invalid status: %s", status)
+}
+
+// Enabled implements the api.Charger interface
+func (wb *ABLevcc) Enabled() (bool, error) {
+	v, err := wb.get(ablEvccCmdGetBreak)
+	if err != nil {
+		return false, err
+	}
+
+	wb.enabled = v == 0
+
+	return wb.enabled, nil
+}
+
+// Enable implements the api.Charger interface
+func (wb *ABLevcc) Enable(enable bool) error {
+	pwm, cmd := ablEvccPwmDisabled, uint8(ablEvccCmdSetBreak)
+	if enable {
+		pwm, cmd = wb.curr, ablEvccCmdClearBreak
+	}
+
+	// stop an ongoing charge before halting the state machine, apply the
+	// current before releasing it
+	if err := wb.setPwm(pwm); err != nil {
+		return err
+	}
+
+	if _, err := wb.conn.Transact(wb.addr, cmd, ""); err != nil {
+		return err
+	}
+
+	wb.enabled = enable
+
+	return nil
+}
+
+// MaxCurrent implements the api.Charger interface
+func (wb *ABLevcc) MaxCurrent(current int64) error {
+	return wb.MaxCurrentMillis(float64(current))
+}
+
+var _ api.ChargerEx = (*ABLevcc)(nil)
+
+// MaxCurrentMillis implements the api.ChargerEx interface
+func (wb *ABLevcc) MaxCurrentMillis(current float64) error {
+	if current < ablEvccMinCurrent {
+		return fmt.Errorf("invalid current %.1f", current)
+	}
+
+	pwm := ablEvccPwm(min(current, wb.maxA))
+
+	// don't lift the charging block while disabled
+	if wb.enabled {
+		if err := wb.setPwm(pwm); err != nil {
+			return err
+		}
+	}
+
+	wb.curr = pwm
+
+	return nil
+}
+
+var _ api.CurrentGetter = (*ABLevcc)(nil)
+
+// GetMaxCurrent implements the api.CurrentGetter interface
+func (wb *ABLevcc) GetMaxCurrent() (float64, error) {
+	v, err := wb.get(ablEvccCmdGetPwm)
+	if err != nil {
+		return 0, err
+	}
+
+	// outside of the signalling range the module does not offer any current
+	if v < ablEvccPwmMin || v > ablEvccPwmMax {
+		return 0, nil
+	}
+
+	return ablEvccCurrent(v), nil
+}
+
+// getMinMaxCurrent implements the api.CurrentLimiter interface
+func (wb *ABLevcc) getMinMaxCurrent() (float64, float64, error) {
+	return ablEvccMinCurrent, wb.maxA, nil
+}
+
+var _ api.Diagnosis = (*ABLevcc)(nil)
+
+// Diagnose implements the api.Diagnosis interface
+func (wb *ABLevcc) Diagnose() {
+	if s, err := wb.conn.Transact(wb.addr, ablEvccCmdFirmware, ""); err == nil {
+		fmt.Printf("\tFirmware: %s\n", s)
+	}
+	if v, err := wb.get(ablEvccCmdGetDefault); err == nil {
+		fmt.Printf("\tMax. current: %.1fA\n", ablEvccCurrent(v))
+	}
+	if v, err := wb.get(ablEvccCmdInputs); err == nil {
+		fmt.Printf("\tEnable input: %t\n", v&1 != 0)
+		fmt.Printf("\tLock input: %t\n", v&2 != 0)
+	}
+}
+
+var _ api.Resurrector = (*ABLevcc)(nil)
+
+// WakeUp implements the api.Resurrector interface
+func (wb *ABLevcc) WakeUp() error {
+	// CP off
+	if _, err := wb.conn.Transact(wb.addr, ablEvccCmdEnterAPrime, ""); err != nil {
+		return err
+	}
+
+	time.Sleep(3 * time.Second)
+
+	// CP on
+	_, err := wb.conn.Transact(wb.addr, ablEvccCmdLeaveAPrime, "")
+
+	return err
+}

--- a/charger/abl-evcc.go
+++ b/charger/abl-evcc.go
@@ -75,14 +75,6 @@ var ablEvccStatus = map[int]api.ChargeStatus{
 	6:  api.StatusC, // D  Charging with ventilation
 }
 
-var ablEvccErrors = map[int]string{
-	33:  "CS error",
-	35:  "EV error",
-	37:  "lock error",
-	39:  "ventilation error",
-	255: "manual mode",
-}
-
 func init() {
 	registry.AddCtx("abl-evcc", NewABLevccFromConfig)
 }
@@ -193,16 +185,12 @@ func (wb *ABLevcc) Status() (api.ChargeStatus, error) {
 		return api.StatusNone, err
 	}
 
-	if status, ok := ablEvccStatus[v]; ok {
-		return status, nil
-	}
-
-	status, ok := ablEvccErrors[v]
+	status, ok := ablEvccStatus[v]
 	if !ok {
-		status = fmt.Sprintf("%04d", v)
+		return api.StatusNone, fmt.Errorf("invalid status: %04d", v)
 	}
 
-	return api.StatusNone, fmt.Errorf("invalid status: %s", status)
+	return status, nil
 }
 
 // Enabled implements the api.Charger interface

--- a/charger/abl-evcc.go
+++ b/charger/abl-evcc.go
@@ -42,17 +42,17 @@ type ABLevcc struct {
 }
 
 const (
-	ablEvccCmdFirmware    = 1
-	ablEvccCmdStatus      = 2
-	ablEvccCmdInputs      = 10
-	ablEvccCmdGetPwm      = 11
-	ablEvccCmdSetPwm      = 12
-	ablEvccCmdGetDefault  = 26
-	ablEvccCmdSetBreak    = 27
-	ablEvccCmdClearBreak  = 28
-	ablEvccCmdGetBreak    = 29
-	ablEvccCmdEnterAPrime = 30
-	ablEvccCmdLeaveAPrime = 31
+	ablEvccCmdFirmware   = 1
+	ablEvccCmdStatus     = 2
+	ablEvccCmdInputs     = 10
+	ablEvccCmdGetPwm     = 11
+	ablEvccCmdSetPwm     = 12
+	ablEvccCmdGetDefault = 26
+	ablEvccCmdSetBreak   = 27
+	ablEvccCmdClearBreak = 28
+	ablEvccCmdGetBreak   = 29
+	ablEvccCmdLock       = 30
+	ablEvccCmdUnlock     = 31
 
 	ablEvccPwmMin      = 100 // 10.0% = 6A
 	ablEvccPwmMax      = 970 // 97.0% = 82.5A
@@ -65,14 +65,14 @@ const (
 // is mapped directly since api.ChargeStatusString only evaluates the first
 // character and would return both a status and an error for the error states.
 var ablEvccStatus = map[int]api.ChargeStatus{
-	0:  api.StatusA, // A  waiting for EV
-	17: api.StatusA, // A' CP off, EV detection disabled
-	4:  api.StatusB, // B2 enabled, waiting for charge request
-	9:  api.StatusB, // B' charging stopped by EV
-	12: api.StatusB, // B1 halted by bBreakCharge (undocumented)
-	13: api.StatusB, // B1 EV detected
-	5:  api.StatusC, // C  charging
-	6:  api.StatusC, // D  charging with ventilation
+	0:  api.StatusA, // A  Available - waiting for EV
+	17: api.StatusA, // A' Unavailable - CP off, EV detection disabled
+	4:  api.StatusB, // B2 SuspendedEV - enabled, waiting for charge request
+	9:  api.StatusB, // B' SuspendedEV - charging stopped by EV
+	12: api.StatusB, // B1 SuspendedEVSE - halted by bBreakCharge (undocumented)
+	13: api.StatusB, // B1 SuspendedEVSE - EV detected
+	5:  api.StatusC, // C  Charging
+	6:  api.StatusC, // D  Charging with ventilation
 }
 
 var ablEvccErrors = map[int]string{
@@ -309,14 +309,14 @@ var _ api.Resurrector = (*ABLevcc)(nil)
 // WakeUp implements the api.Resurrector interface
 func (wb *ABLevcc) WakeUp() error {
 	// CP off
-	if _, err := wb.conn.Transact(wb.addr, ablEvccCmdEnterAPrime, ""); err != nil {
+	if _, err := wb.conn.Transact(wb.addr, ablEvccCmdLock, ""); err != nil {
 		return err
 	}
 
 	time.Sleep(3 * time.Second)
 
 	// CP on
-	_, err := wb.conn.Transact(wb.addr, ablEvccCmdLeaveAPrime, "")
+	_, err := wb.conn.Transact(wb.addr, ablEvccCmdUnlock, "")
 
 	return err
 }

--- a/charger/abl-evcc.go
+++ b/charger/abl-evcc.go
@@ -54,11 +54,12 @@ const (
 	ablEvccCmdLock       = 30
 	ablEvccCmdUnlock     = 31
 
-	ablEvccPwmMin      = 100 // 10.0% = 6A
-	ablEvccPwmMax      = 970 // 97.0% = 82.5A
+	ablEvccPwmMin      = 80  // 8.0%, lower end of the signalling range
+	ablEvccPwmMax      = 970 // 97.0%, upper end of the signalling range
 	ablEvccPwmDisabled = 999 // charging not allowed
 
 	ablEvccMinCurrent = 6
+	ablEvccMaxCurrent = 80
 )
 
 // ablEvccStatus maps the device state machine to the charge status. The status
@@ -120,8 +121,8 @@ func NewABLevcc(ctx context.Context, device, uri string, addr uint8, timeout tim
 		Caps: implement.New(),
 		conn: conn,
 		addr: addr,
-		curr: ablEvccPwmMin,
-		maxA: ablEvccCurrent(ablEvccPwmMax),
+		curr: ablEvccPwm(ablEvccMinCurrent),
+		maxA: ablEvccMaxCurrent,
 	}
 
 	// verify device presence
@@ -143,30 +144,34 @@ func NewABLevcc(ctx context.Context, device, uri string, addr uint8, timeout tim
 }
 
 // ablEvccCurrent converts a duty cycle in 0.1% steps into the signalled current
+// according to IEC 61851-1 table A.8
 func ablEvccCurrent(pwm int) float64 {
 	d := float64(pwm) / 10
 
-	if d > 85 {
+	switch {
+	case d < 10:
+		return ablEvccMinCurrent
+	case d <= 85:
+		return d * 0.6
+	case d <= 96:
 		return (d - 64) * 2.5
+	default:
+		return ablEvccMaxCurrent
 	}
-
-	return d * 0.6
 }
 
 // ablEvccPwm converts a current into a duty cycle in 0.1% steps
 func ablEvccPwm(current float64) int {
-	var pwm int
+	current = min(max(current, ablEvccMinCurrent), ablEvccMaxCurrent)
 
 	switch {
 	case current <= 51:
-		pwm = int(math.Round(current / 0.06))
+		return int(math.Round(current / 0.06))
 	case current < 52.75:
-		pwm = 850 // gap between both duty cycle ranges, limit to 51A
+		return 850 // gap between both duty cycle ranges, limit to 51A
 	default:
-		pwm = int(math.Round((current/2.5 + 64) * 10))
+		return int(math.Round((current/2.5 + 64) * 10))
 	}
-
-	return min(max(pwm, ablEvccPwmMin), ablEvccPwmMax)
 }
 
 func (wb *ABLevcc) get(cmd uint8) (int, error) {

--- a/charger/abl-evcc_test.go
+++ b/charger/abl-evcc_test.go
@@ -84,10 +84,9 @@ func TestABLevccStatus(t *testing.T) {
 		assert.Equal(t, expected, ablEvccStatus[code], "%04d", code)
 	}
 
-	// error states must not be mapped to a charge status
+	// error and manual states must not be mapped to a charge status
 	for _, code := range []int{33, 35, 37, 39, 255} {
 		_, ok := ablEvccStatus[code]
 		assert.False(t, ok, "%04d", code)
-		assert.NotEmpty(t, ablEvccErrors[code], "%04d", code)
 	}
 }

--- a/charger/abl-evcc_test.go
+++ b/charger/abl-evcc_test.go
@@ -29,18 +29,18 @@ func TestABLevccPwm(t *testing.T) {
 		current float64
 		pwm     int
 	}{
-		{0, ablEvccPwmMin},   // clamped
-		{6, 100},             // 10.0%
-		{10, 167},            // 16.7%
-		{16, 267},            // 26.7%
-		{32, 533},            // 53.3%
-		{51, 850},            // 85.0%, upper end of the linear range
-		{52, 850},            // gap between both ranges
-		{53, 852},            // 85.2%
-		{63, 892},            // 89.2%
-		{80, 960},            // 96.0%
-		{82.5, 970},          // 97.0%
-		{100, ablEvccPwmMax}, // clamped
+		{0, 100},    // clamped to 6A
+		{6, 100},    // 10.0%
+		{10, 167},   // 16.7%
+		{16, 267},   // 26.7%
+		{32, 533},   // 53.3%
+		{51, 850},   // 85.0%, upper end of the linear range
+		{52, 850},   // gap between both ranges
+		{53, 852},   // 85.2%
+		{63, 892},   // 89.2%
+		{80, 960},   // 96.0%
+		{82.5, 960}, // clamped to 80A
+		{100, 960},  // clamped to 80A
 	} {
 		assert.Equal(t, tc.pwm, ablEvccPwm(tc.current), "%.1fA", tc.current)
 	}
@@ -51,12 +51,15 @@ func TestABLevccCurrent(t *testing.T) {
 		pwm     int
 		current float64
 	}{
-		{100, 6},
+		{80, 6},  // 8.0%, lower band signals 6A
+		{99, 6},  // 9.9%
+		{100, 6}, // 10.0%
 		{267, 16.02},
 		{850, 51},
 		{852, 53},
 		{960, 80},
-		{970, 82.5},
+		{961, 80}, // 96.1%, upper band signals 80A
+		{970, 80}, // 97.0%
 	} {
 		assert.InDelta(t, tc.current, ablEvccCurrent(tc.pwm), 0.001, "%d", tc.pwm)
 	}

--- a/charger/abl-evcc_test.go
+++ b/charger/abl-evcc_test.go
@@ -1,0 +1,93 @@
+package charger
+
+import (
+	"testing"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/api/implement"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestABLevccCapabilities(t *testing.T) {
+	wb := &ABLevcc{Caps: implement.New()}
+
+	assert.True(t, api.HasCap[api.Charger](wb))
+	assert.True(t, api.HasCap[api.ChargerEx](wb))
+	assert.True(t, api.HasCap[api.CurrentGetter](wb))
+	assert.True(t, api.HasCap[api.Diagnosis](wb))
+	assert.True(t, api.HasCap[api.Resurrector](wb))
+
+	// only registered when the module reports its default current
+	assert.False(t, api.HasCap[api.CurrentLimiter](wb))
+
+	implement.Has(wb, implement.CurrentLimiter(wb.getMinMaxCurrent))
+	assert.True(t, api.HasCap[api.CurrentLimiter](wb))
+}
+
+func TestABLevccPwm(t *testing.T) {
+	for _, tc := range []struct {
+		current float64
+		pwm     int
+	}{
+		{0, ablEvccPwmMin},   // clamped
+		{6, 100},             // 10.0%
+		{10, 167},            // 16.7%
+		{16, 267},            // 26.7%
+		{32, 533},            // 53.3%
+		{51, 850},            // 85.0%, upper end of the linear range
+		{52, 850},            // gap between both ranges
+		{53, 852},            // 85.2%
+		{63, 892},            // 89.2%
+		{80, 960},            // 96.0%
+		{82.5, 970},          // 97.0%
+		{100, ablEvccPwmMax}, // clamped
+	} {
+		assert.Equal(t, tc.pwm, ablEvccPwm(tc.current), "%.1fA", tc.current)
+	}
+}
+
+func TestABLevccCurrent(t *testing.T) {
+	for _, tc := range []struct {
+		pwm     int
+		current float64
+	}{
+		{100, 6},
+		{267, 16.02},
+		{850, 51},
+		{852, 53},
+		{960, 80},
+		{970, 82.5},
+	} {
+		assert.InDelta(t, tc.current, ablEvccCurrent(tc.pwm), 0.001, "%d", tc.pwm)
+	}
+}
+
+// every representable current must survive the round trip
+func TestABLevccCurrentRoundtrip(t *testing.T) {
+	for _, current := range []float64{6, 8, 10, 13, 16, 20, 24, 32, 40, 51, 53, 63, 70, 80} {
+		res := ablEvccCurrent(ablEvccPwm(current))
+		assert.InDelta(t, current, res, 0.03, "%.1fA", current)
+	}
+}
+
+func TestABLevccStatus(t *testing.T) {
+	// documented states must map to a charge status
+	for code, expected := range map[int]api.ChargeStatus{
+		0:  api.StatusA,
+		4:  api.StatusB,
+		5:  api.StatusC,
+		6:  api.StatusC,
+		9:  api.StatusB,
+		13: api.StatusB,
+		17: api.StatusA,
+	} {
+		assert.Equal(t, expected, ablEvccStatus[code], "%04d", code)
+	}
+
+	// error states must not be mapped to a charge status
+	for _, code := range []int{33, 35, 37, 39, 255} {
+		_, ok := ablEvccStatus[code]
+		assert.False(t, ok, "%04d", code)
+		assert.NotEmpty(t, ablEvccErrors[code], "%04d", code)
+	}
+}

--- a/charger/ablevcc/connection.go
+++ b/charger/ablevcc/connection.go
@@ -1,0 +1,307 @@
+package ablevcc
+
+// LICENSE
+
+// Copyright (c) evcc.io (andig, naltatis, premultiply)
+
+// This module is NOT covered by the MIT license. All rights reserved.
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/evcc-io/evcc/util"
+	"go.bug.st/serial"
+)
+
+const (
+	// Baudrate is the fixed EVCC line speed
+	Baudrate = 38400
+
+	// Timeout is the default reply timeout
+	Timeout = 2 * time.Second
+)
+
+// ErrRejected indicates that the device did not accept the command
+var ErrRejected = errors.New("command rejected")
+
+var (
+	mu        sync.Mutex
+	instances = make(map[string]*Connection)
+)
+
+// Connection is a shared RS485 bus connection. Since all modules on the bus answer
+// on the same wire, transactions are serialized across all chargers using it.
+type Connection struct {
+	mu      sync.Mutex
+	log     *util.Logger
+	dial    func() (io.ReadWriteCloser, error)
+	timeout time.Duration
+	conn    io.ReadWriteCloser
+	r       *bufio.Reader
+	closed  bool
+}
+
+// Instance returns the shared connection for the given bus. Chargers on the same
+// device or uri share a single physical connection.
+func Instance(ctx context.Context, log *util.Logger, device, uri string, timeout time.Duration) (*Connection, error) {
+	if (device == "") == (uri == "") {
+		return nil, errors.New("can only have either uri or device")
+	}
+
+	if timeout <= 0 {
+		timeout = Timeout
+	}
+
+	key := device + uri
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if conn, ok := instances[key]; ok {
+		return conn, nil
+	}
+
+	conn := &Connection{
+		log:     log,
+		timeout: timeout,
+		dial:    dialer(device, uri, timeout),
+	}
+
+	// release the port on shutdown
+	go func() {
+		<-ctx.Done()
+
+		conn.mu.Lock()
+		defer conn.mu.Unlock()
+
+		conn.closed = true
+		conn.close()
+	}()
+
+	instances[key] = conn
+
+	return conn, nil
+}
+
+// dialer creates the transport specific connect function
+func dialer(device, uri string, timeout time.Duration) func() (io.ReadWriteCloser, error) {
+	if device != "" {
+		return func() (io.ReadWriteCloser, error) {
+			port, err := serial.Open(device, &serial.Mode{
+				BaudRate: Baudrate,
+				DataBits: 8,
+				Parity:   serial.NoParity,
+				StopBits: serial.OneStopBit,
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			if err := port.SetReadTimeout(timeout); err != nil {
+				_ = port.Close()
+				return nil, err
+			}
+
+			return &serialPort{port}, nil
+		}
+	}
+
+	return func() (io.ReadWriteCloser, error) {
+		conn, err := net.DialTimeout("tcp", uri, timeout)
+		if err != nil {
+			return nil, err
+		}
+
+		return &tcpPort{Conn: conn, timeout: timeout}, nil
+	}
+}
+
+// serialPort translates the serial read timeout convention into an error.
+// go.bug.st/serial signals a read timeout as (0, nil) which would make bufio
+// spin until it gives up with io.ErrNoProgress.
+type serialPort struct {
+	serial.Port
+}
+
+func (p *serialPort) Read(b []byte) (int, error) {
+	n, err := p.Port.Read(b)
+	if n == 0 && err == nil {
+		return 0, os.ErrDeadlineExceeded
+	}
+
+	return n, err
+}
+
+// tcpPort applies the read timeout to an Ethernet-RS485 adapter
+type tcpPort struct {
+	net.Conn
+	timeout time.Duration
+}
+
+func (p *tcpPort) Read(b []byte) (int, error) {
+	if err := p.Conn.SetReadDeadline(time.Now().Add(p.timeout)); err != nil {
+		return 0, err
+	}
+
+	return p.Conn.Read(b)
+}
+
+// Transact sends a command to the given module address and returns the reply data.
+// Data is returned verbatim since the firmware reply is not numeric.
+func (c *Connection) Transact(addr, cmd uint8, payload string) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var res string
+	var err error
+
+	// retry once on communication error, but never on a rejected command
+	for range 2 {
+		if res, err = c.transact(addr, cmd, payload); err == nil || errors.Is(err, ErrRejected) {
+			break
+		}
+
+		// drop the connection so that the next attempt reconnects
+		c.close()
+	}
+
+	return res, err
+}
+
+// Int sends a command and converts the numeric reply
+func (c *Connection) Int(addr, cmd uint8, payload string) (int, error) {
+	s, err := c.Transact(addr, cmd, payload)
+	if err != nil {
+		return 0, err
+	}
+
+	res, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid data: %q", s)
+	}
+
+	return res, nil
+}
+
+func (c *Connection) transact(addr, cmd uint8, payload string) (string, error) {
+	if err := c.connect(); err != nil {
+		return "", err
+	}
+
+	req := fmt.Sprintf("!%d %02d\r\n", addr, cmd)
+	if payload != "" {
+		req = fmt.Sprintf("!%d %02d %s\r\n", addr, cmd, payload)
+	}
+
+	// discard leftover replies of previous transactions
+	c.r.Reset(c.conn)
+
+	c.log.TRACE.Printf("send: %q", req)
+
+	if _, err := c.conn.Write([]byte(req)); err != nil {
+		return "", err
+	}
+
+	// modules of other addresses may answer on the same bus
+	for deadline := time.Now().Add(c.timeout); time.Now().Before(deadline); {
+		line, err := c.r.ReadString('\n')
+		if err != nil {
+			return "", err
+		}
+
+		c.log.TRACE.Printf("recv: %q", line)
+
+		resAddr, resCmd, data, err := parse(line)
+		if err != nil || resAddr != addr || resCmd != cmd {
+			continue
+		}
+
+		if data == "ERR" {
+			return "", fmt.Errorf("%w: %02d", ErrRejected, cmd)
+		}
+
+		return data, nil
+	}
+
+	return "", os.ErrDeadlineExceeded
+}
+
+func (c *Connection) connect() error {
+	if c.closed {
+		return net.ErrClosed
+	}
+
+	if c.conn != nil {
+		return nil
+	}
+
+	conn, err := c.dial()
+	if err != nil {
+		return err
+	}
+
+	c.conn = conn
+	c.r = bufio.NewReader(conn)
+
+	return nil
+}
+
+func (c *Connection) close() {
+	if c.conn != nil {
+		_ = c.conn.Close()
+		c.conn = nil
+		c.r = nil
+	}
+}
+
+// parse splits a device reply of the form ">n cc[ data]". The device is known to
+// pad replies with additional spaces.
+func parse(line string) (uint8, uint8, string, error) {
+	rest, ok := strings.CutPrefix(strings.TrimSpace(line), ">")
+	if !ok {
+		return 0, 0, "", fmt.Errorf("invalid reply: %q", line)
+	}
+
+	f := strings.Fields(rest)
+	if len(f) < 2 || len(f) > 3 {
+		return 0, 0, "", fmt.Errorf("invalid reply: %q", line)
+	}
+
+	addr, err := strconv.ParseUint(f[0], 10, 8)
+	if err != nil {
+		return 0, 0, "", fmt.Errorf("invalid address: %q", line)
+	}
+
+	cmd, err := strconv.ParseUint(f[1], 10, 8)
+	if err != nil {
+		return 0, 0, "", fmt.Errorf("invalid command: %q", line)
+	}
+
+	var data string
+	if len(f) == 3 {
+		data = f[2]
+	}
+
+	return uint8(addr), uint8(cmd), data, nil
+}

--- a/charger/ablevcc/connection.go
+++ b/charger/ablevcc/connection.go
@@ -55,9 +55,9 @@ var (
 type Connection struct {
 	mu      sync.Mutex
 	log     *util.Logger
-	dial    func() (io.ReadWriteCloser, error)
+	dial    func() (port, error)
 	timeout time.Duration
-	conn    io.ReadWriteCloser
+	conn    port
 	r       *bufio.Reader
 	closed  bool
 	refs    int // number of chargers using the connection, guarded by the package mutex
@@ -126,11 +126,17 @@ func release(key string, conn *Connection) {
 	conn.close()
 }
 
+// port is the transport with net.Conn deadline semantics
+type port interface {
+	io.ReadWriteCloser
+	SetReadDeadline(t time.Time) error
+}
+
 // dialer creates the transport specific connect function
-func dialer(device, uri string, timeout time.Duration) func() (io.ReadWriteCloser, error) {
+func dialer(device, uri string, timeout time.Duration) func() (port, error) {
 	if device != "" {
-		return func() (io.ReadWriteCloser, error) {
-			port, err := serial.Open(device, &serial.Mode{
+		return func() (port, error) {
+			p, err := serial.Open(device, &serial.Mode{
 				BaudRate: Baudrate,
 				DataBits: 8,
 				Parity:   serial.NoParity,
@@ -140,32 +146,27 @@ func dialer(device, uri string, timeout time.Duration) func() (io.ReadWriteClose
 				return nil, err
 			}
 
-			if err := port.SetReadTimeout(timeout); err != nil {
-				_ = port.Close()
-				return nil, err
-			}
-
-			return &serialPort{port}, nil
+			return &serialPort{p}, nil
 		}
 	}
 
-	return func() (io.ReadWriteCloser, error) {
-		conn, err := net.DialTimeout("tcp", uri, timeout)
-		if err != nil {
-			return nil, err
-		}
-
-		return &tcpPort{Conn: conn, timeout: timeout}, nil
+	return func() (port, error) {
+		return net.DialTimeout("tcp", uri, timeout)
 	}
 }
 
-// serialPort translates the serial read timeout convention into an error.
-// go.bug.st/serial signals a read timeout as (0, nil) which would make bufio
-// spin until it gives up with io.ErrNoProgress.
+// serialPort adapts go.bug.st/serial to net.Conn deadline semantics
 type serialPort struct {
 	serial.Port
 }
 
+func (p *serialPort) SetReadDeadline(t time.Time) error {
+	return p.Port.SetReadTimeout(max(time.Until(t), 0))
+}
+
+// Read translates the serial read timeout convention into an error. The port
+// signals a timeout as (0, nil) which would make bufio spin until it gives up
+// with io.ErrNoProgress.
 func (p *serialPort) Read(b []byte) (int, error) {
 	n, err := p.Port.Read(b)
 	if n == 0 && err == nil {
@@ -173,20 +174,6 @@ func (p *serialPort) Read(b []byte) (int, error) {
 	}
 
 	return n, err
-}
-
-// tcpPort applies the read timeout to an Ethernet-RS485 adapter
-type tcpPort struct {
-	net.Conn
-	timeout time.Duration
-}
-
-func (p *tcpPort) Read(b []byte) (int, error) {
-	if err := p.Conn.SetReadDeadline(time.Now().Add(p.timeout)); err != nil {
-		return 0, err
-	}
-
-	return p.Conn.Read(b)
 }
 
 // Transact sends a command to the given module address and returns the reply data.
@@ -245,8 +232,14 @@ func (c *Connection) transact(addr, cmd uint8, payload string) (string, error) {
 		return "", err
 	}
 
+	deadline := time.Now().Add(c.timeout)
+
 	// modules of other addresses may answer on the same bus
-	for deadline := time.Now().Add(c.timeout); time.Now().Before(deadline); {
+	for time.Now().Before(deadline) {
+		if err := c.conn.SetReadDeadline(deadline); err != nil {
+			return "", err
+		}
+
 		line, err := c.r.ReadString('\n')
 		if err != nil {
 			return "", err

--- a/charger/ablevcc/connection.go
+++ b/charger/ablevcc/connection.go
@@ -60,6 +60,7 @@ type Connection struct {
 	conn    io.ReadWriteCloser
 	r       *bufio.Reader
 	closed  bool
+	refs    int // number of chargers using the connection, guarded by the package mutex
 }
 
 // Instance returns the shared connection for the given bus. Chargers on the same
@@ -73,35 +74,56 @@ func Instance(ctx context.Context, log *util.Logger, device, uri string, timeout
 		timeout = Timeout
 	}
 
-	key := device + uri
+	key := "uri:" + uri
+	if device != "" {
+		key = "device:" + device
+	}
 
 	mu.Lock()
 	defer mu.Unlock()
 
-	if conn, ok := instances[key]; ok {
-		return conn, nil
+	conn, ok := instances[key]
+	if !ok {
+		conn = &Connection{
+			log:     log,
+			timeout: timeout,
+			dial:    dialer(device, uri, timeout),
+		}
+
+		instances[key] = conn
 	}
 
-	conn := &Connection{
-		log:     log,
-		timeout: timeout,
-		dial:    dialer(device, uri, timeout),
-	}
+	conn.refs++
 
-	// release the port on shutdown
+	// release the connection once the last charger using it is gone
 	go func() {
 		<-ctx.Done()
-
-		conn.mu.Lock()
-		defer conn.mu.Unlock()
-
-		conn.closed = true
-		conn.close()
+		release(key, conn)
 	}()
 
-	instances[key] = conn
-
 	return conn, nil
+}
+
+func release(key string, conn *Connection) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	conn.refs--
+	if conn.refs > 0 {
+		return
+	}
+
+	// the key may already refer to a newer connection
+	if instances[key] == conn {
+		delete(instances, key)
+	}
+
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
+
+	// prevent late callers from reopening the port
+	conn.closed = true
+	conn.close()
 }
 
 // dialer creates the transport specific connect function

--- a/charger/ablevcc/connection_test.go
+++ b/charger/ablevcc/connection_test.go
@@ -47,8 +47,8 @@ func testConnection(t *testing.T, replies ...string) *Connection {
 	return &Connection{
 		log:     util.NewLogger("test"),
 		timeout: 100 * time.Millisecond,
-		dial: func() (io.ReadWriteCloser, error) {
-			return &tcpPort{Conn: client, timeout: 100 * time.Millisecond}, nil
+		dial: func() (port, error) {
+			return client, nil
 		},
 	}
 }
@@ -99,6 +99,38 @@ func TestTransactTimeout(t *testing.T) {
 	_, err := c.Transact(1, 2, "")
 	require.Error(t, err)
 	assert.NotErrorIs(t, err, ErrRejected)
+}
+
+// a late reply of another module must not restart the timeout
+func TestTransactDeadline(t *testing.T) {
+	client, device := net.Pipe()
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = device.Close()
+	})
+
+	go func() {
+		r := bufio.NewReader(device)
+		if _, err := r.ReadString('\n'); err != nil {
+			return
+		}
+
+		time.Sleep(150 * time.Millisecond)
+		_, _ = io.WriteString(device, ">2 02 0000\r\n")
+	}()
+
+	c := &Connection{
+		log:     util.NewLogger("test"),
+		timeout: 200 * time.Millisecond,
+		dial: func() (port, error) {
+			return client, nil
+		},
+	}
+
+	start := time.Now()
+	_, err := c.Transact(1, 2, "")
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 300*time.Millisecond)
 }
 
 func TestTransactFirmware(t *testing.T) {

--- a/charger/ablevcc/connection_test.go
+++ b/charger/ablevcc/connection_test.go
@@ -2,6 +2,7 @@ package ablevcc
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"net"
 	"testing"
@@ -169,4 +170,64 @@ func TestInstanceShared(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Same(t, c1, c2, "chargers on the same bus must share the connection")
+}
+
+func TestInstanceDistinctTransports(t *testing.T) {
+	log := util.NewLogger("test")
+
+	c1, err := Instance(t.Context(), log, "foo", "", 0)
+	require.NoError(t, err)
+
+	c2, err := Instance(t.Context(), log, "", "foo", 0)
+	require.NoError(t, err)
+
+	assert.NotSame(t, c1, c2, "device and uri of the same name must not share the connection")
+}
+
+// a cancelled context must remove the connection from the pool so that a
+// recreated charger (config reload, failed constructor, device test) gets a fresh one
+func TestInstanceReleased(t *testing.T) {
+	log := util.NewLogger("test")
+	ctx, cancel := context.WithCancel(t.Context())
+
+	c1, err := Instance(ctx, log, "", "localhost:14197", 0)
+	require.NoError(t, err)
+
+	cancel()
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		_, ok := instances["uri:localhost:14197"]
+		return !ok
+	}, time.Second, 10*time.Millisecond)
+
+	c2, err := Instance(t.Context(), log, "", "localhost:14197", 0)
+	require.NoError(t, err)
+	assert.NotSame(t, c1, c2)
+
+	// late callers must not reopen the port
+	_, err = c1.Transact(1, 2, "")
+	assert.ErrorIs(t, err, net.ErrClosed)
+}
+
+// the connection must survive as long as any charger on the bus is alive
+func TestInstanceRefcount(t *testing.T) {
+	log := util.NewLogger("test")
+	ctx1, cancel1 := context.WithCancel(t.Context())
+
+	c1, err := Instance(ctx1, log, "", "localhost:14198", 0)
+	require.NoError(t, err)
+
+	c2, err := Instance(t.Context(), log, "", "localhost:14198", 0)
+	require.NoError(t, err)
+	require.Same(t, c1, c2)
+
+	cancel1()
+
+	assert.Never(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return instances["uri:localhost:14198"] != c2
+	}, 100*time.Millisecond, 10*time.Millisecond, "connection released while still in use")
 }

--- a/charger/ablevcc/connection_test.go
+++ b/charger/ablevcc/connection_test.go
@@ -1,0 +1,172 @@
+package ablevcc
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testConnection wires a Connection to an in-memory device answering with replies.
+// The device answers each request with the corresponding entry, the last entry is
+// repeated for further requests. An empty entry means no answer at all.
+func testConnection(t *testing.T, replies ...string) *Connection {
+	t.Helper()
+
+	client, device := net.Pipe()
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = device.Close()
+	})
+
+	go func() {
+		r := bufio.NewReader(device)
+
+		for i := 0; ; i++ {
+			if _, err := r.ReadString('\n'); err != nil {
+				return
+			}
+
+			reply := replies[min(i, len(replies)-1)]
+			if reply == "" {
+				continue
+			}
+
+			if _, err := io.WriteString(device, reply); err != nil {
+				return
+			}
+		}
+	}()
+
+	return &Connection{
+		log:     util.NewLogger("test"),
+		timeout: 100 * time.Millisecond,
+		dial: func() (io.ReadWriteCloser, error) {
+			return &tcpPort{Conn: client, timeout: 100 * time.Millisecond}, nil
+		},
+	}
+}
+
+func TestTransact(t *testing.T) {
+	c := testConnection(t, ">1 02 0005\r\n")
+
+	res, err := c.Transact(1, 2, "")
+	require.NoError(t, err)
+	assert.Equal(t, "0005", res)
+}
+
+func TestTransactExcessSpaces(t *testing.T) {
+	c := testConnection(t, ">1  02   0005 \r\n")
+
+	res, err := c.Transact(1, 2, "")
+	require.NoError(t, err)
+	assert.Equal(t, "0005", res)
+}
+
+func TestTransactAck(t *testing.T) {
+	c := testConnection(t, ">1 12\r\n")
+
+	res, err := c.Transact(1, 12, "0267")
+	require.NoError(t, err)
+	assert.Empty(t, res)
+}
+
+// replies of other modules on the same bus must be skipped
+func TestTransactForeignAddress(t *testing.T) {
+	c := testConnection(t, ">2 02 0000\r\n>1 02 0005\r\n")
+
+	res, err := c.Transact(1, 2, "")
+	require.NoError(t, err)
+	assert.Equal(t, "0005", res)
+}
+
+func TestTransactRejected(t *testing.T) {
+	c := testConnection(t, ">1 12 ERR\r\n")
+
+	_, err := c.Transact(1, 12, "0999")
+	assert.ErrorIs(t, err, ErrRejected)
+}
+
+func TestTransactTimeout(t *testing.T) {
+	c := testConnection(t, "")
+
+	_, err := c.Transact(1, 2, "")
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrRejected)
+}
+
+func TestTransactFirmware(t *testing.T) {
+	c := testConnection(t, ">1 01 V2.3\r\n")
+
+	res, err := c.Transact(1, 1, "")
+	require.NoError(t, err)
+	assert.Equal(t, "V2.3", res)
+}
+
+func TestInt(t *testing.T) {
+	c := testConnection(t, ">1 26 0267\r\n")
+
+	res, err := c.Int(1, 26, "")
+	require.NoError(t, err)
+	assert.Equal(t, 267, res)
+}
+
+func TestParse(t *testing.T) {
+	for _, tc := range []struct {
+		line string
+		addr uint8
+		cmd  uint8
+		data string
+		err  bool
+	}{
+		{">1 02 0005\r\n", 1, 2, "0005", false},
+		{">1 02\r\n", 1, 2, "", false},
+		{">8  11   0850  \r\n", 8, 11, "0850", false},
+		{">1 01 V2.3\r\n", 1, 1, "V2.3", false},
+		{">1 12 ERR\r\n", 1, 12, "ERR", false},
+		{"!1 02 0005\r\n", 0, 0, "", true}, // request echo
+		{">1\r\n", 0, 0, "", true},
+		{">1 02 0005 0006\r\n", 0, 0, "", true},
+		{">x 02\r\n", 0, 0, "", true},
+		{"", 0, 0, "", true},
+	} {
+		addr, cmd, data, err := parse(tc.line)
+
+		if tc.err {
+			assert.Error(t, err, tc.line)
+			continue
+		}
+
+		require.NoError(t, err, tc.line)
+		assert.Equal(t, tc.addr, addr, tc.line)
+		assert.Equal(t, tc.cmd, cmd, tc.line)
+		assert.Equal(t, tc.data, data, tc.line)
+	}
+}
+
+func TestInstanceRequiresSingleTransport(t *testing.T) {
+	log := util.NewLogger("test")
+
+	_, err := Instance(t.Context(), log, "", "", 0)
+	assert.Error(t, err)
+
+	_, err = Instance(t.Context(), log, "/dev/ttyUSB0", "localhost:4196", 0)
+	assert.Error(t, err)
+}
+
+func TestInstanceShared(t *testing.T) {
+	log := util.NewLogger("test")
+
+	c1, err := Instance(t.Context(), log, "", "localhost:14196", 0)
+	require.NoError(t, err)
+
+	c2, err := Instance(t.Context(), log, "", "localhost:14196", 0)
+	require.NoError(t, err)
+
+	assert.Same(t, c1, c2, "chargers on the same bus must share the connection")
+}

--- a/templates/definition/charger/abl-evcc.yaml
+++ b/templates/definition/charger/abl-evcc.yaml
@@ -22,7 +22,7 @@ requirements:
       Der maximal einstellbare Ladestrom wird durch den am Modul hinterlegten
       Default-Ladestrom begrenzt (Werkseinstellung 16 A).
     en: |
-      For early ABL wallboxes with EVCC control module only (no modbus).
+      For early ABL wallboxes with EVCC control module only (no Modbus).
 
       Communication uses RS485 (38400 Bd, 8N1), either via a USB-RS485 adapter
       (`device`) or an Ethernet-RS485 adapter (`uri`).
@@ -38,8 +38,8 @@ params:
       de: Serieller Anschluss (USB-RS485-Adapter)
       en: Serial port (USB-RS485 adapter)
     help:
-      de: z. B. /dev/ttyUSB0 — gegenseitig ausschließend mit uri
-      en: e.g. /dev/ttyUSB0 — mutually exclusive with uri
+      de: z. B. /dev/ttyUSB0, alternativ zu uri
+      en: e.g. /dev/ttyUSB0, alternative to uri
     service: hardware/serial
     example: /dev/ttyUSB0
   - name: uri
@@ -47,8 +47,8 @@ params:
       de: TCP-Endpunkt eines Ethernet-RS485-Adapters
       en: TCP endpoint of an Ethernet-RS485 adapter
     help:
-      de: z. B. localhost:4196 — gegenseitig ausschließend mit device
-      en: e.g. localhost:4196 — mutually exclusive with device
+      de: z. B. localhost:4196, alternativ zu device
+      en: e.g. localhost:4196, alternative to device
     example: localhost:4196
   - name: address
     description:

--- a/templates/definition/charger/abl-evcc.yaml
+++ b/templates/definition/charger/abl-evcc.yaml
@@ -1,0 +1,70 @@
+template: abl-evcc
+products:
+  - brand: ABL
+    description:
+      generic: EVCC Controller
+  - brand: E.ON
+    description:
+      generic: Ladebox (EVSE101/201/203/205)
+capabilities: ["mA", "dim"]
+requirements:
+  evcc: ["sponsorship"]
+  description:
+    de: |
+      Nur für frühe ABL-Wallboxen mit EVCC-Steuermodul (ohne Modbus).
+
+      Die Anbindung erfolgt über RS485 (38400 Bd, 8N1), entweder mit einem
+      USB-RS485-Adapter (`device`) oder einem Ethernet-RS485-Adapter (`uri`).
+      Der Bus ist an beiden Enden mit je 120 Ω abzuschließen.
+
+      Mehrere Wallboxen an einem Bus: jedem Modul eine eigene Adresse (1..8) zuweisen.
+
+      Der maximal einstellbare Ladestrom wird durch den am Modul hinterlegten
+      Default-Ladestrom begrenzt (Werkseinstellung 16 A).
+    en: |
+      For early ABL wallboxes with EVCC control module only (no modbus).
+
+      Communication uses RS485 (38400 Bd, 8N1), either via a USB-RS485 adapter
+      (`device`) or an Ethernet-RS485 adapter (`uri`).
+      Terminate the bus with 120 Ω at both ends.
+
+      For multiple wallboxes on one bus assign an individual address (1..8) to each module.
+
+      The maximum current is limited by the module's default charging current
+      (factory setting 16 A).
+params:
+  - name: device
+    description:
+      de: Serieller Anschluss (USB-RS485-Adapter)
+      en: Serial port (USB-RS485 adapter)
+    help:
+      de: z. B. /dev/ttyUSB0 — gegenseitig ausschließend mit uri
+      en: e.g. /dev/ttyUSB0 — mutually exclusive with uri
+    service: hardware/serial
+    example: /dev/ttyUSB0
+  - name: uri
+    description:
+      de: TCP-Endpunkt eines Ethernet-RS485-Adapters
+      en: TCP endpoint of an Ethernet-RS485 adapter
+    help:
+      de: z. B. localhost:4196 — gegenseitig ausschließend mit device
+      en: e.g. localhost:4196 — mutually exclusive with device
+    example: localhost:4196
+  - name: address
+    description:
+      de: Busadresse (1..8)
+      en: Bus address (1..8)
+    type: int
+    default: 1
+  - name: timeout
+    default: 2s
+    advanced: true
+render: |
+  type: abl-evcc
+  {{- if .uri }}
+  uri: {{ .uri }}
+  {{- else }}
+  device: {{ .device }}
+  {{- end }}
+  address: {{ .address }}
+  timeout: {{ .timeout }}


### PR DESCRIPTION
replaces #33494

Adds support for early ABL SURSUM wallboxes built around the pre-Modbus EVCC control module, found e.g. in the E.ON Ladebox (EVSE101/201/203/205). These modules speak a line-based ASCII protocol over RS485 (38400 Bd, 8N1) and are not covered by the existing `abl` implementation. Written from scratch against the [protocol documentation](https://web.archive.org/web/20160122105853/http://www.abl-sursum.com/global/downloads/bedienungsanleitungen/EVCC.pdf) following the established charger patterns.

- Serial (`device`) or Ethernet-RS485 adapter (`uri`), mutually exclusive
- One shared, reference counted bus connection per device or uri, so multiple wallboxes (addresses 1..8) can use a single adapter. Transactions are serialized bus-wide and replies are matched by address and command
- Current is set as direct duty cycle in 0.1% steps (`mA` capability). Current mapping follows IEC 61851-1 including the 6 A and 80 A edge bands
- The module's default current is reported as upper limit via `CurrentLimiter` and not modified
- Enable/disable via "charging not allowed" plus `bBreakCharge`; enabled state is read back from the break flag, which is unambiguous in every module state
- Wake-up by toggling CP through state A'
- Sponsorship required

**TODO**
- [ ] Verify on hardware that PWM 0999 terminates an ongoing charge in state C, otherwise additionally send "stop charging"
- [ ] Verify undocumented state code 0012, assumed to be B1 with `bBreakCharge` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)
