### PR TITLE
NRGkick Connect: write current and enable state in a single request

### DIFF
--- a/charger/nrgconnect.go
+++ b/charger/nrgconnect.go
@@ -22,6 +22,7 @@ type NRGKickConnect struct {
 	mac           string
 	password      string
 	enabled       bool
+	current       int64
 	settingsG     util.Cacheable[connect.Settings]
 	measurementsG util.Cacheable[connect.Measurements]
 }
@@ -132,8 +133,9 @@ func (nrg *NRGKickConnect) Enabled() (bool, error) {
 	return nrg.enabled, nil
 }
 
-// Enable implements the api.Charger interface
-func (nrg *NRGKickConnect) Enable(enable bool) error {
+// putSettings writes charging status and current in a single request.
+// The v1 Connect dongle drops requests arriving back-to-back (#33625).
+func (nrg *NRGKickConnect) putSettings(enable bool) error {
 	data := connect.Settings{
 		Values: connect.Values{
 			ChargingStatus: &connect.ChargingStatus{
@@ -145,7 +147,18 @@ func (nrg *NRGKickConnect) Enable(enable bool) error {
 		},
 	}
 
-	err := nrg.putJSON(nrg.apiURL(connect.SettingsPath), data)
+	if nrg.current > 0 {
+		data.Values.ChargingCurrent = &connect.ChargingCurrent{
+			Value: float64(nrg.current),
+		}
+	}
+
+	return nrg.putJSON(nrg.apiURL(connect.SettingsPath), data)
+}
+
+// Enable implements the api.Charger interface
+func (nrg *NRGKickConnect) Enable(enable bool) error {
+	err := nrg.putSettings(enable)
 	if err == nil {
 		nrg.enabled = enable
 	}
@@ -155,21 +168,14 @@ func (nrg *NRGKickConnect) Enable(enable bool) error {
 
 // MaxCurrent implements the api.Charger interface
 func (nrg *NRGKickConnect) MaxCurrent(current int64) error {
-	data := connect.Settings{
-		Values: connect.Values{
-			ChargingStatus: &connect.ChargingStatus{
-				Charging: nrg.enabled,
-			},
-			ChargingCurrent: &connect.ChargingCurrent{
-				Value: float64(current),
-			},
-			DeviceMetadata: connect.DeviceMetadata{
-				Password: nrg.password,
-			},
-		},
+	nrg.current = current
+
+	// while disabled the current is written together with the enable request
+	if !nrg.enabled {
+		return nil
 	}
 
-	return nrg.putJSON(nrg.apiURL(connect.SettingsPath), data)
+	return nrg.putSettings(true)
 }
 
 var _ api.Meter = (*NRGKickConnect)(nil)

--- a/charger/nrgconnect_test.go
+++ b/charger/nrgconnect_test.go
@@ -1,0 +1,50 @@
+package charger
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/evcc-io/evcc/charger/nrg/connect"
+	"github.com/stretchr/testify/require"
+)
+
+// https://github.com/evcc-io/evcc/issues/33625
+func TestNRGKickConnectSinglePut(t *testing.T) {
+	var puts []connect.Settings
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPut, r.Method)
+
+		var s connect.Settings
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&s))
+		puts = append(puts, s)
+
+		w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	nrg, err := NewNRGKickConnect(srv.URL, "mac", "pw", time.Second)
+	require.NoError(t, err)
+
+	// current while disabled is deferred to the enable request
+	require.NoError(t, nrg.MaxCurrent(16))
+	require.Empty(t, puts)
+
+	require.NoError(t, nrg.Enable(true))
+	require.Len(t, puts, 1)
+	require.True(t, puts[0].Values.ChargingStatus.Charging)
+	require.Equal(t, 16.0, puts[0].Values.ChargingCurrent.Value)
+
+	// current while enabled is written immediately
+	require.NoError(t, nrg.MaxCurrent(6))
+	require.Len(t, puts, 2)
+	require.True(t, puts[1].Values.ChargingStatus.Charging)
+	require.Equal(t, 6.0, puts[1].Values.ChargingCurrent.Value)
+
+	require.NoError(t, nrg.Enable(false))
+	require.Len(t, puts, 3)
+	require.False(t, puts[2].Values.ChargingStatus.Charging)
+}


### PR DESCRIPTION
fixes #33625

The NRGkick v1 Connect dongle drops a settings request that arrives right after a previous one. Enabling the charger sent current and enable state as two back-to-back requests, so the enable was lost while evcc's cached state moved on.

- current set while disabled is deferred and written together with the enable request
- current set while enabled is written immediately, as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)