### PR TITLE
go-e: add status reason for access control

### DIFF
--- a/charger/go-e.go
+++ b/charger/go-e.go
@@ -77,6 +77,7 @@ func newGoEFromConfig(v2 bool, other map[string]any) (api.Charger, error) {
 
 	if c.api.IsV2() {
 		implement.Has(c, implement.PhaseSwitcher(c.phases1p3p))
+		implement.Has(c, implement.StatusReasoner(c.statusReason))
 	}
 
 	return c, nil
@@ -110,6 +111,7 @@ func (c *GoE) Status() (api.ChargeStatus, error) {
 		return api.StatusNone, err
 	}
 
+	// Unknown/Error=0, Idle=1, Charging=2, WaitCar=3, Complete=4, Error=5, Initializing=6
 	switch car := resp.Status(); car {
 	case 1:
 		return api.StatusA, nil
@@ -120,6 +122,20 @@ func (c *GoE) Status() (api.ChargeStatus, error) {
 	default:
 		return api.StatusNone, fmt.Errorf("car unknown result: %d", car)
 	}
+}
+
+// statusReason implements the api.StatusReasoner interface - v2 only
+func (c *GoE) statusReason() (api.Reason, error) {
+	resp, err := c.api.Status()
+	if err != nil {
+		return api.ReasonUnknown, err
+	}
+
+	if resp.ModelStatus() == goe.ModelStatusAccessControl {
+		return api.ReasonWaitingForAuthorization, nil
+	}
+
+	return api.ReasonUnknown, nil
 }
 
 // Enabled implements the api.Charger interface

--- a/charger/go-e.go
+++ b/charger/go-e.go
@@ -131,7 +131,7 @@ func (c *GoE) statusReason() (api.Reason, error) {
 		return api.ReasonUnknown, err
 	}
 
-	if resp.ModelStatus() == goe.ModelStatusAccessControl {
+	if resp.AccessControl() {
 		return api.ReasonWaitingForAuthorization, nil
 	}
 

--- a/charger/go-e/api.go
+++ b/charger/go-e/api.go
@@ -16,7 +16,7 @@ const CloudURI = "https://api.go-e.co"
 type Response interface {
 	Status() int
 	Enabled() bool
-	ModelStatus() int
+	AccessControl() bool
 	CurrentPower() float64
 	ChargedEnergy() float64
 	TotalEnergy() float64

--- a/charger/go-e/api.go
+++ b/charger/go-e/api.go
@@ -16,6 +16,7 @@ const CloudURI = "https://api.go-e.co"
 type Response interface {
 	Status() int
 	Enabled() bool
+	ModelStatus() int
 	CurrentPower() float64
 	ChargedEnergy() float64
 	TotalEnergy() float64
@@ -85,7 +86,7 @@ func (c *LocalAPI) response(partial string, res any) error {
 func (c *LocalAPI) status() (Response, error) {
 	if c.v2 {
 		var res StatusResponse2
-		err := c.response("status?filter=alw,car,eto,nrg,wh,trx,cards", &res)
+		err := c.response("status?filter=alw,car,eto,nrg,wh,trx,cards,modelStatus", &res)
 		return &res, err
 	}
 

--- a/charger/go-e/api_test.go
+++ b/charger/go-e/api_test.go
@@ -59,7 +59,7 @@ func TestLocalV2(t *testing.T) {
 	h.expect("/api/status?filter=alw")
 	local := NewLocal(util.NewLogger("foo"), srv.URL, 0)
 
-	h.expect("/api/status?filter=alw,car,eto,nrg,wh,trx,cards")
+	h.expect("/api/status?filter=alw,car,eto,nrg,wh,trx,cards,modelStatus")
 	if _, err := local.Status(); err != nil {
 		t.Error(err)
 	}

--- a/charger/go-e/types.go
+++ b/charger/go-e/types.go
@@ -41,9 +41,9 @@ func (g *StatusResponse) Enabled() bool {
 	return g.Alw == 1
 }
 
-// ModelStatus is not available in the v1 api
-func (g *StatusResponse) ModelStatus() int {
-	return 0
+// AccessControl is not available in the v1 api
+func (g *StatusResponse) AccessControl() bool {
+	return false
 }
 
 func (g *StatusResponse) CurrentPower() float64 {

--- a/charger/go-e/types.go
+++ b/charger/go-e/types.go
@@ -41,6 +41,11 @@ func (g *StatusResponse) Enabled() bool {
 	return g.Alw == 1
 }
 
+// ModelStatus is not available in the v1 api
+func (g *StatusResponse) ModelStatus() int {
+	return 0
+}
+
 func (g *StatusResponse) CurrentPower() float64 {
 	if len(g.Nrg) == 16 {
 		return g.Nrg[11] * 10

--- a/charger/go-e/types2.go
+++ b/charger/go-e/types2.go
@@ -5,20 +5,20 @@ const ModelStatusAccessControl = 2
 
 // StatusResponse2 is the v2 API response
 type StatusResponse2 struct {
-	Fwv   string    // firmware version
-	Car   int       // car status
-	Alw   bool      // allow charging
-	Amp   int       // current [A]
-	Err   int       // error
-	Eto   uint64    // energy total Wh
-	Psm   int       // phase switching
-	Stp   int       // stop state
-	Tmp   int       // temperature [°C]
-	Trx   int       // transaction
-	Nrg   []float64 // voltage, current, power
-	Wh    float64   // energy [Wh]
-	Cards []Card    // RFID cards
-	Msd   int       `json:"modelStatus"` // reason why charging is allowed or not
+	Fwv         string    // firmware version
+	Car         int       // car status
+	Alw         bool      // allow charging
+	Amp         int       // current [A]
+	Err         int       // error
+	Eto         uint64    // energy total Wh
+	Psm         int       // phase switching
+	Stp         int       // stop state
+	Tmp         int       // temperature [°C]
+	Trx         int       // transaction
+	Nrg         []float64 // voltage, current, power
+	Wh          float64   // energy [Wh]
+	Cards       []Card    // RFID cards
+	ModelStatus int       // reason why charging is allowed or not
 }
 
 // Card is the v2 RFID card
@@ -36,8 +36,8 @@ func (g *StatusResponse2) Enabled() bool {
 	return g.Alw
 }
 
-func (g *StatusResponse2) ModelStatus() int {
-	return g.Msd
+func (g *StatusResponse2) AccessControl() bool {
+	return g.ModelStatus == ModelStatusAccessControl
 }
 
 func (g *StatusResponse2) CurrentPower() float64 {

--- a/charger/go-e/types2.go
+++ b/charger/go-e/types2.go
@@ -1,5 +1,8 @@
 package goe
 
+// ModelStatusAccessControl is the v2 modelStatus NotChargingBecauseAccessControl
+const ModelStatusAccessControl = 2
+
 // StatusResponse2 is the v2 API response
 type StatusResponse2 struct {
 	Fwv   string    // firmware version
@@ -15,6 +18,7 @@ type StatusResponse2 struct {
 	Nrg   []float64 // voltage, current, power
 	Wh    float64   // energy [Wh]
 	Cards []Card    // RFID cards
+	Msd   int       `json:"modelStatus"` // reason why charging is allowed or not
 }
 
 // Card is the v2 RFID card
@@ -30,6 +34,10 @@ func (g *StatusResponse2) Status() int {
 
 func (g *StatusResponse2) Enabled() bool {
 	return g.Alw
+}
+
+func (g *StatusResponse2) ModelStatus() int {
+	return g.Msd
 }
 
 func (g *StatusResponse2) CurrentPower() float64 {

--- a/charger/go-e_test.go
+++ b/charger/go-e_test.go
@@ -11,11 +11,13 @@ import (
 )
 
 type handler struct {
-	uri string
+	uri  string
+	body string
 }
 
 func (h *handler) expect(uri string) {
 	h.uri = uri
+	h.body = "{}"
 }
 
 func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -25,7 +27,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if path == h.uri {
-		fmt.Fprint(w, "{}")
+		fmt.Fprint(w, h.body)
 	} else {
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintf(w, "expected %s", h.uri)
@@ -54,6 +56,10 @@ func TestGoEV1(t *testing.T) {
 	if _, ok := api.Cap[api.Identifier](wb); !ok {
 		t.Error("missing Identifier api")
 	}
+
+	if _, ok := api.Cap[api.StatusReasoner](wb); ok {
+		t.Error("unexpected StatusReasoner api")
+	}
 }
 
 func TestGoEV2(t *testing.T) {
@@ -64,7 +70,7 @@ func TestGoEV2(t *testing.T) {
 
 	sponsor.Subject = "foo"
 
-	wb, err := newGoEFromConfig(false, map[string]any{"uri": srv.URL})
+	wb, err := newGoEFromConfig(false, map[string]any{"uri": srv.URL, "cache": "0s"})
 	if err != nil {
 		t.Error(err)
 	}
@@ -87,5 +93,32 @@ func TestGoEV2(t *testing.T) {
 
 	if _, ok := api.Cap[api.PhaseSwitcher](wb); !ok {
 		t.Error("missing PhaseSwitcher api")
+	}
+
+	sr, ok := api.Cap[api.StatusReasoner](wb)
+	if !ok {
+		t.Fatal("missing StatusReasoner api")
+	}
+
+	h.expect("/api/status?filter=alw,car,eto,nrg,wh,trx,cards,modelStatus")
+
+	for _, tc := range []struct {
+		body   string
+		reason api.Reason
+	}{
+		{`{"modelStatus":2}`, api.ReasonWaitingForAuthorization},
+		{`{"modelStatus":3}`, api.ReasonUnknown},
+		{`{}`, api.ReasonUnknown},
+	} {
+		h.body = tc.body
+
+		reason, err := sr.StatusReason()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if reason != tc.reason {
+			t.Errorf("%s: expected %v, got %v", tc.body, tc.reason, reason)
+		}
 	}
 }


### PR DESCRIPTION
Adds `api.StatusReasoner` support for go-e chargers using the v2 API: `modelStatus` is added to the status filter and `NotChargingBecauseAccessControl` (2) is mapped to `ReasonWaitingForAuthorization`, so the UI shows that RFID/app authorization is pending while the vehicle is connected.

`Status()` is unchanged: only unambiguous `car` states are mapped (1→A, 2→C, 3/4→B); 0/5/6 (Unknown, Error, Initializing) are deliberately treated as errors.

Related: #33650