### PR TITLE
Loadpoint: always use wrapper charge rater and timer

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -141,10 +141,9 @@ type Loadpoint struct {
 	vehicleDetectTicker *clock.Ticker
 	vehicleIdentifier   string
 
-	charger          api.Charger
-	chargeTimer      api.ChargeTimer
-	chargeRater      api.ChargeRater
-	chargedAtStartup float64 // session energy at startup
+	charger     api.Charger
+	chargeTimer *wrapper.ChargeTimer
+	chargeRater *wrapper.ChargeRater
 
 	circuit        api.Circuit        // Circuit
 	chargeMeter    *chargeMeter       // Charger usage meter
@@ -468,35 +467,27 @@ func (lp *Loadpoint) configureChargerType(charger api.Charger) {
 		}
 	}
 
-	// ensure charge rater exists
-	// measurement are obtained from separate charge meter if defined
+	// charge rater; measurements are obtained from separate charge meter if defined
 	// (https://github.com/evcc-io/evcc/issues/2469)
-	if rt, ok := api.Cap[api.ChargeRater](charger); ok && integrated {
-		lp.chargeRater = rt
-
-		// when restarting in the middle of charging session, use this as negative offset
-		if f, err := rt.ChargedEnergy(); err == nil {
-			lp.chargedAtStartup = f
-		}
-	} else {
-		rt := wrapper.NewChargeRater(lp.log, lp.chargeMeter)
-		_ = lp.bus.Subscribe(evChargePower, rt.SetChargePower)
-		_ = lp.bus.Subscribe(evVehicleConnect, func() { rt.StartCharge(false) })
-		_ = lp.bus.Subscribe(evChargeStart, func() { rt.StartCharge(true) })
-		_ = lp.bus.Subscribe(evChargeStop, rt.StopCharge)
-		lp.chargeRater = rt
+	var upstream api.ChargeRater
+	if integrated {
+		upstream, _ = api.Cap[api.ChargeRater](charger)
 	}
 
-	// ensure charge timer exists
-	if ct, ok := api.Cap[api.ChargeTimer](charger); ok {
-		lp.chargeTimer = ct
-	} else {
-		ct := wrapper.NewChargeTimer()
-		_ = lp.bus.Subscribe(evVehicleConnect, func() { ct.StartCharge(false) })
-		_ = lp.bus.Subscribe(evChargeStart, func() { ct.StartCharge(true) })
-		_ = lp.bus.Subscribe(evChargeStop, ct.StopCharge)
-		lp.chargeTimer = ct
-	}
+	rt := wrapper.NewChargeRater(lp.log, lp.chargeMeter, upstream)
+	_ = lp.bus.Subscribe(evChargePower, rt.SetChargePower)
+	_ = lp.bus.Subscribe(evVehicleConnect, func() { rt.StartCharge(false) })
+	_ = lp.bus.Subscribe(evChargeStart, func() { rt.StartCharge(true) })
+	_ = lp.bus.Subscribe(evChargeStop, rt.StopCharge)
+	lp.chargeRater = rt
+
+	// charge timer
+	timer, _ := api.Cap[api.ChargeTimer](charger)
+	ct := wrapper.NewChargeTimer(timer)
+	_ = lp.bus.Subscribe(evVehicleConnect, func() { ct.StartCharge(false) })
+	_ = lp.bus.Subscribe(evChargeStart, func() { ct.StartCharge(true) })
+	_ = lp.bus.Subscribe(evChargeStop, ct.StopCharge)
+	lp.chargeTimer = ct
 
 	// add wakeup timer
 	lp.wakeUpTimer = NewTimer()
@@ -636,9 +627,6 @@ func (lp *Loadpoint) evVehicleDisconnectHandler() {
 
 	// charge status
 	lp.publish(keys.ChargerStatusReason, api.ReasonUnknown)
-
-	// forget startup energy offset
-	lp.chargedAtStartup = 0
 
 	// remove charger vehicle id and stop potential detection
 	lp.setVehicleIdentifier("")
@@ -2013,16 +2001,14 @@ func (lp *Loadpoint) updateChargeVoltages() {
 // publish charged energy and duration
 func (lp *Loadpoint) publishChargeProgress() {
 	if f, err := lp.chargeRater.ChargedEnergy(); err == nil {
-		// workaround for Go-E resetting during disconnect, see
-		// https://github.com/evcc-io/evcc/issues/5092
-		switch session := f - lp.chargedAtStartup; {
-		case session > maxSessionEnergy:
+		switch {
+		case f > maxSessionEnergy:
 			// guard against meters reporting register garbage, see
 			// https://github.com/evcc-io/evcc/issues/32159
-			lp.log.WARN.Printf("ignoring implausible session energy: %.3fkWh", session)
+			lp.log.WARN.Printf("ignoring implausible session energy: %.3fkWh", f)
 
-		case session > 0:
-			added, addedGreen := lp.energyMetrics.Update(session)
+		case f > 0:
+			added, addedGreen := lp.energyMetrics.Update(f)
 			if added > 0 {
 				lp.log.DEBUG.Printf("session energy: %.3fkWh", f)
 			}

--- a/core/loadpoint_phases_test.go
+++ b/core/loadpoint_phases_test.go
@@ -248,8 +248,8 @@ func TestPvScalePhases(t *testing.T) {
 			bus:              evbus.New(),
 			clock:            clock,
 			chargeMeter:      newChargeMeter(&Null{}), // silence nil panics
-			chargeRater:      &Null{},                 // silence nil panics
-			chargeTimer:      &Null{},                 // silence nil panics
+			chargeRater:      nullRater(),             // silence nil panics
+			chargeTimer:      nullTimer(),             // silence nil panics
 			progress:         NewProgress(0, 10),      // silence nil panics
 			wakeUpTimer:      NewTimer(),              // silence nil panics
 			mode:             api.ModeNow,
@@ -767,8 +767,8 @@ func TestUpdatePhaseSwitchNotAvailable(t *testing.T) {
 		bus:         evbus.New(),
 		clock:       clock,
 		chargeMeter: newChargeMeter(&Null{}),
-		chargeRater: &Null{},
-		chargeTimer: &Null{},
+		chargeRater: nullRater(),
+		chargeTimer: nullTimer(),
 		progress:    NewProgress(0, 10),
 		wakeUpTimer: NewTimer(),
 		mode:        api.ModeNow,
@@ -854,8 +854,8 @@ func TestPvScalePhasesCircuitLimits(t *testing.T) {
 				bus:            evbus.New(),
 				clock:          clock.NewMock(),
 				chargeMeter:    newChargeMeter(&Null{}),
-				chargeRater:    &Null{},
-				chargeTimer:    &Null{},
+				chargeRater:    nullRater(),
+				chargeTimer:    nullTimer(),
 				progress:       NewProgress(0, 10),
 				wakeUpTimer:    NewTimer(),
 				mode:           api.ModeNow,

--- a/core/loadpoint_session.go
+++ b/core/loadpoint_session.go
@@ -8,7 +8,6 @@ import (
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/core/keys"
 	"github.com/evcc-io/evcc/core/session"
-	"github.com/evcc-io/evcc/core/wrapper"
 	"github.com/evcc-io/evcc/tariff"
 	"github.com/jinzhu/now"
 )
@@ -152,14 +151,13 @@ func (lp *Loadpoint) finalizeSessionEnergy() {
 		return
 	}
 
-	chargedKWh := f - lp.chargedAtStartup
-	if chargedKWh <= s.ChargedEnergy {
+	if f <= s.ChargedEnergy {
 		return
 	}
 
-	lp.log.DEBUG.Printf("session energy: %.3f -> %.3fkWh", s.ChargedEnergy, chargedKWh)
+	lp.log.DEBUG.Printf("session energy: %.3f -> %.3fkWh", s.ChargedEnergy, f)
 
-	lp.energyMetrics.Update(chargedKWh)
+	lp.energyMetrics.Update(f)
 
 	lp.applyEnergyMetrics(s)
 }
@@ -176,12 +174,8 @@ func (lp *Loadpoint) resetHeatingSession() {
 	lp.stopSession()
 	lp.clearSession()
 
-	if cr, ok := lp.chargeRater.(wrapper.ChargeResetter); ok {
-		cr.ResetCharge()
-	}
-	if ct, ok := lp.chargeTimer.(wrapper.ChargeResetter); ok {
-		ct.ResetCharge()
-	}
+	lp.chargeRater.ResetCharge()
+	lp.chargeTimer.ResetCharge()
 
 	lp.createSession()
 }

--- a/core/loadpoint_session_test.go
+++ b/core/loadpoint_session_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/benbjohnson/clock"
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/core/session"
+	"github.com/evcc-io/evcc/core/wrapper"
 	serverdb "github.com/evcc-io/evcc/db"
 	"github.com/evcc-io/evcc/util"
 	"github.com/stretchr/testify/assert"
@@ -228,6 +229,8 @@ func TestResetHeatingSession(t *testing.T) {
 		db:          db,
 		charger:     charger,
 		chargeMeter: newChargeMeter(cm),
+		chargeRater: nullRater(),
+		chargeTimer: nullTimer(),
 	}
 
 	// create session
@@ -272,6 +275,7 @@ func TestFinalizeSessionEnergy(t *testing.T) {
 		mm := api.NewMockMeter(ctrl)
 		me := api.NewMockMeterEnergy(ctrl)
 		rater := api.NewMockChargeRater(ctrl)
+		rater.EXPECT().ChargedEnergy().Return(0.0, nil) // startup offset
 
 		type EnergyDecorator struct {
 			api.Meter
@@ -287,7 +291,7 @@ func TestFinalizeSessionEnergy(t *testing.T) {
 			log:         util.NewLogger("foo"),
 			clock:       clock.NewMock(),
 			db:          db,
-			chargeRater: rater,
+			chargeRater: wrapper.NewChargeRater(util.NewLogger("foo"), nil, rater),
 			chargeMeter: newChargeMeter(cm),
 		}
 		return lp, me, rater

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evcc-io/evcc/core/loadpoint"
 	"github.com/evcc-io/evcc/core/settings"
 	"github.com/evcc-io/evcc/core/soc"
+	"github.com/evcc-io/evcc/core/wrapper"
 	"github.com/evcc-io/evcc/messenger"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/config"
@@ -29,12 +30,12 @@ func (n *Null) CurrentPower() (float64, error) {
 	return 0, nil
 }
 
-func (n *Null) ChargedEnergy() (float64, error) {
-	return 0, nil
+func nullRater() *wrapper.ChargeRater {
+	return wrapper.NewChargeRater(util.NewLogger("null"), nil, nil)
 }
 
-func (n *Null) ChargeDuration() (time.Duration, error) {
-	return 0, nil
+func nullTimer() *wrapper.ChargeTimer {
+	return wrapper.NewChargeTimer(nil)
 }
 
 func createChannels(t *testing.T) (chan util.Param, chan messenger.Event, chan *Loadpoint) {
@@ -166,8 +167,8 @@ func TestUpdatePowerZero(t *testing.T) {
 			clock:       clock,
 			charger:     charger,
 			chargeMeter: newChargeMeter(&Null{}), // silence nil panics
-			chargeRater: &Null{},                 // silence nil panics
-			chargeTimer: &Null{},                 // silence nil panics
+			chargeRater: nullRater(),             // silence nil panics
+			chargeTimer: nullTimer(),             // silence nil panics
 			wakeUpTimer: NewTimer(),
 			minCurrent:  minA,
 			maxCurrent:  maxA,
@@ -405,8 +406,8 @@ func TestDisableAndEnableAtTargetSoc(t *testing.T) {
 		clock:       clock,
 		charger:     charger,
 		chargeMeter: newChargeMeter(&Null{}), // silence nil panics
-		chargeRater: &Null{},                 // silence nil panics
-		chargeTimer: &Null{},                 // silence nil panics
+		chargeRater: nullRater(),             // silence nil panics
+		chargeTimer: nullTimer(),             // silence nil panics
 		progress:    NewProgress(0, 10),      // silence nil panics
 		wakeUpTimer: NewTimer(),              // silence nil panics
 		// coordinator:   coordinator.NewDummy(), // silence nil panics
@@ -485,8 +486,8 @@ func TestSetModeAndSocAtDisconnect(t *testing.T) {
 		settings:    settings.NewDatabaseSettingsAdapter("foo"),
 		charger:     charger,
 		chargeMeter: newChargeMeter(&Null{}), // silence nil panics
-		chargeRater: &Null{},                 // silence nil panics
-		chargeTimer: &Null{},                 // silence nil panics
+		chargeRater: nullRater(),             // silence nil panics
+		chargeTimer: nullTimer(),             // silence nil panics
 		wakeUpTimer: NewTimer(),
 		minCurrent:  minA,
 		maxCurrent:  maxA,
@@ -545,6 +546,7 @@ func TestChargedEnergyAtDisconnect(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	charger := api.NewMockCharger(ctrl)
 	rater := api.NewMockChargeRater(ctrl)
+	rater.EXPECT().ChargedEnergy().Return(0.0, nil) // startup offset
 
 	lp := &Loadpoint{
 		log:         util.NewLogger("foo"),
@@ -552,8 +554,8 @@ func TestChargedEnergyAtDisconnect(t *testing.T) {
 		clock:       clock,
 		charger:     charger,
 		chargeMeter: newChargeMeter(&Null{}), // silence nil panics
-		chargeRater: rater,
-		chargeTimer: &Null{}, // silence nil panics
+		chargeRater: wrapper.NewChargeRater(util.NewLogger("foo"), nil, rater),
+		chargeTimer: nullTimer(), // silence nil panics
 		wakeUpTimer: NewTimer(),
 		minCurrent:  minA,
 		maxCurrent:  maxA,
@@ -799,8 +801,8 @@ func TestConnectionDurationDropDetection(t *testing.T) {
 		minCurrent:  minA,
 		maxCurrent:  maxA,
 		chargeMeter: newChargeMeter(&Null{}), // silence nil panics
-		chargeRater: &Null{},                 // silence nil panics
-		chargeTimer: &Null{},                 // silence nil panics
+		chargeRater: nullRater(),             // silence nil panics
+		chargeTimer: nullTimer(),             // silence nil panics
 		wakeUpTimer: NewTimer(),              // silence nil panics
 	}
 
@@ -847,8 +849,8 @@ func TestWelcomeChargeAppliedOnlyOnce(t *testing.T) {
 		minCurrent:  minA,
 		maxCurrent:  maxA,
 		chargeMeter: newChargeMeter(&Null{}), // silence nil panics
-		chargeRater: &Null{},                 // silence nil panics
-		chargeTimer: &Null{},                 // silence nil panics
+		chargeRater: nullRater(),             // silence nil panics
+		chargeTimer: nullTimer(),             // silence nil panics
 		wakeUpTimer: NewTimer(),              // silence nil panics
 	}
 

--- a/core/loadpoint_vehicle_test.go
+++ b/core/loadpoint_vehicle_test.go
@@ -42,8 +42,8 @@ func TestPublishSocAndRange(t *testing.T) {
 		charger:      charger,
 		vehicle:      vehicle,
 		chargeMeter:  newChargeMeter(&Null{}), // silence nil panics
-		chargeRater:  &Null{},                 // silence nil panics
-		chargeTimer:  &Null{},                 // silence nil panics
+		chargeRater:  nullRater(),             // silence nil panics
+		chargeTimer:  nullTimer(),             // silence nil panics
 		socEstimator: soc.NewEstimator(log, vehicle),
 		minCurrent:   minA,
 		maxCurrent:   maxA,
@@ -158,8 +158,8 @@ func TestPublishSocAndRangeVehiclesAndChargers(t *testing.T) {
 			charger:     tc.charger,
 			vehicle:     tc.vehicle,
 			chargeMeter: newChargeMeter(&Null{}), // silence nil panics
-			chargeRater: &Null{},                 // silence nil panics
-			chargeTimer: &Null{},                 // silence nil panics
+			chargeRater: nullRater(),             // silence nil panics
+			chargeTimer: nullTimer(),             // silence nil panics
 			minCurrent:  minA,
 			maxCurrent:  maxA,
 			phases:      1,
@@ -211,8 +211,8 @@ func TestPublishSocAndRangeEnergyLimit(t *testing.T) {
 		charger:      api.NewMockCharger(ctrl),
 		vehicle:      vehicle,
 		chargeMeter:  newChargeMeter(&Null{}), // silence nil panics
-		chargeRater:  &Null{},                 // silence nil panics
-		chargeTimer:  &Null{},                 // silence nil panics
+		chargeRater:  nullRater(),             // silence nil panics
+		chargeTimer:  nullTimer(),             // silence nil panics
 		socEstimator: soc.NewEstimator(log, vehicle),
 		minCurrent:   minA,
 		maxCurrent:   maxA,
@@ -621,8 +621,8 @@ func TestReconnectVehicle(t *testing.T) {
 				clock:       clck,
 				charger:     charger,
 				chargeMeter: newChargeMeter(&Null{}), // silence nil panics
-				chargeRater: &Null{},                 // silence nil panics
-				chargeTimer: &Null{},                 // silence nil panics
+				chargeRater: nullRater(),             // silence nil panics
+				chargeTimer: nullTimer(),             // silence nil panics
 				wakeUpTimer: NewTimer(),
 				minCurrent:  minA,
 				maxCurrent:  maxA,

--- a/core/site_prioritize_test.go
+++ b/core/site_prioritize_test.go
@@ -135,8 +135,8 @@ func TestReservedPVPowerSmartFeedInPause(t *testing.T) {
 			car.clock = clck
 			car.charger = &feedInCharger{status: tc.status, enabled: tc.enabled}
 			car.chargeMeter = newChargeMeter(&Null{}) // silence nil panics
-			car.chargeRater = &Null{}                 // silence nil panics
-			car.chargeTimer = &Null{}                 // silence nil panics
+			car.chargeRater = nullRater()             // silence nil panics
+			car.chargeTimer = nullTimer()             // silence nil panics
 			car.wakeUpTimer = NewTimer()
 			car.smartFeedInPriorityLimit = &limit
 			car.vehicleSoc = 20

--- a/core/wrapper/chargerater.go
+++ b/core/wrapper/chargerater.go
@@ -20,7 +20,7 @@ type ChargeRater struct {
 	clck          clock.Clock
 	meter         api.Meter
 	upstream      api.ChargeRater // charger-provided session energy, takes precedence over meter
-	offset        float64         // upstream energy at startup, see https://github.com/evcc-io/evcc/issues/5092
+	offset        *float64        // upstream energy at startup, nil until read (https://github.com/evcc-io/evcc/issues/5092)
 	charging      bool
 	start         time.Time
 	startEnergy   *float64 // nil until baseline successfully read from meter
@@ -41,7 +41,7 @@ func NewChargeRater(log *util.Logger, meter api.Meter, upstream api.ChargeRater)
 	// when restarting in the middle of charging session, use this as negative offset
 	if upstream != nil {
 		if f, err := upstream.ChargedEnergy(); err == nil {
-			cr.offset = f
+			cr.offset = &f
 		}
 	}
 
@@ -111,8 +111,9 @@ func (cr *ChargeRater) ResetCharge() {
 
 	// upstream keeps counting, everything so far belongs to the previous session
 	if cr.upstream != nil {
+		cr.offset = nil
 		if f, err := cr.upstream.ChargedEnergy(); err == nil {
-			cr.offset = f
+			cr.offset = &f
 		}
 		return
 	}
@@ -165,12 +166,17 @@ func (cr *ChargeRater) ChargedEnergy() (float64, error) {
 			return 0, err
 		}
 
-		// charger reset its counter, e.g. at start of a new session
-		if f < cr.offset {
-			cr.offset = 0
+		// late-latch offset if it could not be read before
+		if cr.offset == nil {
+			cr.offset = &f
 		}
 
-		return f - cr.offset, nil
+		// charger reset its counter, e.g. at start of a new session
+		if f < *cr.offset {
+			cr.offset = new(0.0)
+		}
+
+		return f - *cr.offset, nil
 	}
 
 	// return previously charged energy

--- a/core/wrapper/chargerater.go
+++ b/core/wrapper/chargerater.go
@@ -19,24 +19,33 @@ type ChargeRater struct {
 	log           *util.Logger
 	clck          clock.Clock
 	meter         api.Meter
+	upstream      api.ChargeRater // charger-provided session energy, takes precedence over meter
+	offset        float64         // upstream energy at startup, see https://github.com/evcc-io/evcc/issues/5092
 	charging      bool
 	start         time.Time
 	startEnergy   *float64 // nil until baseline successfully read from meter
 	chargedEnergy float64
 }
 
-// ChargeResetter resets the charging session
-type ChargeResetter interface {
-	ResetCharge()
-}
-
-// NewChargeRater creates charge rater and initializes realtime clock
-func NewChargeRater(log *util.Logger, meter api.Meter) *ChargeRater {
-	return &ChargeRater{
-		log:   log,
-		clck:  clock.New(),
-		meter: meter,
+// NewChargeRater creates charge rater and initializes realtime clock.
+// Session energy is taken from upstream if given, otherwise from the meter's
+// TotalEnergy or integrated from charge power.
+func NewChargeRater(log *util.Logger, meter api.Meter, upstream api.ChargeRater) *ChargeRater {
+	cr := &ChargeRater{
+		log:      log,
+		clck:     clock.New(),
+		meter:    meter,
+		upstream: upstream,
 	}
+
+	// when restarting in the middle of charging session, use this as negative offset
+	if upstream != nil {
+		if f, err := upstream.ChargedEnergy(); err == nil {
+			cr.offset = f
+		}
+	}
+
+	return cr
 }
 
 // StartCharge records meter start energy. If meter does not supply TotalEnergy,
@@ -44,6 +53,10 @@ func NewChargeRater(log *util.Logger, meter api.Meter) *ChargeRater {
 func (cr *ChargeRater) StartCharge(continued bool) {
 	cr.Lock()
 	defer cr.Unlock()
+
+	if cr.upstream != nil {
+		return
+	}
 
 	// time is needed if MeterEnergy is not supported
 	cr.start = cr.clck.Now()
@@ -72,6 +85,10 @@ func (cr *ChargeRater) StopCharge() {
 	cr.Lock()
 	defer cr.Unlock()
 
+	if cr.upstream != nil {
+		return
+	}
+
 	cr.charging = false
 
 	// get end energy amount
@@ -87,12 +104,18 @@ func (cr *ChargeRater) StopCharge() {
 	}
 }
 
-var _ ChargeResetter = (*ChargeRater)(nil)
-
-// ChargeResetter resets the charging session
+// ResetCharge resets the charging session
 func (cr *ChargeRater) ResetCharge() {
 	cr.Lock()
 	defer cr.Unlock()
+
+	// upstream keeps counting, everything so far belongs to the previous session
+	if cr.upstream != nil {
+		if f, err := cr.upstream.ChargedEnergy(); err == nil {
+			cr.offset = f
+		}
+		return
+	}
 
 	// get end energy amount
 	if m, ok := api.Cap[api.MeterEnergy](cr.meter); ok {
@@ -117,7 +140,7 @@ func (cr *ChargeRater) SetChargePower(power float64) {
 	cr.Lock()
 	defer cr.Unlock()
 
-	if !cr.charging {
+	if cr.upstream != nil || !cr.charging {
 		return
 	}
 
@@ -135,6 +158,20 @@ func (cr *ChargeRater) SetChargePower(power float64) {
 func (cr *ChargeRater) ChargedEnergy() (float64, error) {
 	cr.Lock()
 	defer cr.Unlock()
+
+	if cr.upstream != nil {
+		f, err := cr.upstream.ChargedEnergy()
+		if err != nil {
+			return 0, err
+		}
+
+		// charger reset its counter, e.g. at start of a new session
+		if f < cr.offset {
+			cr.offset = 0
+		}
+
+		return f - cr.offset, nil
+	}
 
 	// return previously charged energy
 	if !cr.charging {

--- a/core/wrapper/chargerater_test.go
+++ b/core/wrapper/chargerater_test.go
@@ -204,4 +204,32 @@ func TestUpstream(t *testing.T) {
 	if f, err := cr.ChargedEnergy(); f != 0.5 || err != nil {
 		t.Errorf("energy: %.1f %v", f, err)
 	}
+
+	// charger unavailable during reset latches the offset on next read
+	up.EXPECT().ChargedEnergy().Return(0.0, errors.New("not available"))
+	cr.ResetCharge()
+
+	up.EXPECT().ChargedEnergy().Return(6.0, nil)
+	if f, err := cr.ChargedEnergy(); f != 0 || err != nil {
+		t.Errorf("energy: %.1f %v", f, err)
+	}
+
+	up.EXPECT().ChargedEnergy().Return(6.5, nil)
+	if f, err := cr.ChargedEnergy(); f != 0.5 || err != nil {
+		t.Errorf("energy: %.1f %v", f, err)
+	}
+
+	// charger unavailable at startup latches the offset on first read
+	up.EXPECT().ChargedEnergy().Return(0.0, errors.New("not available"))
+	cr = NewChargeRater(util.NewLogger("foo"), nil, up)
+
+	up.EXPECT().ChargedEnergy().Return(2.0, nil)
+	if f, err := cr.ChargedEnergy(); f != 0 || err != nil {
+		t.Errorf("energy: %.1f %v", f, err)
+	}
+
+	up.EXPECT().ChargedEnergy().Return(2.5, nil)
+	if f, err := cr.ChargedEnergy(); f != 0.5 || err != nil {
+		t.Errorf("energy: %.1f %v", f, err)
+	}
 }

--- a/core/wrapper/chargerater_test.go
+++ b/core/wrapper/chargerater_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestNoMeter(t *testing.T) {
-	cr := NewChargeRater(util.NewLogger("foo"), nil)
+	cr := NewChargeRater(util.NewLogger("foo"), nil, nil)
 	clck := clock.NewMock()
 	cr.clck = clck
 
@@ -71,7 +71,7 @@ func TestWrappedMeter(t *testing.T) {
 
 	cm := &EnergyDecorator{Meter: mm, MeterEnergy: me}
 
-	cr := NewChargeRater(util.NewLogger("foo"), cm)
+	cr := NewChargeRater(util.NewLogger("foo"), cm, nil)
 	clck := clock.NewMock()
 	cr.clck = clck
 
@@ -130,7 +130,7 @@ func TestDeferredBaseline(t *testing.T) {
 
 	cm := &EnergyDecorator{Meter: mm, MeterEnergy: me}
 
-	cr := NewChargeRater(util.NewLogger("foo"), cm)
+	cr := NewChargeRater(util.NewLogger("foo"), cm, nil)
 	clck := clock.NewMock()
 	cr.clck = clck
 
@@ -166,5 +166,42 @@ func TestDeferredBaseline(t *testing.T) {
 
 	if f, err := cr.ChargedEnergy(); f != 5 || err != nil {
 		t.Errorf("final energy: %.1f %v", f, err)
+	}
+}
+
+// TestUpstream covers chargers providing session energy themselves: the value
+// at startup is a negative offset until the charger resets its counter.
+func TestUpstream(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	up := api.NewMockChargeRater(ctrl)
+
+	// restart in the middle of a session
+	up.EXPECT().ChargedEnergy().Return(3.0, nil)
+	cr := NewChargeRater(util.NewLogger("foo"), nil, up)
+
+	// power integration is ignored
+	cr.StartCharge(true)
+	cr.SetChargePower(1e3)
+
+	up.EXPECT().ChargedEnergy().Return(5.0, nil)
+	if f, err := cr.ChargedEnergy(); f != 2 || err != nil {
+		t.Errorf("energy: %.1f %v", f, err)
+	}
+
+	// charger reset its counter for a new session
+	up.EXPECT().ChargedEnergy().Return(1.0, nil)
+	if f, err := cr.ChargedEnergy(); f != 1 || err != nil {
+		t.Errorf("energy: %.1f %v", f, err)
+	}
+
+	// reset re-latches the offset
+	up.EXPECT().ChargedEnergy().Return(4.0, nil)
+	cr.ResetCharge()
+
+	up.EXPECT().ChargedEnergy().Return(4.5, nil)
+	if f, err := cr.ChargedEnergy(); f != 0.5 || err != nil {
+		t.Errorf("energy: %.1f %v", f, err)
 	}
 }

--- a/core/wrapper/chargetimer.go
+++ b/core/wrapper/chargetimer.go
@@ -5,12 +5,14 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
+	"github.com/evcc-io/evcc/api"
 )
 
 // ChargeTimer measures charging time between start and stop events
 type ChargeTimer struct {
 	sync.Mutex
-	clck clock.Clock
+	clck     clock.Clock
+	upstream api.ChargeTimer // charger-provided duration, takes precedence
 
 	charging bool
 	start    time.Time
@@ -18,10 +20,11 @@ type ChargeTimer struct {
 }
 
 // NewChargeTimer creates ChargeTimer for tracking duration between
-// start and stop events
-func NewChargeTimer() *ChargeTimer {
+// start and stop events. Duration is taken from upstream if given.
+func NewChargeTimer(upstream api.ChargeTimer) *ChargeTimer {
 	return &ChargeTimer{
-		clck: clock.New(),
+		clck:     clock.New(),
+		upstream: upstream,
 	}
 }
 
@@ -29,6 +32,10 @@ func NewChargeTimer() *ChargeTimer {
 func (m *ChargeTimer) StartCharge(continued bool) {
 	m.Lock()
 	defer m.Unlock()
+
+	if m.upstream != nil {
+		return
+	}
 
 	m.start = m.clck.Now()
 
@@ -44,16 +51,22 @@ func (m *ChargeTimer) StopCharge() {
 	m.Lock()
 	defer m.Unlock()
 
+	if m.upstream != nil {
+		return
+	}
+
 	m.charging = false
 	m.duration += m.clck.Since(m.start)
 }
 
-var _ ChargeResetter = (*ChargeTimer)(nil)
-
-// ChargeResetter resets the charging session
+// ResetCharge resets the charging session
 func (m *ChargeTimer) ResetCharge() {
 	m.Lock()
 	defer m.Unlock()
+
+	if m.upstream != nil {
+		return
+	}
 
 	m.duration = 0
 }
@@ -62,6 +75,10 @@ func (m *ChargeTimer) ResetCharge() {
 func (m *ChargeTimer) ChargeDuration() (time.Duration, error) {
 	m.Lock()
 	defer m.Unlock()
+
+	if m.upstream != nil {
+		return m.upstream.ChargeDuration()
+	}
 
 	if m.charging {
 		return m.duration + m.clck.Since(m.start), nil

--- a/core/wrapper/chargetimer_test.go
+++ b/core/wrapper/chargetimer_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestTimer(t *testing.T) {
-	ct := NewChargeTimer()
+	ct := NewChargeTimer(nil)
 	clck := clock.NewMock()
 	ct.clck = clck
 


### PR DESCRIPTION
Stacked on #33672.

`chargeRater` and `chargeTimer` were either the charger's own implementation or a wrapper, decided at boot and distinguished later by type assertions (`wrapper.ChargeResetter`) and by the loadpoint-side `chargedAtStartup` offset that only applied to the charger-native path.

Now the loadpoint always holds `*wrapper.ChargeRater` / `*wrapper.ChargeTimer`. A charger's `ChargeRater` (only when no external meter is configured, as before) or `ChargeTimer` is passed in as upstream and takes precedence over meter energy or power integration. The startup offset lives in the rater: latched at construction, cleared once the charger reports a value below it (counter reset at a new session), re-latched on `ResetCharge`. Behaviour change to note: the heating daily reset now also applies to chargers providing their own `ChargedEnergy`, which previously was a no-op for them.

Removes `chargedAtStartup`, the integrated-vs-wrapper branching in `configureChargerType`, the `ChargeResetter` interface and the `Null` rater/timer stubs in tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
