### PR TITLE
Issue triage: apply area label alongside type Bug, fix label names

### DIFF
--- a/.github/workflows/claude-issue-agent-run.yml
+++ b/.github/workflows/claude-issue-agent-run.yml
@@ -136,14 +136,17 @@ jobs:
 
             If MODE is "triage", also do the following:
 
-            3. LABEL: Based on your investigation, pick the single best label from this
-               set and apply it with
+            3. LABEL: Based on your investigation, pick the single best area label from
+               this set and apply it with
                `gh issue edit ${{ inputs.issue_number }} --add-label <label>`:
-               enhancement, documentation, question, device, tariff, vehicle, heating.
-               Only ever apply a label from this existing set — never create a new label.
+               enhancement, documentation, question, devices, tariffs, vehicles, heating.
+               Only ever apply a label from this existing set, spelled exactly as
+               listed — never create a new label.
+               Skip the area label only if the issue already has one of these labels.
                NEVER apply a `bug` label. A bug is expressed as the issue type only
-               (`gh issue edit ${{ inputs.issue_number }} --type Bug`).
-               Skip this step if the issue already has one of these labels or type Bug.
+               (`gh issue edit ${{ inputs.issue_number }} --type Bug`). The type is
+               set IN ADDITION to the area label, never instead of it: a confirmed
+               tariff bug gets both `tariffs` and type Bug.
                - Be reluctant to classify as a bug. Set type Bug ONLY when the report
                  gives clear, reproducible evidence of a genuine software defect that
                  you confirmed against the code, and your step 2 comment states that

--- a/.github/workflows/claude-issue-agent-run.yml
+++ b/.github/workflows/claude-issue-agent-run.yml
@@ -153,8 +153,8 @@ jobs:
                  cause without asking the reporter anything. Missing information, an
                  unreproducible report, a screenshot in place of logs/data, or any
                  doubt between a software defect and a configuration/user error all
-                 mean: do NOT set type Bug — pick a better fitting label (e.g.
-                 `question`) or leave it unlabeled, and explain why in your comment.
+                 mean: do NOT set type Bug — the area label alone (falling back to
+                 `question`) is enough, and explain why in your comment.
                  Default away from Bug.
                - If your step 2 comment contains ANY question to the reporter — missing
                  information, a request to confirm your diagnosis, a "could you check


### PR DESCRIPTION
Triage run for #33653 set type Bug but applied no label, a maintainer added `tariffs` by hand. Two causes in the triage prompt of `claude-issue-agent-run.yml`:

- "pick the single best label ... skip this step if the issue already has ... type Bug" made the agent treat type Bug as the label choice. Confirmed bugs never got an area label.
- The label set named `device`, `tariff`, `vehicle`. Repo labels are `devices`, `tariffs`, `vehicles`, so `gh issue edit --add-label` would have failed for those three anyway.

Changes: area label always required (skip only if one already present), type Bug stated as additional, label names corrected to the existing ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)