### PR TITLE
Loadpoint: log when circuit limit falls below min current

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -999,7 +999,11 @@ func (lp *Loadpoint) setLimit(current float64) error {
 		powerLimit := lp.circuit.ValidatePower(lp.chargePower, currentToPower(current, activePhases))
 		currentLimitViaPower := powerToCurrent(powerLimit, activePhases)
 
-		current = lp.roundedCurrent(min(currentLimit, currentLimitViaPower))
+		limited := lp.roundedCurrent(min(currentLimit, currentLimitViaPower))
+		if minCurrent := lp.effectiveMinCurrent(); limited < minCurrent && current >= minCurrent {
+			lp.log.DEBUG.Printf("circuit limit %.3gA below min current %.3gA", limited, minCurrent)
+		}
+		current = limited
 	}
 
 	// https://github.com/evcc-io/evcc/issues/16309


### PR DESCRIPTION
Ref #33187

When a circuit caps the requested current below the loadpoint's effective minimum, `setLimit` silently skips enabling the charger. The only trace is the circuit's `validate power` line, which requires knowing the loadpoint's minimum power to interpret.

Add a debug line so the stuck-at-status-B case is visible:

```
circuit limit 5.5A below min current 6A
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)